### PR TITLE
Add queued generated-file speech flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 xcuserdata/
 DerivedData/
 .derived/
+/.local/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 *.profraw
+!scripts/repo-maintenance/release/*.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,12 +137,13 @@
 - Keep `xcodebuild` invocations explicit and reproducible (always pass scheme, destination or SDK, and configuration when relevant).
 - Prefer deterministic non-interactive CLI usage in automation/CI for both `swift package` and `xcodebuild`.
 - For this repository specifically, use an Xcode-built worker product for real MLX-backed command-line runs and real-model e2e coverage. Upstream `mlx-swift` does not make the Metal shader bundle available to the plain SwiftPM command-line build.
-- When launching the real worker from the shell, point `DYLD_FRAMEWORK_PATH` at the matching Xcode build products directory so `mlx-swift_Cmlx.bundle` and `default.metallib` are visible at runtime.
+- When launching the real worker from the shell, prefer the published local runtime directories under `.local/xcode/Debug` or `.local/xcode/Release`, and point `DYLD_FRAMEWORK_PATH` at the matching published runtime directory so `mlx-swift_Cmlx.bundle` and `default.metallib` are visible at runtime.
 - If a real worker run fails with `default.metallib` or `mlx-swift_Cmlx.bundle` errors, treat that as a build-and-launch-path problem first, not as evidence that the worker runtime itself is broken.
 - For direct forensic worker captures, prefer the proven held-open stdin pattern instead of sending one JSONL file and allowing stdin to close immediately. A working shape is:
   - create or reuse a profile directory under `/tmp/.../profiles`
   - prepare an `input.jsonl` request file
-  - run `(cat input.jsonl; sleep 180) | env DYLD_FRAMEWORK_PATH=... SPEAKSWIFTLY_PLAYBACK_TRACE=1 <xcode-worker> --profiles-dir /tmp/.../profiles > /tmp/.../stdout.jsonl 2> /tmp/.../stderr.jsonl`
+  - run `sh scripts/repo-maintenance/publish-runtime.sh --configuration Debug`
+  - then run `(cat input.jsonl; sleep 180) | env DYLD_FRAMEWORK_PATH="$PWD/.local/xcode/Debug" SPEAKSWIFTLY_PLAYBACK_TRACE=1 "$PWD/.local/xcode/Debug/SpeakSwiftly" --profiles-dir /tmp/.../profiles > /tmp/.../stdout.jsonl 2> /tmp/.../stderr.jsonl`
   - inspect `stdout.jsonl` for worker lifecycle and request completion
   - inspect `stderr.jsonl` for `playback_rebuffer_started`, `playback_rebuffer_resumed`, `playback_starved`, `playback_schedule_gap_warning`, and final `playback_finished` details
 - Important current behavior: if stdin closes before queued work is drained, the worker can cancel queued requests, including requests still waiting behind resident-model warmup. Do not treat that as normal playback failure; it is a current worker shutdown/queue-handling quirk that should be fixed soon.

--- a/README.md
+++ b/README.md
@@ -110,29 +110,33 @@ swift build
 
 The executable intentionally leans on the existing `mlx-audio-swift` API surface and keeps its own scope focused on process ownership, queueing, playback, and profile storage.
 
-For real MLX-backed runs, use `xcodebuild` instead of relying on the SwiftPM command-line executable. Upstream `mlx-swift` is explicit that command-line SwiftPM does not build the Metal shader bundle, while `xcodebuild` does, and command-line tools need that bundle visible at runtime.
+For real MLX-backed runs, use the repo-maintenance runtime publisher instead of relying on the SwiftPM command-line executable. Upstream `mlx-swift` is explicit that command-line SwiftPM does not build the Metal shader bundle, while `xcodebuild` does, and command-line tools need that bundle visible at runtime.
 
 ```bash
-xcodebuild build \
-  -scheme SpeakSwiftly \
-  -destination 'platform=macOS' \
-  -derivedDataPath "$PWD/.derived" \
-  -clonedSourcePackagesDirPath /tmp/SpeakSwiftly-xcodebuild-spm
+sh scripts/repo-maintenance/publish-runtime.sh --configuration Debug
+sh scripts/repo-maintenance/publish-runtime.sh --configuration Release
 ```
+
+That command publishes stable local Xcode-backed runtime directories here:
+
+- Debug: [`.local/xcode/Debug`](/Users/galew/Workspace/SpeakSwiftly/.local/xcode/Debug)
+- Release: [`.local/xcode/Release`](/Users/galew/Workspace/SpeakSwiftly/.local/xcode/Release)
+
+Each published runtime includes:
+
+- the `SpeakSwiftly` executable
+- the bundled `mlx-swift_Cmlx.bundle/.../default.metallib`
+- a metadata manifest at [`.local/xcode/SpeakSwiftly.debug.json`](/Users/galew/Workspace/SpeakSwiftly/.local/xcode/SpeakSwiftly.debug.json) or [`.local/xcode/SpeakSwiftly.release.json`](/Users/galew/Workspace/SpeakSwiftly/.local/xcode/SpeakSwiftly.release.json)
 
 ## Usage
 
-Use `swift run` only for fast package-local development that does not need the real MLX Metal runtime. For the real worker executable, build with `xcodebuild` and run the product from the Xcode build directory with `DYLD_FRAMEWORK_PATH` pointing at that same products directory.
+Use `swift run` only for fast package-local development that does not need the real MLX Metal runtime. For the real worker executable, publish the runtime first, then run the product from the published runtime directory with `DYLD_FRAMEWORK_PATH` pointing at that same directory.
 
 ```bash
-xcodebuild build \
-  -scheme SpeakSwiftly \
-  -destination 'platform=macOS' \
-  -derivedDataPath "$PWD/.derived" \
-  -clonedSourcePackagesDirPath /tmp/SpeakSwiftly-xcodebuild-spm
+sh scripts/repo-maintenance/publish-runtime.sh --configuration Debug
 
-DYLD_FRAMEWORK_PATH="$PWD/.derived/Build/Products/Debug" \
-  "$PWD/.derived/Build/Products/Debug/SpeakSwiftly"
+DYLD_FRAMEWORK_PATH="$PWD/.local/xcode/Debug" \
+  "$PWD/.local/xcode/Debug/SpeakSwiftly"
 ```
 
 At startup the worker begins preloading the resident `0.6B` model and emits JSONL status events on `stdout`.
@@ -301,7 +305,7 @@ The preferred ownership model is:
 
 That arrangement keeps the package history, tags, and releases independent while still letting the larger repository pin an exact commit.
 
-Older adjacent consumers such as [`speak-to-user-mcp`](https://github.com/gaelic-ghost/speak-to-user-mcp) and [`speak-to-user-server`](https://github.com/gaelic-ghost/speak-to-user-server) should now point at one shared built runtime directory instead of relying on tag-triggered copy hooks. The preferred local development shape is to build `SpeakSwiftly` once in the monorepo checkout and then point those hosts at the Xcode products directory so the executable and MLX bundle stay together.
+Older adjacent consumers such as [`speak-to-user-mcp`](https://github.com/gaelic-ghost/speak-to-user-mcp) and [`speak-to-user-server`](https://github.com/gaelic-ghost/speak-to-user-server) should now point at one shared published runtime directory instead of relying on tag-triggered copy hooks or raw DerivedData guesses. The preferred local development shape is to publish `SpeakSwiftly` once here and then point those hosts at the stable runtime directory so the executable and MLX bundle stay together.
 
 When `speak-to-user` is using this package, the expected package path is:
 
@@ -331,17 +335,13 @@ swift build
 swift test
 ```
 
-Real MLX-backed validation should use an Xcode-built worker product. A reproducible local command is:
+Real MLX-backed validation should use a published Xcode-backed worker runtime. A reproducible local command is:
 
 ```bash
-xcodebuild build \
-  -scheme SpeakSwiftly \
-  -destination 'platform=macOS' \
-  -derivedDataPath "$PWD/.derived" \
-  -clonedSourcePackagesDirPath /tmp/SpeakSwiftly-xcodebuild-spm
+sh scripts/repo-maintenance/publish-runtime.sh --configuration Debug
 ```
 
-Opt-in real-model e2e coverage is available for three main sequential workflows, and the harness builds and launches the Xcode-backed worker automatically:
+Opt-in real-model e2e coverage is available for three main sequential workflows, and the harness now publishes and launches the shared Debug runtime automatically at [`.local/xcode/Debug`](/Users/galew/Workspace/SpeakSwiftly/.local/xcode/Debug):
 
 - VoiceDesign profile creation, then silent playback, then audible playback.
 - Clone profile creation from caller-provided reference audio plus transcript, then silent playback, then audible playback.
@@ -379,7 +379,7 @@ SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_FORENSIC_E2E=1 SPEAKSWIFTLY_PLAYBACK_TRACE=1 swi
 
 The real-model e2e coverage uses a shared profile convention named `testing-profile` with the voice description `A generic, warm, masculine, slow speaking voice.` Each workflow still runs inside its own isolated profile root, but using the same profile shape keeps downstream app e2e coverage aligned with this package.
 
-If a real worker run fails with a message about `default.metallib` or `mlx-swift_Cmlx.bundle`, the executable was almost certainly launched from a plain SwiftPM build instead of an Xcode-built products directory. Rebuild with `xcodebuild`, then run the executable with `DYLD_FRAMEWORK_PATH` pointed at the matching Xcode build products directory.
+If a real worker run fails with a message about `default.metallib` or `mlx-swift_Cmlx.bundle`, the executable was almost certainly launched from a plain SwiftPM build instead of a published Xcode-backed runtime directory. Re-publish the runtime, then run the executable with `DYLD_FRAMEWORK_PATH` pointed at the matching published runtime directory.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Example request shapes:
 {"id":"req-1c","op":"queue_speech_live","text":"stderr: broken pipe","profile_name":"default-femme","text_profile_name":"logs","cwd":"/Users/galew/Workspace/SpeakSwiftly","repo_root":"/Users/galew/Workspace/SpeakSwiftly","text_format":"cli_output"}
 {"id":"req-1d","op":"queue_speech_live","text":"```swift\nlet sampleRate = profile?.sampleRate ?? 24000\n```","profile_name":"default-femme","text_format":"markdown","nested_source_format":"swift_source"}
 {"id":"req-1e","op":"queue_speech_live","text":"struct WorkerRuntime { let sampleRate: Int }","profile_name":"default-femme","source_format":"swift_source"}
+{"id":"req-1f","op":"queue_speech_file","text":"Save this one for later playback.","profile_name":"default-femme"}
+{"id":"req-1g","op":"generated_file","artifact_id":"req-1f"}
+{"id":"req-1h","op":"generated_files"}
 {"id":"req-2","op":"create_profile","profile_name":"bright-guide","text":"Hello there","voice_description":"A warm, bright, feminine narrator voice.","output_path":"/tmp/bright-guide.wav"}
 {"id":"req-3","op":"list_profiles"}
 {"id":"req-4","op":"remove_profile","profile_name":"bright-guide"}
@@ -174,6 +177,13 @@ Example response and event shapes:
 {"id":"req-1","event":"progress","stage":"preroll_ready"}
 {"id":"req-1","event":"progress","stage":"playback_finished"}
 {"id":"req-1","ok":true}
+{"id":"req-1f","ok":true}
+{"id":"req-1f","event":"started","op":"queue_speech_file"}
+{"id":"req-1f","event":"progress","stage":"generating_file_audio"}
+{"id":"req-1f","event":"progress","stage":"writing_generated_file"}
+{"id":"req-1f","ok":true,"generated_file":{"artifact_id":"req-1f","profile_name":"default-femme","text_profile_name":null,"sample_rate":24000,"created_at":"2026-04-07T18:22:00Z","file_path":"/tmp/generated-files/7265712d3166/generated.wav"}}
+{"id":"req-1g","ok":true,"generated_file":{"artifact_id":"req-1f","profile_name":"default-femme","text_profile_name":null,"sample_rate":24000,"created_at":"2026-04-07T18:22:00Z","file_path":"/tmp/generated-files/7265712d3166/generated.wav"}}
+{"id":"req-1h","ok":true,"generated_files":[{"artifact_id":"req-1f","profile_name":"default-femme","text_profile_name":null,"sample_rate":24000,"created_at":"2026-04-07T18:22:00Z","file_path":"/tmp/generated-files/7265712d3166/generated.wav"}]}
 {"id":"req-2","ok":true,"profile_name":"bright-guide","profile_path":"/path/to/profile"}
 {"id":"req-3","ok":true,"profiles":[{"profile_name":"bright-guide","created_at":"2026-04-01T12:00:00Z","voice_description":"A warm, bright, feminine narrator voice.","source_text":"Hello there"}]}
 {"id":"req-6","ok":true,"text_profiles":[{"id":"logs","name":"Logs","replacements":[{"id":"logs-rule","text":"stderr","replacement":"standard error","match":"exact_phrase","phase":"before_built_ins","isCaseSensitive":false,"formats":[],"priority":0}]}],"text_profile_path":"/path/to/text-profiles.json"}
@@ -185,11 +195,14 @@ Queued events are only emitted for requests that will actually wait. Once the re
 
 `queue_speech_live` is the wire-level live playback operation. The worker acknowledges queue acceptance immediately through the request stream, then emits the usual `started`, `progress`, and terminal success or failure events later as playback advances.
 
-The `text_profile_*`, `load_text_profiles`, `save_text_profiles`, and `*_text_replacement` operations are immediate control operations. They do not wait for resident-model warmup and do not enter the serialized speech-generation queue.
+`queue_speech_file` uses the same resident generation queue, but it never enters the playback queue. It acknowledges queue acceptance immediately, renders and saves a managed WAV artifact under the runtime store, then emits a terminal success payload with `generated_file` metadata keyed by the original request id.
+
+`generated_file`, `generated_files`, `text_profile_*`, `load_text_profiles`, `save_text_profiles`, and `*_text_replacement` are immediate control operations. They do not wait for resident-model warmup and do not enter the serialized speech-generation queue.
 
 Current operation families are:
 
 - Resident `0.6B` startup warmup and live playback with named stored profiles.
+- Resident `0.6B` startup warmup and generated-file rendering with managed artifact metadata and fetch/list reads.
 - On-demand `1.7B` VoiceDesign profile creation.
 - On-demand clone profile creation from caller-provided reference audio, with optional transcript inference.
 - Immutable profile storage, selection, listing, and removal.
@@ -248,14 +261,18 @@ Current `SpeakSwiftly.Normalizer` helpers are:
 
 `runtime.normalizer` remains available as a compatibility alias to the injected normalizer object when callers already have a runtime in hand.
 
-The current typed voice-profile creation helpers on `SpeakSwiftly.Runtime` are:
+The current typed generation and profile helpers on `SpeakSwiftly.Runtime` are:
 
+- `speak(text:with:as:textProfileName:textContext:sourceFormat:id:)`
 - `createProfile(named:from:voice:outputPath:id:)`
 - `createClone(named:from:transcript:id:)`
+- `generatedFile(id:requestID:)`
+- `generatedFiles(id:)`
 
 Current live-playback behavior is:
 
 - `queue_speech_live` loads the stored profile and reference audio first.
+- `queue_speech_file` loads the stored profile and reference audio first, then saves the completed WAV under the generated-file store instead of scheduling playback.
 - The resident `0.6B` model streams generated chunks at the current `0.18` cadence.
 - The resident and profile-generation paths now pass explicit local generation parameters instead of relying on whatever default values the current `mlx-audio-swift` dependency tip happens to expose, which helps keep short utterances from drifting back into runaway generation behavior.
 - Playback is now owned by a real `PlaybackController` actor in `Sources/SpeakSwiftly/Playback/PlaybackController.swift`, while the lower-level AVFoundation engine driver stays internal to the playback feature instead of living in `Runtime/`.
@@ -268,6 +285,14 @@ Current live-playback behavior is:
 - After generation finishes, playback drain uses a dynamic timeout based on queued audio plus padding, with a minimum of 5 seconds, so the worker does not fail long buffered requests with the same cutoff used for short ones.
 - If drain completion times out, the request fails with `audio_playback_timeout` and the worker stays alive for later requests.
 - For short forensic captures, set `SPEAKSWIFTLY_PLAYBACK_TRACE=1` to emit chunk-level trace JSONL events such as `playback_trace_chunk_received`, `playback_trace_buffer_scheduled`, and `playback_trace_buffer_played_back`. Leave that mode off for normal runs.
+
+Current generated-file behavior is:
+
+- The request id is the artifact id for the first saved file generated by that request.
+- Saved artifacts live in the runtime-managed generated-file store, not at a caller-provided output path.
+- `generated_file` returns one stored artifact by `artifact_id`.
+- `generated_files` returns the current artifact summaries known to the store.
+- `list_profiles` ignores generated-file directories, so artifact storage does not pollute the voice-profile surface.
 
 Current `stderr` observability is JSONL with fields such as:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,7 @@
 - [ ] Milestone 16: `mlx-audio-swift` upgrade review
 - [ ] Milestone 17: Notification-linked priority playback
 - [ ] Milestone 18: Package docs and distribution polish
+- [ ] Milestone 19: Persisted async generation jobs and batch artifacts
 
 ## Milestone 0: Bootstrap
 
@@ -496,6 +497,31 @@ Exit criteria:
 - [ ] The project has one explicit design for notification-linked priority playback and job triggering, with queue semantics that are documented and testable.
 - [ ] The design makes clear whether the existing request queue was extended or a distinct playback queue was justified after review.
 - [ ] The implementation path avoids unnecessary new layers and keeps playback, generation, and notification ownership easy to reason about.
+
+## Milestone 19: Persisted async generation jobs and batch artifacts
+
+Scope:
+
+- [ ] Evolve managed generated-file output into a durable async job surface that can support later batch-oriented generation work cleanly.
+- [ ] Let callers reconnect to generation state, inspect saved artifacts, and fetch completed output without relying on one live request stream staying attached forever.
+- [ ] Keep the first expansion grounded in the current worker and typed-library model, and avoid introducing a broader service subsystem until the batch and multi-client use cases truly require it.
+
+Tickets:
+
+- [ ] Define a persisted generation-job record shape that can represent queued, running, completed, failed, and expired generated-file requests.
+- [ ] Decide which parts of job state belong in the immediate worker contract versus a later service or MCP resource surface.
+- [ ] Add first-class stored artifact metadata for generated files so callers can list, inspect, fetch, and eventually garbage-collect output intentionally.
+- [ ] Define the retention, cleanup, and expiry rules for generated files and their job metadata without making single-file generation harder to reason about.
+- [ ] Decide whether request id remains the durable artifact id, the durable job id, or both when batch generation introduces one-to-many outputs.
+- [ ] Design the batch-generation shape explicitly, including a future `generated_batch(id:)` and `generated_batches()` surface that can sit on top of the same persisted-job model.
+- [ ] Add reconnectable inspection semantics for completed and in-flight generation jobs so callers do not have to keep one typed stream or stdio session attached for long-running work.
+- [ ] Document the point at which this milestone should become a true service or subscription surface rather than an extension of the current worker contract.
+
+Exit criteria:
+
+- [ ] The repository has one documented direction for persisted async generation jobs that clearly composes from single-file generation into future batch generation.
+- [ ] Generated-file metadata, retention rules, and later batch identifiers are explicit enough that future implementation work does not need a second naming or ownership reset.
+- [ ] The roadmap distinguishes the near-term managed `.file` generation path from the later heavier async-job-service expansion.
 
 ## Current Review Findings To Address
 

--- a/Sources/SpeakSwiftly/API/GeneratedFiles.swift
+++ b/Sources/SpeakSwiftly/API/GeneratedFiles.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+// MARK: - Generated File API
+
+public extension SpeakSwiftly.Runtime {
+    func generatedFile(
+        id artifactID: String,
+        requestID: String = UUID().uuidString
+    ) async -> SpeakSwiftly.RequestHandle {
+        await submit(.generatedFile(id: requestID, artifactID: artifactID))
+    }
+
+    func generatedFiles(
+        id requestID: String = UUID().uuidString
+    ) async -> SpeakSwiftly.RequestHandle {
+        await submit(.generatedFiles(id: requestID))
+    }
+}

--- a/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
+++ b/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
@@ -1,0 +1,140 @@
+import Foundation
+@preconcurrency import MLX
+import TextForSpeech
+
+// MARK: - Generated File Logic
+
+extension SpeakSwiftly.Runtime {
+    func handleQueueSpeechFileGeneration(
+        id: String,
+        op: String,
+        text: String,
+        profileName: String,
+        textProfileName: String?,
+        textContext: TextForSpeech.Context?,
+        sourceFormat: TextForSpeech.SourceFormat?
+    ) async throws -> SpeakSwiftly.GeneratedFile {
+        let (residentModel, profile, refAudio) = try await loadResidentSpeechInputs(
+            requestID: id,
+            op: op,
+            profileName: profileName
+        )
+
+        let textProfile = await normalizerRef.effectiveProfile(named: textProfileName)
+        let normalizedText = if let sourceFormat {
+            TextForSpeech.normalizeSource(
+                text,
+                as: sourceFormat,
+                context: textContext,
+                profile: textProfile
+            )
+        } else {
+            TextForSpeech.normalizeText(
+                text,
+                context: textContext,
+                profile: textProfile
+            )
+        }
+
+        await emitProgress(id: id, stage: .generatingFileAudio)
+        let generationStartedAt = dependencies.now()
+        let stream = residentModel.generateSamplesStream(
+            text: normalizedText,
+            voice: nil,
+            refAudio: refAudio,
+            refText: profile.manifest.sourceText,
+            language: "English",
+            generationParameters: GenerationPolicy.residentParameters(for: normalizedText),
+            streamingInterval: PlaybackConfiguration.residentStreamingInterval
+        )
+        var audio = [Float]()
+        for try await chunk in stream {
+            try Task.checkCancellation()
+            audio.append(contentsOf: chunk)
+        }
+        await logRequestEvent(
+            "generated_file_audio_rendered",
+            requestID: id,
+            op: op,
+            profileName: profileName,
+            details: [
+                "duration_ms": .int(elapsedMS(since: generationStartedAt)),
+                "sample_count": .int(audio.count),
+            ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
+        )
+        try Task.checkCancellation()
+
+        let tempDirectory = dependencies.fileManager.temporaryDirectory
+            .appendingPathComponent("SpeakSwiftly", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try dependencies.fileManager.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? dependencies.fileManager.removeItem(at: tempDirectory) }
+
+        let tempAudioURL = tempDirectory.appendingPathComponent(GeneratedFileStore.audioFileName)
+        try dependencies.writeWAV(audio, residentModel.sampleRate, tempAudioURL)
+        let audioData = try Data(contentsOf: tempAudioURL)
+        try Task.checkCancellation()
+
+        await emitProgress(id: id, stage: .writingGeneratedFile)
+        let writeStartedAt = dependencies.now()
+        let generatedFile = try generatedFileStore.createGeneratedFile(
+            artifactID: id,
+            profileName: profileName,
+            textProfileName: textProfileName,
+            sampleRate: residentModel.sampleRate,
+            audioData: audioData
+        )
+        await logRequestEvent(
+            "generated_file_written",
+            requestID: id,
+            op: op,
+            profileName: profileName,
+            details: [
+                "path": .string(generatedFile.audioURL.path),
+                "duration_ms": .int(elapsedMS(since: writeStartedAt)),
+                "sample_rate": .int(residentModel.sampleRate),
+            ]
+        )
+
+        return generatedFile.summary
+    }
+
+    func loadResidentSpeechInputs(
+        requestID id: String,
+        op: String,
+        profileName: String
+    ) async throws -> (model: AnySpeechModel, profile: StoredProfile, refAudio: MLXArray?) {
+        let residentModel = try residentModelOrThrow()
+
+        await emitProgress(id: id, stage: .loadingProfile)
+        let profileLoadStartedAt = dependencies.now()
+        let profile = try profileStore.loadProfile(named: profileName)
+        await logRequestEvent(
+            "profile_loaded",
+            requestID: id,
+            op: op,
+            profileName: profileName,
+            details: [
+                "path": .string(profile.directoryURL.path),
+                "duration_ms": .int(elapsedMS(since: profileLoadStartedAt)),
+            ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
+        )
+
+        let refAudioLoadStartedAt = dependencies.now()
+        let refAudio = try dependencies.loadAudioSamples(profile.referenceAudioURL, residentModel.sampleRate)
+        await logRequestEvent(
+            "reference_audio_loaded",
+            requestID: id,
+            op: op,
+            profileName: profileName,
+            details: [
+                "path": .string(profile.referenceAudioURL.path),
+                "duration_ms": .int(elapsedMS(since: refAudioLoadStartedAt)),
+                "sample_rate": .int(residentModel.sampleRate),
+            ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
+        )
+        try Task.checkCancellation()
+
+        return (residentModel, profile, refAudio)
+    }
+}

--- a/Sources/SpeakSwiftly/Generation/GeneratedFileStore.swift
+++ b/Sources/SpeakSwiftly/Generation/GeneratedFileStore.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+// MARK: - Generated File Models
+
+struct GeneratedFileManifest: Codable, Sendable, Equatable {
+    let version: Int
+    let artifactID: String
+    let createdAt: Date
+    let profileName: String
+    let textProfileName: String?
+    let sampleRate: Int
+    let audioFile: String
+}
+
+public extension SpeakSwiftly {
+    struct GeneratedFile: Codable, Sendable, Equatable {
+        public let artifactID: String
+        public let createdAt: Date
+        public let profileName: String
+        public let textProfileName: String?
+        public let sampleRate: Int
+        public let filePath: String
+
+        enum CodingKeys: String, CodingKey {
+            case artifactID = "artifact_id"
+            case createdAt = "created_at"
+            case profileName = "profile_name"
+            case textProfileName = "text_profile_name"
+            case sampleRate = "sample_rate"
+            case filePath = "file_path"
+        }
+
+        public init(
+            artifactID: String,
+            createdAt: Date,
+            profileName: String,
+            textProfileName: String?,
+            sampleRate: Int,
+            filePath: String
+        ) {
+            self.artifactID = artifactID
+            self.createdAt = createdAt
+            self.profileName = profileName
+            self.textProfileName = textProfileName
+            self.sampleRate = sampleRate
+            self.filePath = filePath
+        }
+    }
+}
+
+struct StoredGeneratedFile: Sendable, Equatable {
+    let manifest: GeneratedFileManifest
+    let directoryURL: URL
+    let audioURL: URL
+
+    var summary: SpeakSwiftly.GeneratedFile {
+        SpeakSwiftly.GeneratedFile(
+            artifactID: manifest.artifactID,
+            createdAt: manifest.createdAt,
+            profileName: manifest.profileName,
+            textProfileName: manifest.textProfileName,
+            sampleRate: manifest.sampleRate,
+            filePath: audioURL.standardizedFileURL.path
+        )
+    }
+}
+
+// MARK: - Generated File Store
+
+struct GeneratedFileStore {
+    static let directoryName = "generated-files"
+    static let manifestFileName = "generated-file.json"
+    static let audioFileName = "generated.wav"
+
+    let rootURL: URL
+    let fileManager: FileManager
+    let encoder: JSONEncoder
+    let decoder: JSONDecoder
+
+    init(
+        rootURL: URL,
+        fileManager: FileManager = .default,
+        encoder: JSONEncoder = GeneratedFileStore.makeEncoder(),
+        decoder: JSONDecoder = GeneratedFileStore.makeDecoder()
+    ) {
+        self.rootURL = rootURL
+        self.fileManager = fileManager
+        self.encoder = encoder
+        self.decoder = decoder
+    }
+
+    func ensureRootExists() throws {
+        try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    }
+
+    func createGeneratedFile(
+        artifactID: String,
+        profileName: String,
+        textProfileName: String?,
+        sampleRate: Int,
+        audioData: Data
+    ) throws -> StoredGeneratedFile {
+        try ensureRootExists()
+
+        let directoryURL = generatedFileDirectoryURL(for: artifactID)
+        guard !fileManager.fileExists(atPath: directoryURL.path) else {
+            throw WorkerError(
+                code: .generatedFileAlreadyExists,
+                message: "Generated file '\(artifactID)' already exists in the SpeakSwiftly generated-file store and cannot be overwritten."
+            )
+        }
+
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: false)
+
+        let manifest = GeneratedFileManifest(
+            version: 1,
+            artifactID: artifactID,
+            createdAt: Date(),
+            profileName: profileName,
+            textProfileName: textProfileName,
+            sampleRate: sampleRate,
+            audioFile: Self.audioFileName
+        )
+
+        do {
+            try audioData.write(to: audioURL(for: directoryURL), options: .atomic)
+            let manifestData = try encoder.encode(manifest)
+            try manifestData.write(to: manifestURL(for: directoryURL), options: .atomic)
+        } catch {
+            try? fileManager.removeItem(at: directoryURL)
+            throw WorkerError(
+                code: .filesystemError,
+                message: "Generated file '\(artifactID)' could not be written to disk. \(error.localizedDescription)"
+            )
+        }
+
+        return StoredGeneratedFile(
+            manifest: manifest,
+            directoryURL: directoryURL,
+            audioURL: audioURL(for: directoryURL)
+        )
+    }
+
+    func loadGeneratedFile(id artifactID: String) throws -> StoredGeneratedFile {
+        try ensureRootExists()
+
+        let directoryURL = generatedFileDirectoryURL(for: artifactID)
+        guard fileManager.fileExists(atPath: directoryURL.path) else {
+            throw WorkerError(
+                code: .generatedFileNotFound,
+                message: "Generated file '\(artifactID)' was not found in the SpeakSwiftly generated-file store."
+            )
+        }
+
+        do {
+            let manifestData = try Data(contentsOf: manifestURL(for: directoryURL))
+            let manifest = try decoder.decode(GeneratedFileManifest.self, from: manifestData)
+            return StoredGeneratedFile(
+                manifest: manifest,
+                directoryURL: directoryURL,
+                audioURL: audioURL(for: directoryURL, fileName: manifest.audioFile)
+            )
+        } catch let workerError as WorkerError {
+            throw workerError
+        } catch {
+            throw WorkerError(
+                code: .filesystemError,
+                message: "Generated file '\(artifactID)' exists, but its metadata could not be read. \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func listGeneratedFiles() throws -> [SpeakSwiftly.GeneratedFile] {
+        try ensureRootExists()
+
+        let urls = try fileManager.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+
+        let generatedFiles = try urls
+            .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+            .map { directoryURL in
+                do {
+                    let manifestData = try Data(contentsOf: manifestURL(for: directoryURL))
+                    let manifest = try decoder.decode(GeneratedFileManifest.self, from: manifestData)
+                    return StoredGeneratedFile(
+                        manifest: manifest,
+                        directoryURL: directoryURL,
+                        audioURL: audioURL(for: directoryURL, fileName: manifest.audioFile)
+                    ).summary
+                } catch {
+                    throw WorkerError(
+                        code: .filesystemError,
+                        message: "SpeakSwiftly could not list generated files because the manifest in '\(directoryURL.path)' is unreadable or corrupt. \(error.localizedDescription)"
+                    )
+                }
+            }
+
+        return generatedFiles
+    }
+
+    func generatedFileDirectoryURL(for artifactID: String) -> URL {
+        rootURL.appendingPathComponent(encodedDirectoryName(for: artifactID), isDirectory: true)
+    }
+
+    func manifestURL(for directoryURL: URL) -> URL {
+        directoryURL.appendingPathComponent(Self.manifestFileName)
+    }
+
+    func audioURL(for directoryURL: URL, fileName: String = Self.audioFileName) -> URL {
+        directoryURL.appendingPathComponent(fileName)
+    }
+
+    private func encodedDirectoryName(for artifactID: String) -> String {
+        artifactID.utf8.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/SpeakSwiftly/Generation/ProfileStore.swift
+++ b/Sources/SpeakSwiftly/Generation/ProfileStore.swift
@@ -178,9 +178,13 @@ struct ProfileStore {
 
         let manifests = try urls
             .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
-            .map { directoryURL in
+            .compactMap { directoryURL -> ProfileManifest? in
+                let manifestPath = manifestURL(for: directoryURL)
+                guard fileManager.fileExists(atPath: manifestPath.path) else {
+                    return nil
+                }
+
                 do {
-                    let manifestPath = manifestURL(for: directoryURL)
                     let manifestData = try Data(contentsOf: manifestPath)
                     return try decoder.decode(ProfileManifest.self, from: manifestData)
                 } catch {

--- a/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
@@ -17,7 +17,7 @@ extension SpeakSwiftly.Runtime {
         )
 
         for job in queuedJobs {
-            if job.request.isSpeechRequest {
+            if job.request.requiresPlayback {
                 _ = await playbackController.discard(requestID: job.request.id)
             }
             failRequestStream(for: job.request.id, error: cancellation)

--- a/Sources/SpeakSwiftly/Runtime/WorkerProtocol.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerProtocol.swift
@@ -6,6 +6,7 @@ import TextForSpeech
 struct RawWorkerRequest: Decodable, Sendable {
     let id: String?
     let op: String?
+    let artifactID: String?
     let text: String?
     let profileName: String?
     let textProfileName: String?
@@ -29,6 +30,7 @@ struct RawWorkerRequest: Decodable, Sendable {
     enum CodingKeys: String, CodingKey {
         case id
         case op
+        case artifactID = "artifact_id"
         case text
         case profileName = "profile_name"
         case textProfileName = "text_profile_name"
@@ -55,6 +57,7 @@ struct RawWorkerRequest: Decodable, Sendable {
 
         id = try container.decodeIfPresent(String.self, forKey: .id)
         op = try container.decodeIfPresent(String.self, forKey: .op)
+        artifactID = try container.decodeIfPresent(String.self, forKey: .artifactID)
         text = try container.decodeIfPresent(String.self, forKey: .text)
         profileName = try container.decodeIfPresent(String.self, forKey: .profileName)
         textProfileName = try container.decodeIfPresent(String.self, forKey: .textProfileName)
@@ -152,6 +155,8 @@ enum WorkerRequest: Sendable, Equatable {
         textContext: TextForSpeech.Context?,
         sourceFormat: TextForSpeech.SourceFormat?
     )
+    case generatedFile(id: String, artifactID: String)
+    case generatedFiles(id: String)
     case createProfile(id: String, profileName: String, text: String, voiceDescription: String, outputPath: String?)
     case createClone(id: String, profileName: String, referenceAudioPath: String, transcript: String?)
     case listProfiles(id: String)
@@ -180,6 +185,8 @@ enum WorkerRequest: Sendable, Equatable {
     var id: String {
         switch self {
         case .queueSpeech(id: let id, text: _, profileName: _, textProfileName: _, jobType: _, textContext: _, sourceFormat: _),
+             .generatedFile(let id, _),
+             .generatedFiles(let id),
              .createProfile(let id, _, _, _, _),
              .createClone(let id, _, _, _),
              .listProfiles(let id),
@@ -212,6 +219,12 @@ enum WorkerRequest: Sendable, Equatable {
         switch self {
         case .queueSpeech(id: _, text: _, profileName: _, textProfileName: _, jobType: .live, textContext: _, sourceFormat: _):
             "queue_speech_live"
+        case .queueSpeech(id: _, text: _, profileName: _, textProfileName: _, jobType: .file, textContext: _, sourceFormat: _):
+            "queue_speech_file"
+        case .generatedFile:
+            "generated_file"
+        case .generatedFiles:
+            "generated_files"
         case .createProfile:
             "create_profile"
         case .createClone:
@@ -278,6 +291,15 @@ enum WorkerRequest: Sendable, Equatable {
         }
     }
 
+    var requiresPlayback: Bool {
+        switch self {
+        case .queueSpeech(id: _, text: _, profileName: _, textProfileName: _, jobType: .live, textContext: _, sourceFormat: _):
+            return true
+        default:
+            return false
+        }
+    }
+
     var acknowledgesEnqueueImmediately: Bool {
         if case .queueSpeech = self {
             return true
@@ -285,9 +307,20 @@ enum WorkerRequest: Sendable, Equatable {
         return false
     }
 
+    var emitsTerminalSuccessAfterAcknowledgement: Bool {
+        switch self {
+        case .queueSpeech(id: _, text: _, profileName: _, textProfileName: _, jobType: .file, textContext: _, sourceFormat: _):
+            return true
+        default:
+            return false
+        }
+    }
+
     var isImmediateControlOperation: Bool {
         switch self {
-        case .textProfileActive,
+        case .generatedFile,
+             .generatedFiles,
+             .textProfileActive,
              .textProfileBase,
              .textProfile,
              .textProfiles,
@@ -320,7 +353,9 @@ enum WorkerRequest: Sendable, Equatable {
              .createClone(_, let profileName, _, _),
              .removeProfile(_, let profileName):
             profileName
-        case .textProfileActive,
+        case .generatedFile,
+             .generatedFiles,
+             .textProfileActive,
              .textProfileBase,
              .textProfiles,
              .textProfilePersistence,
@@ -352,7 +387,9 @@ enum WorkerRequest: Sendable, Equatable {
         switch self {
         case .queueSpeech(id: _, text: _, profileName: _, textProfileName: let textProfileName, jobType: _, textContext: _, sourceFormat: _):
             textProfileName
-        case .createProfile,
+        case .generatedFile,
+             .generatedFiles,
+             .createProfile,
              .createClone,
              .listProfiles,
              .removeProfile,
@@ -384,7 +421,9 @@ enum WorkerRequest: Sendable, Equatable {
         switch self {
         case .queueSpeech(id: _, text: _, profileName: _, textProfileName: _, jobType: _, textContext: let textContext, sourceFormat: _):
             textContext
-        case .createProfile,
+        case .generatedFile,
+             .generatedFiles,
+             .createProfile,
              .createClone,
              .listProfiles,
              .removeProfile,
@@ -416,7 +455,9 @@ enum WorkerRequest: Sendable, Equatable {
         switch self {
         case .queueSpeech(id: _, text: _, profileName: _, textProfileName: _, jobType: _, textContext: _, sourceFormat: let sourceFormat):
             sourceFormat
-        case .createProfile,
+        case .generatedFile,
+             .generatedFiles,
+             .createProfile,
              .createClone,
              .listProfiles,
              .removeProfile,
@@ -493,6 +534,39 @@ enum WorkerRequest: Sendable, Equatable {
                 textContext: textContext,
                 sourceFormat: raw.sourceFormat
             )
+
+        case "queue_speech_file":
+            let text = try requireNonEmpty(raw.text, field: "text", id: id)
+            let profileName = try requireNonEmpty(raw.profileName, field: "profile_name", id: id)
+            let textProfileName = raw.textProfileName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+            if raw.sourceFormat != nil && (raw.textFormat != nil || raw.nestedSourceFormat != nil) {
+                throw WorkerError(
+                    code: .invalidRequest,
+                    message: "Request '\(id)' cannot combine the whole-source lane (`source_format`) with mixed-text lane fields (`text_format` or `nested_source_format`)."
+                )
+            }
+            let textContext = TextForSpeech.Context(
+                cwd: raw.cwd,
+                repoRoot: raw.repoRoot,
+                textFormat: raw.textFormat,
+                nestedSourceFormat: raw.nestedSourceFormat
+            ).nilIfEmpty
+            return .queueSpeech(
+                id: id,
+                text: text,
+                profileName: profileName,
+                textProfileName: textProfileName,
+                jobType: .file,
+                textContext: textContext,
+                sourceFormat: raw.sourceFormat
+            )
+
+        case "generated_file":
+            let artifactID = try requireNonEmpty(raw.artifactID, field: "artifact_id", id: id)
+            return .generatedFile(id: id, artifactID: artifactID)
+
+        case "generated_files":
+            return .generatedFiles(id: id)
 
         case "create_profile":
             let profileName = try requireNonEmpty(raw.profileName, field: "profile_name", id: id)
@@ -674,6 +748,8 @@ public extension SpeakSwiftly {
 
     enum ProgressStage: String, Codable, Sendable {
         case loadingProfile = "loading_profile"
+        case generatingFileAudio = "generating_file_audio"
+        case writingGeneratedFile = "writing_generated_file"
         case startingPlayback = "starting_playback"
         case bufferingAudio = "buffering_audio"
         case prerollReady = "preroll_ready"
@@ -746,6 +822,8 @@ public extension SpeakSwiftly {
     struct Success: Encodable, Sendable, Equatable {
         public let id: String
         public let ok = true
+        public let generatedFile: GeneratedFile?
+        public let generatedFiles: [GeneratedFile]?
         public let profileName: String?
         public let profilePath: String?
         public let profiles: [ProfileSummary]?
@@ -761,6 +839,8 @@ public extension SpeakSwiftly {
         enum CodingKeys: String, CodingKey {
             case id
             case ok
+            case generatedFile = "generated_file"
+            case generatedFiles = "generated_files"
             case profileName = "profile_name"
             case profilePath = "profile_path"
             case profiles
@@ -776,6 +856,8 @@ public extension SpeakSwiftly {
 
         public init(
             id: String,
+            generatedFile: GeneratedFile? = nil,
+            generatedFiles: [GeneratedFile]? = nil,
             profileName: String? = nil,
             profilePath: String? = nil,
             profiles: [ProfileSummary]? = nil,
@@ -789,6 +871,8 @@ public extension SpeakSwiftly {
             cancelledRequestID: String? = nil
         ) {
             self.id = id
+            self.generatedFile = generatedFile
+            self.generatedFiles = generatedFiles
             self.profileName = profileName
             self.profilePath = profilePath
             self.profiles = profiles
@@ -874,6 +958,8 @@ public extension SpeakSwiftly {
         case invalidJSON = "invalid_json"
         case invalidRequest = "invalid_request"
         case unknownOperation = "unknown_operation"
+        case generatedFileNotFound = "generated_file_not_found"
+        case generatedFileAlreadyExists = "generated_file_already_exists"
         case profileNotFound = "profile_not_found"
         case profileAlreadyExists = "profile_already_exists"
         case invalidProfileName = "invalid_profile_name"

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Emission.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Emission.swift
@@ -15,6 +15,8 @@ extension SpeakSwiftly.Runtime {
             )
             let success = WorkerSuccessResponse(
                 id: payload.id,
+                generatedFile: payload.generatedFile,
+                generatedFiles: payload.generatedFiles,
                 profileName: payload.profileName,
                 profilePath: payload.profilePath,
                 profiles: payload.profiles,
@@ -29,7 +31,7 @@ extension SpeakSwiftly.Runtime {
             )
             yieldRequestEvent(.completed(success), for: request.id)
             finishRequestStream(for: request.id)
-            if !request.acknowledgesEnqueueImmediately {
+            if !request.acknowledgesEnqueueImmediately || request.emitsTerminalSuccessAfterAcknowledgement {
                 await emit(success)
             }
 
@@ -155,6 +157,7 @@ extension SpeakSwiftly.Runtime {
     func submitRequest(
         id: String,
         op: String,
+        artifactID: String? = nil,
         text: String? = nil,
         profileName: String? = nil,
         textProfileName: String? = nil,
@@ -175,6 +178,7 @@ extension SpeakSwiftly.Runtime {
         let request = OutgoingWorkerRequest(
             id: id,
             op: op,
+            artifactID: artifactID,
             text: text,
             profileName: profileName,
             textProfileName: textProfileName,
@@ -222,6 +226,17 @@ extension SpeakSwiftly.Runtime {
                 textProfileName: textProfileName,
                 textContext: textContext,
                 sourceFormat: sourceFormat
+            )
+        case .generatedFile(let id, let artifactID):
+            await submitRequest(
+                id: id,
+                op: request.opName,
+                artifactID: artifactID
+            )
+        case .generatedFiles(let id):
+            await submitRequest(
+                id: id,
+                op: request.opName
             )
         case .createProfile(let id, let profileName, let text, let voiceDescription, let outputPath):
             await submitRequest(

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
@@ -29,6 +29,8 @@ public extension SpeakSwiftly {
 
     struct WorkerSuccessPayload: Sendable {
         let id: String
+        let generatedFile: SpeakSwiftly.GeneratedFile?
+        let generatedFiles: [SpeakSwiftly.GeneratedFile]?
         let profileName: String?
         let profilePath: String?
         let profiles: [ProfileSummary]?
@@ -43,6 +45,8 @@ public extension SpeakSwiftly {
 
         init(
             id: String,
+            generatedFile: SpeakSwiftly.GeneratedFile? = nil,
+            generatedFiles: [SpeakSwiftly.GeneratedFile]? = nil,
             profileName: String? = nil,
             profilePath: String? = nil,
             profiles: [ProfileSummary]? = nil,
@@ -56,6 +60,8 @@ public extension SpeakSwiftly {
             cancelledRequestID: String? = nil
         ) {
             self.id = id
+            self.generatedFile = generatedFile
+            self.generatedFiles = generatedFiles
             self.profileName = profileName
             self.profilePath = profilePath
             self.profiles = profiles
@@ -78,6 +84,7 @@ public extension SpeakSwiftly {
     struct OutgoingWorkerRequest: Encodable {
         let id: String
         let op: String
+        let artifactID: String?
         let text: String?
         let profileName: String?
         let textProfileName: String?
@@ -101,6 +108,7 @@ public extension SpeakSwiftly {
         enum CodingKeys: String, CodingKey {
             case id
             case op
+            case artifactID = "artifact_id"
             case text
             case profileName = "profile_name"
             case textProfileName = "text_profile_name"
@@ -177,6 +185,7 @@ public extension SpeakSwiftly {
     let encoder = JSONEncoder()
     let logEncoder = JSONEncoder()
     let profileStore: ProfileStore
+    let generatedFileStore: GeneratedFileStore
     let normalizerRef: SpeakSwiftly.Normalizer
     let playbackController: PlaybackController
     let generationController = GenerationController()
@@ -195,11 +204,13 @@ public extension SpeakSwiftly {
     init(
         dependencies: WorkerDependencies,
         profileStore: ProfileStore,
+        generatedFileStore: GeneratedFileStore,
         normalizer: SpeakSwiftly.Normalizer,
         playbackController: PlaybackController
     ) {
         self.dependencies = dependencies
         self.profileStore = profileStore
+        self.generatedFileStore = generatedFileStore
         normalizerRef = normalizer
         self.playbackController = playbackController
         encoder.outputFormatting = [.sortedKeys]
@@ -221,6 +232,9 @@ public extension SpeakSwiftly {
         let normalizer = normalizer ?? SpeakSwiftly.Normalizer(
             persistenceURL: profileStore.rootURL.appending(path: ProfileStore.textProfilesFileName)
         )
+        let generatedFileStore = GeneratedFileStore(
+            rootURL: profileStore.rootURL.appendingPathComponent(GeneratedFileStore.directoryName, isDirectory: true)
+        )
         do {
             try await normalizer.loadProfiles()
         } catch {
@@ -233,6 +247,7 @@ public extension SpeakSwiftly {
         let runtime = Runtime(
             dependencies: dependencies,
             profileStore: profileStore,
+            generatedFileStore: generatedFileStore,
             normalizer: normalizer,
             playbackController: playbackController
         )
@@ -435,7 +450,7 @@ public extension SpeakSwiftly {
             return
         }
 
-        if request.isSpeechRequest, await playbackController.jobCount() >= maxAcceptedSpeechJobs {
+        if request.requiresPlayback, await playbackController.jobCount() >= maxAcceptedSpeechJobs {
             let workerError = WorkerError(
                 code: .invalidRequest,
                 message: "Request '\(request.id)' was rejected because the live speech queue is already holding \(maxAcceptedSpeechJobs) accepted jobs. Wait for playback to drain or clear queued work before adding more."
@@ -455,7 +470,7 @@ public extension SpeakSwiftly {
             profileName: request.profileName,
             queueDepth: await generationQueueDepth()
         )
-        if request.isSpeechRequest {
+        if request.requiresPlayback {
             let speechJob = await makeSpeechJobState(for: request)
             await playbackController.enqueue(speechJob)
         }
@@ -517,7 +532,7 @@ public extension SpeakSwiftly {
             await self.processGeneration(job.request, token: job.token)
         }
         activeGeneration = ActiveRequest(token: job.token, request: job.request, task: task)
-        if case .queueSpeech(id: let id, text: _, profileName: _, textProfileName: _, jobType: _, textContext: _, sourceFormat: _) = job.request {
+        if case .queueSpeech(id: let id, text: _, profileName: _, textProfileName: _, jobType: .live, textContext: _, sourceFormat: _) = job.request {
             await playbackController.setGenerationTask(task, for: id)
         }
     }
@@ -530,6 +545,31 @@ public extension SpeakSwiftly {
             case .queueSpeech(id: let id, text: let text, profileName: let profileName, textProfileName: _, jobType: .live, textContext: _, sourceFormat: _):
                 try await handleQueueSpeechLiveGeneration(id: id, op: request.opName, text: text, profileName: profileName)
                 disposition = .requestStillPendingPlayback(id)
+
+            case .queueSpeech(
+                id: let id,
+                text: let text,
+                profileName: let profileName,
+                textProfileName: let textProfileName,
+                jobType: .file,
+                textContext: let textContext,
+                sourceFormat: let sourceFormat
+            ):
+                let generatedFile = try await handleQueueSpeechFileGeneration(
+                    id: id,
+                    op: request.opName,
+                    text: text,
+                    profileName: profileName,
+                    textProfileName: textProfileName,
+                    textContext: textContext,
+                    sourceFormat: sourceFormat
+                )
+                disposition = .requestCompleted(.success(
+                    WorkerSuccessPayload(
+                        id: id,
+                        generatedFile: generatedFile
+                    )
+                ))
 
             case .createProfile(let id, let profileName, let text, let voiceDescription, let outputPath):
                 let storedProfile = try await handleCreateProfile(
@@ -593,7 +633,9 @@ public extension SpeakSwiftly {
                 )
                 disposition = .requestCompleted(.success(WorkerSuccessPayload(id: id, profileName: profileName)))
 
-            case .textProfileActive,
+            case .generatedFile,
+                 .generatedFiles,
+                 .textProfileActive,
                  .textProfileBase,
                  .textProfile,
                  .textProfiles,
@@ -640,6 +682,22 @@ public extension SpeakSwiftly {
 
         do {
             switch request {
+            case .generatedFile(let id, let artifactID):
+                result = .success(
+                    WorkerSuccessPayload(
+                        id: id,
+                        generatedFile: try generatedFileStore.loadGeneratedFile(id: artifactID).summary
+                    )
+                )
+
+            case .generatedFiles(let id):
+                result = .success(
+                    WorkerSuccessPayload(
+                        id: id,
+                        generatedFiles: try generatedFileStore.listGeneratedFiles()
+                    )
+                )
+
             case .textProfileActive(let id):
                 result = .success(
                     WorkerSuccessPayload(
@@ -878,43 +936,18 @@ public extension SpeakSwiftly {
     }
 
     private func handleQueueSpeechLiveGeneration(id: String, op: String, text: String, profileName: String) async throws {
-        let residentModel = try residentModelOrThrow()
         guard let speechJob = await playbackController.job(for: id) else {
             throw WorkerError(
                 code: .internalError,
                 message: "Request '\(id)' started generation without a matching live speech job state. This indicates a SpeakSwiftly runtime bug."
             )
         }
+        let (residentModel, profile, refAudio) = try await loadResidentSpeechInputs(
+            requestID: id,
+            op: op,
+            profileName: profileName
+        )
         speechJob.sampleRate = Double(residentModel.sampleRate)
-
-        await emitProgress(id: id, stage: .loadingProfile)
-        let profileLoadStartedAt = dependencies.now()
-        let profile = try profileStore.loadProfile(named: profileName)
-        await logRequestEvent(
-            "profile_loaded",
-            requestID: id,
-            op: op,
-            profileName: profileName,
-            details: [
-                "path": .string(profile.directoryURL.path),
-                "duration_ms": .int(elapsedMS(since: profileLoadStartedAt)),
-            ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
-        )
-
-        let refAudioLoadStartedAt = dependencies.now()
-        let refAudio = try dependencies.loadAudioSamples(profile.referenceAudioURL, residentModel.sampleRate)
-        await logRequestEvent(
-            "reference_audio_loaded",
-            requestID: id,
-            op: op,
-            profileName: profileName,
-            details: [
-                "path": .string(profile.referenceAudioURL.path),
-                "duration_ms": .int(elapsedMS(since: refAudioLoadStartedAt)),
-                "sample_rate": .int(residentModel.sampleRate),
-            ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
-        )
-        try Task.checkCancellation()
 
         await emitProgress(id: id, stage: .startingPlayback)
         let stream = residentModel.generateSamplesStream(
@@ -993,7 +1026,7 @@ public extension SpeakSwiftly {
         )
     }
 
-    private func residentModelOrThrow() throws -> AnySpeechModel {
+    func residentModelOrThrow() throws -> AnySpeechModel {
         if isShuttingDown {
             throw WorkerError(
                 code: .workerShuttingDown,
@@ -1015,7 +1048,7 @@ public extension SpeakSwiftly {
         let queuedJobs = await generationController.clearQueued()
 
         for job in queuedJobs {
-            if job.request.isSpeechRequest {
+            if job.request.requiresPlayback {
                 _ = await playbackController.discard(requestID: job.request.id)
             }
             failRequestStream(for: job.request.id, error: error)

--- a/Sources/SpeakSwiftly/SpeakSwiftly.swift
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.swift
@@ -6,6 +6,7 @@ import TextForSpeech
 public enum SpeakSwiftly {
     public enum Job: Sendable, Equatable {
         case live
+        case file
     }
 
     public enum Queue: Sendable, Equatable {

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -36,6 +36,24 @@ import TextForSpeech
             id: id
         )
     }
+    let speakFile: @Sendable (SpeakSwiftly.Runtime, String, String, String?, TextForSpeech.Context?, TextForSpeech.SourceFormat?, String) async -> SpeakSwiftly.RequestHandle = {
+        runtime,
+        text,
+        profileName,
+        textProfileName,
+        textContext,
+        sourceFormat,
+        id in
+        await runtime.speak(
+            text: text,
+            with: profileName,
+            as: .file,
+            textProfileName: textProfileName,
+            textContext: textContext,
+            sourceFormat: sourceFormat,
+            id: id
+        )
+    }
     let normalizer: @Sendable (SpeakSwiftly.Runtime) -> SpeakSwiftly.Normalizer = { runtime in
         runtime.normalizer
     }
@@ -155,6 +173,12 @@ import TextForSpeech
     let removeProfile: @Sendable (SpeakSwiftly.Runtime, String, String) async -> SpeakSwiftly.RequestHandle = { runtime, profileName, id in
         await runtime.removeProfile(named: profileName, id: id)
     }
+    let generatedFile: @Sendable (SpeakSwiftly.Runtime, String, String) async -> SpeakSwiftly.RequestHandle = { runtime, artifactID, requestID in
+        await runtime.generatedFile(id: artifactID, requestID: requestID)
+    }
+    let generatedFiles: @Sendable (SpeakSwiftly.Runtime, String) async -> SpeakSwiftly.RequestHandle = { runtime, requestID in
+        await runtime.generatedFiles(id: requestID)
+    }
     let generationQueue: @Sendable (SpeakSwiftly.Runtime) async -> SpeakSwiftly.RequestHandle = { runtime in
         await runtime.queue(.generation)
     }
@@ -175,6 +199,7 @@ import TextForSpeech
     }
 
     _ = speak
+    _ = speakFile
     _ = normalizer
     _ = makeNormalizer
     _ = liveWithNormalizer
@@ -182,6 +207,8 @@ import TextForSpeech
     _ = createClone
     _ = profiles
     _ = removeProfile
+    _ = generatedFile
+    _ = generatedFiles
     _ = profile
     _ = profilesList
     _ = activeProfile
@@ -219,4 +246,20 @@ import TextForSpeech
     _ = operation
     _ = profileName
     _ = events
+}
+
+@Test func publicGeneratedFileSurfaceExposesStableMetadata() {
+    let artifactID: KeyPath<SpeakSwiftly.GeneratedFile, String> = \.artifactID
+    let createdAt: KeyPath<SpeakSwiftly.GeneratedFile, Date> = \.createdAt
+    let profileName: KeyPath<SpeakSwiftly.GeneratedFile, String> = \.profileName
+    let textProfileName: KeyPath<SpeakSwiftly.GeneratedFile, String?> = \.textProfileName
+    let sampleRate: KeyPath<SpeakSwiftly.GeneratedFile, Int> = \.sampleRate
+    let filePath: KeyPath<SpeakSwiftly.GeneratedFile, String> = \.filePath
+
+    _ = artifactID
+    _ = createdAt
+    _ = profileName
+    _ = textProfileName
+    _ = sampleRate
+    _ = filePath
 }

--- a/Tests/SpeakSwiftlyTests/E2E/SpeakSwiftlyE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/SpeakSwiftlyE2ETests.swift
@@ -1317,19 +1317,10 @@ private final class WorkerProcess: @unchecked Sendable {
 
     private static func computeWorkerExecutableURL() throws -> URL {
         let packageRootURL = try packageRootURL()
-        let derivedDataURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("SpeakSwiftly-xcodebuild-e2e-dd", isDirectory: true)
-        let sourcePackagesURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("SpeakSwiftly-xcodebuild-e2e-spm", isDirectory: true)
+        try publishWorkerRuntime(packageRootURL: packageRootURL, configuration: "Debug")
 
-        try buildWorkerProduct(
-            packageRootURL: packageRootURL,
-            derivedDataURL: derivedDataURL,
-            sourcePackagesURL: sourcePackagesURL
-        )
-
-        let productsURL = derivedDataURL
-            .appendingPathComponent("Build/Products/Debug", isDirectory: true)
+        let productsURL = packageRootURL
+            .appendingPathComponent(".local/xcode/Debug", isDirectory: true)
         let executableURL = productsURL.appendingPathComponent("SpeakSwiftly", isDirectory: false)
         let metallibURL = productsURL
             .appendingPathComponent("mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib", isDirectory: false)
@@ -1372,24 +1363,24 @@ private final class WorkerProcess: @unchecked Sendable {
 
     private static func buildWorkerProduct(
         packageRootURL: URL,
-        derivedDataURL: URL,
-        sourcePackagesURL: URL
+        configuration: String
     ) throws {
         let process = Process()
-        let logURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("SpeakSwiftly-xcodebuild-e2e.log", isDirectory: false)
+        let logURL = packageRootURL
+            .appendingPathComponent(".local/xcode/SpeakSwiftly-e2e-publish-\(configuration.lowercased()).log", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: packageRootURL.appendingPathComponent(".local/xcode", isDirectory: true),
+            withIntermediateDirectories: true
+        )
         FileManager.default.createFile(atPath: logURL.path, contents: nil)
         let logHandle = try FileHandle(forWritingTo: logURL)
         defer { try? logHandle.close() }
 
         process.currentDirectoryURL = packageRootURL
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcodebuild")
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = [
-            "build",
-            "-scheme", "SpeakSwiftly",
-            "-destination", "platform=macOS",
-            "-derivedDataPath", derivedDataURL.path,
-            "-clonedSourcePackagesDirPath", sourcePackagesURL.path,
+            "scripts/repo-maintenance/publish-runtime.sh",
+            "--configuration", configuration,
         ]
         process.standardOutput = logHandle
         process.standardError = logHandle
@@ -1401,9 +1392,19 @@ private final class WorkerProcess: @unchecked Sendable {
             let outputData = try Data(contentsOf: logURL)
             let output = String(decoding: outputData, as: UTF8.self)
             throw WorkerProcessError(
-                "The Xcode-backed SpeakSwiftly build failed with status \(process.terminationStatus). `xcodebuild` output:\n\(output)"
+                "The SpeakSwiftly runtime publisher failed with status \(process.terminationStatus). Publisher output:\n\(output)"
             )
         }
+    }
+
+    private static func publishWorkerRuntime(
+        packageRootURL: URL,
+        configuration: String
+    ) throws {
+        try buildWorkerProduct(
+            packageRootURL: packageRootURL,
+            configuration: configuration
+        )
     }
 }
 

--- a/Tests/SpeakSwiftlyTests/E2E/SpeakSwiftlyE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/SpeakSwiftlyE2ETests.swift
@@ -316,6 +316,86 @@ struct SpeakSwiftlyE2ETests {
         }
     }
 
+    @Test func generatedFileLaneRunsEndToEndAndSupportsManagedArtifactReads() async throws {
+        guard Self.isE2EEnabled else { return }
+
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        let worker = try WorkerProcess(
+            profileRootURL: sandbox.profileRootURL,
+            silentPlayback: true
+        )
+        defer { Task { await worker.stop() } }
+
+        try await Self.awaitWorkerReady(worker, expectPlaybackEngine: false)
+        try await Self.createVoiceDesignProfile(
+            on: worker,
+            id: "req-create-generated-file-profile",
+            profileName: Self.testingProfileName,
+            text: Self.testingProfileText,
+            voiceDescription: Self.testingProfileVoiceDescription
+        )
+
+        let generatedFile = try await Self.runGeneratedFileSpeech(
+            on: worker,
+            id: "req-generated-file-e2e",
+            text: Self.testingPlaybackText,
+            profileName: Self.testingProfileName
+        )
+        #expect(generatedFile["artifact_id"] as? String == "req-generated-file-e2e")
+        #expect(generatedFile["profile_name"] as? String == Self.testingProfileName)
+
+        let generatedFilePath = try #require(generatedFile["file_path"] as? String)
+        #expect(FileManager.default.fileExists(atPath: generatedFilePath))
+
+        try worker.sendJSON(
+            """
+            {"id":"req-generated-file-read","op":"generated_file","artifact_id":"req-generated-file-e2e"}
+            """
+        )
+
+        let fetchedGeneratedFile = try #require(
+            try await worker.waitForJSONObject(timeout: Self.e2eTimeout) {
+                guard
+                    $0["id"] as? String == "req-generated-file-read",
+                    $0["ok"] as? Bool == true,
+                    let generatedFile = $0["generated_file"] as? [String: Any]
+                else {
+                    return false
+                }
+
+                return generatedFile["artifact_id"] as? String == "req-generated-file-e2e"
+            }
+        )
+        let fetchedGeneratedFilePayload = try #require(fetchedGeneratedFile["generated_file"] as? [String: Any])
+        #expect(fetchedGeneratedFilePayload["file_path"] as? String == generatedFilePath)
+
+        try worker.sendJSON(
+            """
+            {"id":"req-generated-files-read","op":"generated_files"}
+            """
+        )
+
+        #expect(try await worker.waitForJSONObject(timeout: Self.e2eTimeout) {
+            guard
+                $0["id"] as? String == "req-generated-files-read",
+                $0["ok"] as? Bool == true,
+                let generatedFiles = $0["generated_files"] as? [[String: Any]]
+            else {
+                return false
+            }
+
+            return generatedFiles.contains {
+                $0["artifact_id"] as? String == "req-generated-file-e2e"
+                    && $0["file_path"] as? String == generatedFilePath
+            }
+        } != nil)
+
+        try worker.closeInput()
+        try await worker.waitForExit(timeout: .seconds(30))
+    }
+
     // MARK: Audible Playback and Tracing
 
     @Test func speakLivePlaybackTraceCanBeCapturedOnDemand() async throws {
@@ -991,6 +1071,56 @@ struct SpeakSwiftlyE2ETests {
             $0["id"] as? String == id
                 && $0["ok"] as? Bool == true
         } != nil)
+    }
+
+    private static func runGeneratedFileSpeech(
+        on worker: WorkerProcess,
+        id: String,
+        text: String,
+        profileName: String
+    ) async throws -> [String: Any] {
+        try worker.sendJSON(
+            """
+            {"id":"\(id)","op":"queue_speech_file","text":"\(text.jsonEscaped)","profile_name":"\(profileName)"}
+            """
+        )
+
+        #expect(try await worker.waitForJSONObject(timeout: Self.e2eTimeout) {
+            $0["id"] as? String == id
+                && $0["ok"] as? Bool == true
+                && $0["generated_file"] == nil
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: Self.e2eTimeout) {
+            $0["id"] as? String == id
+                && $0["event"] as? String == "started"
+                && $0["op"] as? String == "queue_speech_file"
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: Self.e2eTimeout) {
+            $0["id"] as? String == id
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "generating_file_audio"
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: Self.e2eTimeout) {
+            $0["id"] as? String == id
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "writing_generated_file"
+        } != nil)
+
+        let success = try #require(
+            try await worker.waitForJSONObject(timeout: Self.e2eTimeout) {
+                guard
+                    $0["id"] as? String == id,
+                    $0["ok"] as? Bool == true,
+                    let generatedFile = $0["generated_file"] as? [String: Any]
+                else {
+                    return false
+                }
+
+                return generatedFile["artifact_id"] as? String == id
+            }
+        )
+
+        return try #require(success["generated_file"] as? [String: Any])
     }
 
     private static func transcriptLooksCloseToCloneSource(_ transcript: String) -> Bool {

--- a/Tests/SpeakSwiftlyTests/Generation/GeneratedFileStoreTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/GeneratedFileStoreTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import SpeakSwiftlyCore
+
+// MARK: - Generated File Store
+
+@Test func generatedFileStoreWritesLoadsAndListsArtifacts() throws {
+    let rootURL = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let store = try makeGeneratedFileStore(rootURL: rootURL)
+    let created = try store.createGeneratedFile(
+        artifactID: "req-file-1",
+        profileName: "default-femme",
+        textProfileName: "logs",
+        sampleRate: 24_000,
+        audioData: Data([0x01, 0x02, 0x03])
+    )
+
+    #expect(FileManager.default.fileExists(atPath: created.audioURL.path))
+
+    let loaded = try store.loadGeneratedFile(id: "req-file-1")
+    #expect(loaded.summary.artifactID == "req-file-1")
+    #expect(loaded.summary.profileName == "default-femme")
+    #expect(loaded.summary.textProfileName == "logs")
+    #expect(loaded.summary.sampleRate == 24_000)
+    #expect(loaded.summary.filePath == created.audioURL.path)
+
+    let listed = try store.listGeneratedFiles()
+    #expect(listed == [loaded.summary])
+}
+
+@Test func generatedFileStoreRejectsMissingArtifacts() throws {
+    let rootURL = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let store = try makeGeneratedFileStore(rootURL: rootURL)
+
+    #expect(throws: WorkerError(code: .generatedFileNotFound, message: "Generated file 'missing' was not found in the SpeakSwiftly generated-file store.")) {
+        _ = try store.loadGeneratedFile(id: "missing")
+    }
+}

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
@@ -21,6 +21,24 @@ import TextForSpeech
     )
 }
 
+@Test func decodesSpeakFileRequest() throws {
+    let request = try WorkerRequest.decode(
+        from: #"{"id":"req-file","op":"queue_speech_file","text":"Hello","profile_name":"default-femme"}"#
+    )
+
+    #expect(
+        request == .queueSpeech(
+            id: "req-file",
+            text: "Hello",
+            profileName: "default-femme",
+            textProfileName: nil,
+            jobType: .file,
+            textContext: nil,
+            sourceFormat: nil
+        )
+    )
+}
+
 @Test func decodesSpeakLiveRequestWithTextContextAndProfile() throws {
     let request = try WorkerRequest.decode(
         from: #"{"id":"req-1","op":"queue_speech_live","text":"Hello","profile_name":"default-femme","text_profile_name":"logs","cwd":"/Users/galew/Workspace/SpeakSwiftly","repo_root":"/Users/galew/Workspace/SpeakSwiftly","text_format":"cli_output"}"#
@@ -134,6 +152,16 @@ import TextForSpeech
 @Test func decodesListProfilesRequest() throws {
     let request = try WorkerRequest.decode(from: #"{"id":"req-3","op":"list_profiles"}"#)
     #expect(request == .listProfiles(id: "req-3"))
+}
+
+@Test func decodesGeneratedFileRequests() throws {
+    let file = try WorkerRequest.decode(
+        from: #"{"id":"req-generated-file","op":"generated_file","artifact_id":"req-file"}"#
+    )
+    #expect(file == .generatedFile(id: "req-generated-file", artifactID: "req-file"))
+
+    let list = try WorkerRequest.decode(from: #"{"id":"req-generated-files","op":"generated_files"}"#)
+    #expect(list == .generatedFiles(id: "req-generated-files"))
 }
 
 @Test func decodesRemoveProfileRequest() throws {

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeTests.swift
@@ -431,6 +431,157 @@ import TextForSpeech
     await profileGate.open()
 }
 
+// MARK: - Generated File Queueing
+
+@Test func speakFileAcknowledgesQueueThenCompletesWithGeneratedFileMetadata() async throws {
+    let output = OutputRecorder()
+    let playback = PlaybackSpy()
+    let storeRoot = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: storeRoot) }
+
+    let store = try makeProfileStore(rootURL: storeRoot)
+    _ = try store.createProfile(
+        profileName: "default-femme",
+        modelRepo: "test-model",
+        voiceDescription: "Warm and bright.",
+        sourceText: "Reference transcript",
+        sampleRate: 24_000,
+        canonicalAudioData: Data([0x01, 0x02])
+    )
+
+    let runtime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: output,
+        playback: playback,
+        residentModelLoader: { makeResidentModel() }
+    )
+
+    await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    let requestID = await runtime.speak(
+        text: "Hello from the generated file path.",
+        with: "default-femme",
+        as: .file,
+        id: "req-file-1"
+    ).id
+    #expect(requestID == "req-file-1")
+
+    #expect(await waitUntil {
+        output.countJSONObjects {
+            $0["id"] as? String == "req-file-1"
+                && $0["ok"] as? Bool == true
+        } == 2
+    })
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == "req-file-1"
+                && $0["event"] as? String == "started"
+                && $0["op"] as? String == "queue_speech_file"
+        }
+    })
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == "req-file-1"
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "writing_generated_file"
+        }
+    })
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            guard
+                $0["id"] as? String == "req-file-1",
+                let generatedFile = $0["generated_file"] as? [String: Any],
+                generatedFile["artifact_id"] as? String == "req-file-1",
+                generatedFile["profile_name"] as? String == "default-femme",
+                let filePath = generatedFile["file_path"] as? String
+            else {
+                return false
+            }
+
+            return FileManager.default.fileExists(atPath: filePath)
+        }
+    })
+    #expect(!output.containsJSONObject {
+        $0["id"] as? String == "req-file-1"
+            && $0["event"] as? String == "progress"
+            && $0["stage"] as? String == "playback_finished"
+    })
+}
+
+@Test func generatedFileReadOperationsRunDuringResidentWarmupWithoutQueueing() async throws {
+    let output = OutputRecorder()
+    let preloadGate = AsyncGate()
+    let rootURL = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let generatedFileStore = try makeGeneratedFileStore(rootURL: rootURL)
+    _ = try generatedFileStore.createGeneratedFile(
+        artifactID: "req-file-lookup",
+        profileName: "default-femme",
+        textProfileName: nil,
+        sampleRate: 24_000,
+        audioData: Data([0x01, 0x02, 0x03])
+    )
+
+    let runtime = try await makeRuntime(
+        rootURL: rootURL,
+        output: output,
+        playback: PlaybackSpy(),
+        residentModelLoader: {
+            await preloadGate.wait()
+            return makeResidentModel()
+        }
+    )
+
+    await runtime.start()
+    await runtime.accept(line: #"{"id":"req-generated-file","op":"generated_file","artifact_id":"req-file-lookup"}"#)
+    await runtime.accept(line: #"{"id":"req-generated-files","op":"generated_files"}"#)
+
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == "req-generated-file"
+                && $0["event"] as? String == "started"
+        }
+    })
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            guard
+                $0["id"] as? String == "req-generated-file",
+                let generatedFile = $0["generated_file"] as? [String: Any]
+            else {
+                return false
+            }
+
+            return generatedFile["artifact_id"] as? String == "req-file-lookup"
+        }
+    })
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            guard
+                $0["id"] as? String == "req-generated-files",
+                let generatedFiles = $0["generated_files"] as? [[String: Any]]
+            else {
+                return false
+            }
+
+            return generatedFiles.count == 1
+                && generatedFiles.first?["artifact_id"] as? String == "req-file-lookup"
+        }
+    })
+    #expect(!output.containsJSONObject {
+        ($0["id"] as? String == "req-generated-file" || $0["id"] as? String == "req-generated-files")
+            && $0["event"] as? String == "queued"
+    })
+
+    await preloadGate.open()
+}
+
 // MARK: - Live Playback Queueing
 
 @Test func speakLiveBackgroundAcknowledgesQueueBeforePlaybackStartsAndOnlySucceedsOnce() async throws {

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeTests.swift
@@ -1049,7 +1049,7 @@ import TextForSpeech
     await profileGate.open()
 }
 
-@Test func libraryCreateListAndRemoveHelpersSubmitWorkerProtocolRequests() async throws {
+@Test func libraryHelpersSubmitProfileAndGeneratedFileWorkerProtocolRequests() async throws {
     let output = OutputRecorder()
     let storeRoot = makeTempDirectoryURL()
     defer { try? FileManager.default.removeItem(at: storeRoot) }
@@ -1098,6 +1098,61 @@ import TextForSpeech
             }
 
             return profiles.contains { $0["profile_name"] as? String == "bright-guide" }
+        }
+    })
+
+    let speakFileID = await runtime.speak(
+        text: "Save this request as an artifact.",
+        with: "bright-guide",
+        as: .file,
+        id: "req-file-helper"
+    ).id
+    #expect(speakFileID == "req-file-helper")
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            guard
+                $0["id"] as? String == "req-file-helper",
+                $0["ok"] as? Bool == true,
+                let generatedFile = $0["generated_file"] as? [String: Any]
+            else {
+                return false
+            }
+
+            return generatedFile["artifact_id"] as? String == "req-file-helper"
+        }
+    })
+
+    let generatedFileID = await runtime.generatedFile(id: "req-file-helper", requestID: "req-file-read").id
+    #expect(generatedFileID == "req-file-read")
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            guard
+                $0["id"] as? String == "req-file-read",
+                $0["ok"] as? Bool == true,
+                let generatedFile = $0["generated_file"] as? [String: Any]
+            else {
+                return false
+            }
+
+            return generatedFile["artifact_id"] as? String == "req-file-helper"
+        }
+    })
+
+    let generatedFilesID = await runtime.generatedFiles(id: "req-file-list").id
+    #expect(generatedFilesID == "req-file-list")
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            guard
+                $0["id"] as? String == "req-file-list",
+                $0["ok"] as? Bool == true,
+                let generatedFiles = $0["generated_files"] as? [[String: Any]]
+            else {
+                return false
+            }
+
+            return generatedFiles.contains {
+                $0["artifact_id"] as? String == "req-file-helper"
+            }
         }
     })
 

--- a/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
@@ -444,6 +444,15 @@ func makeProfileStore(rootURL: URL) throws -> ProfileStore {
     return store
 }
 
+func makeGeneratedFileStore(rootURL: URL) throws -> GeneratedFileStore {
+    let store = GeneratedFileStore(
+        rootURL: rootURL.appendingPathComponent(GeneratedFileStore.directoryName, isDirectory: true),
+        fileManager: .default
+    )
+    try store.ensureRootExists()
+    return store
+}
+
 func makeRuntime(
     rootURL: URL = makeTempDirectoryURL(),
     output: OutputRecorder,
@@ -460,6 +469,7 @@ func makeRuntime(
     }
 ) async throws -> WorkerRuntime {
     let store = try makeProfileStore(rootURL: rootURL)
+    let generatedFileStore = try makeGeneratedFileStore(rootURL: rootURL)
     let normalizer = SpeakSwiftly.Normalizer(
         persistenceURL: rootURL.appending(path: ProfileStore.textProfilesFileName)
     )
@@ -493,6 +503,7 @@ func makeRuntime(
     let runtime = WorkerRuntime(
         dependencies: dependencies,
         profileStore: store,
+        generatedFileStore: generatedFileStore,
         normalizer: normalizer,
         playbackController: PlaybackController(driver: playbackController)
     )

--- a/scripts/repo-maintenance/publish-runtime.sh
+++ b/scripts/repo-maintenance/publish-runtime.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env sh
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SELF_DIR/lib/common.sh"
+
+configuration="Debug"
+dry_run="false"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --configuration)
+      configuration="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage:
+  publish-runtime.sh [--configuration Debug|Release] [--dry-run]
+USAGE
+      exit 0
+      ;;
+    *)
+      die "Unknown publish-runtime argument: $1"
+      ;;
+  esac
+done
+
+case "$configuration" in
+  Debug|Release)
+    ;;
+  *)
+    die "Runtime publication only supports Debug or Release configurations."
+    ;;
+esac
+
+ensure_git_repo
+
+runtime_root="$REPO_ROOT/.local/xcode"
+derived_data_path="$runtime_root/derived-data/$configuration"
+source_packages_path="$runtime_root/source-packages"
+published_products_path="$runtime_root/$configuration"
+temporary_products_path="$runtime_root/.publish-$configuration.$$"
+lower_configuration=$(printf '%s' "$configuration" | tr '[:upper:]' '[:lower:]')
+metadata_path="$runtime_root/SpeakSwiftly.$lower_configuration.json"
+products_path="$derived_data_path/Build/Products/$configuration"
+binary_path="$products_path/SpeakSwiftly"
+metallib_path="$products_path/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"
+published_binary_path="$published_products_path/SpeakSwiftly"
+published_metallib_path="$published_products_path/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"
+source_commit=$(git -C "$REPO_ROOT" rev-parse HEAD)
+exact_tag=$(git -C "$REPO_ROOT" describe --tags --exact-match HEAD 2>/dev/null || true)
+source_dirty="false"
+status_output=$(git -C "$REPO_ROOT" status --porcelain)
+[ -z "$status_output" ] || source_dirty="true"
+built_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+if ! command -v xcodebuild >/dev/null 2>&1; then
+  die "xcodebuild is required to publish a local SpeakSwiftly runtime."
+fi
+
+log "Publishing SpeakSwiftly $configuration runtime into $published_products_path"
+
+if [ "$dry_run" = "true" ]; then
+  log "Would build with xcodebuild into $derived_data_path and publish products into $published_products_path."
+  exit 0
+fi
+
+mkdir -p "$runtime_root" "$source_packages_path"
+
+xcodebuild build \
+  -scheme SpeakSwiftly \
+  -destination "platform=macOS" \
+  -configuration "$configuration" \
+  -derivedDataPath "$derived_data_path" \
+  -clonedSourcePackagesDirPath "$source_packages_path"
+
+[ -x "$binary_path" ] || die "The Xcode build finished, but no executable was found at $binary_path."
+[ -f "$metallib_path" ] || die "The Xcode build finished, but the MLX Metal shader bundle was not found at $metallib_path."
+
+rm -rf "$temporary_products_path"
+mkdir -p "$temporary_products_path"
+cp -R "$products_path"/. "$temporary_products_path"/
+
+[ -x "$temporary_products_path/SpeakSwiftly" ] || die "The published runtime staging directory does not contain an executable SpeakSwiftly binary."
+[ -f "$temporary_products_path/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib" ] || die "The published runtime staging directory does not contain default.metallib."
+
+rm -rf "$published_products_path"
+mv "$temporary_products_path" "$published_products_path"
+
+cat > "$metadata_path" <<EOF
+{
+  "build_configuration": "$configuration",
+  "products_path": "$published_products_path",
+  "executable_path": "$published_binary_path",
+  "metallib_path": "$published_metallib_path",
+  "source_root": "$REPO_ROOT",
+  "source_commit": "$source_commit",
+  "source_dirty": $source_dirty,
+  "release_tag": "$(printf '%s' "$exact_tag")",
+  "built_at": "$built_at"
+}
+EOF
+
+log "Published SpeakSwiftly $configuration runtime:"
+log "  products: $published_products_path"
+log "  binary:   $published_binary_path"
+log "  metallib: $published_metallib_path"
+log "  metadata: $metadata_path"

--- a/scripts/repo-maintenance/release/15-publish-local-runtimes.sh
+++ b/scripts/repo-maintenance/release/15-publish-local-runtimes.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SELF_DIR/../lib/common.sh"
+
+if [ "${REPO_MAINTENANCE_DRY_RUN:-false}" = "true" ]; then
+  sh "$REPO_MAINTENANCE_ROOT/publish-runtime.sh" --configuration Debug --dry-run
+  sh "$REPO_MAINTENANCE_ROOT/publish-runtime.sh" --configuration Release --dry-run
+  exit 0
+fi
+
+sh "$REPO_MAINTENANCE_ROOT/publish-runtime.sh" --configuration Debug
+sh "$REPO_MAINTENANCE_ROOT/publish-runtime.sh" --configuration Release


### PR DESCRIPTION
## What changed
- add queued generated-file speech jobs with `SpeakSwiftly.Job.file` and the `queue_speech_file` worker op
- store generated WAV artifacts under the managed runtime store and expose `generated_file` and `generated_files` reads keyed by request id
- document the generated-file workflow and add runtime plus end-to-end coverage for the new artifact path

## Verification
- `swift build`
- `swift test`
- `SPEAKSWIFTLY_E2E=1 swift test --filter generatedFileLaneRunsEndToEndAndSupportsManagedArtifactReads`
