### PR TITLE
runtime: persist qwen reference conditioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Those concern handles should stay lightweight views over the shared runtime stat
 The current typed Swift startup and generation conventions are:
 
 - `SpeakSwiftly.liftoff(configuration:)` is the single startup entry point, with `configuration` optional so `liftoff()` remains the one obvious default path
-- `SpeakSwiftly.Configuration` carries startup inputs such as `speechBackend` and an optional `textNormalizer`
+- `SpeakSwiftly.Configuration` carries startup inputs such as `speechBackend`, `qwenConditioningStrategy`, and an optional `textNormalizer`
 - live playback and file rendering are separate generation calls, with `Generate.speech(...)` and `Generate.audio(...)`
 - generation-queue inspection lives under `Jobs`
 - playback-queue inspection lives under `Player.list(...)`
@@ -145,7 +145,9 @@ The wire shape is intentionally more literal and transport-oriented than the Swi
 
 ## Runtime Configuration
 
-`SpeakSwiftly.Configuration` is the typed runtime-startup surface. It now carries the preferred resident `speechBackend` plus an optional startup `textNormalizer`.
+`SpeakSwiftly.Configuration` is the typed runtime-startup surface. It now carries the preferred resident `speechBackend`, the Qwen conditioning strategy, and an optional startup `textNormalizer`.
+
+The current prepared-conditioning integration depends on a temporary frozen `mlx-audio-swift` fork pin while the matching `Qwen3TTS` API is being upstreamed. Keep that pin exact and intentional; do not loosen it back to a moving branch dependency.
 
 Default persisted configuration path:
 
@@ -161,6 +163,13 @@ Backend resolution precedence is:
 2. `SPEAKSWIFTLY_SPEECH_BACKEND`
 3. persisted `configuration.json`
 4. fallback `.qwen3`
+
+Qwen conditioning strategy values are:
+
+- `.legacyRaw`: keep passing raw `refAudio` and `refText` into the resident Qwen model on every request
+- `.preparedConditioning`: prepare Qwen reference conditioning once, persist it on the profile, cache it in memory after load, and reuse it on later requests
+
+The runtime currently reads `qwenConditioningStrategy` only from the explicit or persisted `SpeakSwiftly.Configuration` surface. There is no separate environment-variable override for that setting.
 
 ## Queueing and Resident Controls
 
@@ -418,6 +427,18 @@ One-shot qwen resident `generate_speech` verification:
 
 ```bash
 SPEAKSWIFTLY_E2E=1 swift test --filter SpeakSwiftlyE2ETests/QwenWorkflowSuite/voiceDesignSilentThenAudible
+```
+
+Prepared-conditioning qwen verification. This boots the worker in `prepared_conditioning` mode, confirms the first request persists a stored Qwen conditioning artifact on the profile, then restarts the worker and confirms the second request reloads that stored artifact instead of rebuilding it from raw reference inputs:
+
+```bash
+SPEAKSWIFTLY_E2E=1 swift test --filter SpeakSwiftlyE2ETests/QwenWorkflowSuite/preparedConditioningPersistsAndReloadsAcrossWorkerRestart
+```
+
+Opt-in MLX-backed persistence unit coverage. The plain SwiftPM runner does not ship the Metal bundle needed for direct MLX tensor persistence round-trips, so these tests stay out of the default `swift test` pass and should be run only when you explicitly want that narrow coverage:
+
+```bash
+SPEAKSWIFTLY_MLX_PERSISTENCE_TESTS=1 swift test --filter preparedQwenConditioning
 ```
 
 Force audible playback in the e2e suite:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "eb421b9dadea50dcdc04016cc52e333e5c1b96165b4bfaf21c20d0e34f9e0443",
+  "originHash" : "8a95ba9fdbd885a160a40d84b5a943c9e2f7cd4f11e1d51d29c82797c67666c8",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -13,9 +13,10 @@
     {
       "identity" : "mlx-audio-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
+      "location" : "https://github.com/gaelic-ghost/mlx-audio-swift.git",
       "state" : {
-        "revision" : "9264f40bc21c1dd461feb1ce1206e5ff38e8b9f5"
+        "branch" : "add/qwenReferenceConditioning",
+        "revision" : "478707e1d726b011a44e9d61f15abefbf4aec137"
       }
     },
     {
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
-        "revision" : "6ba4827fb82c97d012eec9ab4b2de21f85c3b33d",
-        "version" : "0.30.6"
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
       }
     },
     {
@@ -32,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "7e19e09027923d89ac47dd087d9627f610e5a91a",
-        "version" : "2.30.6"
+        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
+        "version" : "2.31.3"
       }
     },
     {
@@ -68,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
-        "version" : "4.3.0"
+        "revision" : "bb4ba815dab96d4edc1e0b86d7b9acf9ff973a84",
+        "version" : "4.3.1"
       }
     },
     {
@@ -122,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
+        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
+        "version" : "1.2.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,8 @@ let package = Package(
             .upToNextMajor(from: "0.15.0")
         ),
         .package(
-            url: "https://github.com/Blaizzy/mlx-audio-swift.git",
-            revision: "9264f40bc21c1dd461feb1ce1206e5ff38e8b9f5"
+            url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",
+            revision: "478707e1d726b011a44e9d61f15abefbf4aec137"
         )
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -112,11 +112,18 @@ Runtime preferences have a matching typed surface:
 ```swift
 import SpeakSwiftlyCore
 
-let configuration = SpeakSwiftly.Configuration(speechBackend: .qwen3CustomVoice)
+let configuration = SpeakSwiftly.Configuration(
+    speechBackend: .qwen3CustomVoice,
+    qwenConditioningStrategy: .preparedConditioning
+)
 try configuration.save(to: URL(fileURLWithPath: "/tmp/speakswiftly-configuration.json"))
 
 let runtime = await SpeakSwiftly.liftoff(configuration: configuration)
 ```
+
+For Qwen backends, `qwenConditioningStrategy` lets hosts keep the existing raw reference-audio path or switch to the prepared-conditioning path that persists reusable Qwen reference conditioning on the voice profile and reloads it on later runs.
+
+Right now that prepared-conditioning path depends on a temporary frozen pin to Gale's `mlx-audio-swift` fork while the matching `Qwen3TTS` conditioning API is being upstreamed. The package is pinned to one exact fork revision rather than a moving branch tip.
 
 If a host needs the packaged MLX bundle or the exact metallib path, use the support-resource surface:
 

--- a/Sources/SpeakSwiftly/API/Configuration.swift
+++ b/Sources/SpeakSwiftly/API/Configuration.swift
@@ -3,6 +3,11 @@ import Foundation
 // MARK: - Runtime Configuration
 
 public extension SpeakSwiftly {
+    enum QwenConditioningStrategy: String, Codable, Sendable, Equatable, CaseIterable {
+        case legacyRaw = "legacy_raw"
+        case preparedConditioning = "prepared_conditioning"
+    }
+
     // MARK: Configuration
 
     struct Configuration: Codable, Sendable {
@@ -26,29 +31,38 @@ public extension SpeakSwiftly {
         }
 
         public let speechBackend: SpeakSwiftly.SpeechBackend
+        public let qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy
         public let textNormalizer: SpeakSwiftly.Normalizer?
 
         enum CodingKeys: String, CodingKey {
             case speechBackend
+            case qwenConditioningStrategy
         }
 
         public init(
             speechBackend: SpeakSwiftly.SpeechBackend = .qwen3,
+            qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .legacyRaw,
             textNormalizer: SpeakSwiftly.Normalizer? = nil
         ) {
             self.speechBackend = speechBackend
+            self.qwenConditioningStrategy = qwenConditioningStrategy
             self.textNormalizer = textNormalizer
         }
 
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             speechBackend = try container.decode(SpeakSwiftly.SpeechBackend.self, forKey: .speechBackend)
+            qwenConditioningStrategy = try container.decodeIfPresent(
+                SpeakSwiftly.QwenConditioningStrategy.self,
+                forKey: .qwenConditioningStrategy
+            ) ?? .legacyRaw
             textNormalizer = nil
         }
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(speechBackend, forKey: .speechBackend)
+            try container.encode(qwenConditioningStrategy, forKey: .qwenConditioningStrategy)
         }
 
         public static func load(from persistenceURL: URL) throws -> Self {

--- a/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
+++ b/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
@@ -1,17 +1,23 @@
 import Foundation
 @preconcurrency import MLX
 @preconcurrency import MLXLMCommon
+import MLXAudioTTS
 import TextForSpeech
 
 // MARK: - Generated File Logic
 
 extension SpeakSwiftly.Runtime {
     enum ResidentSpeechInputs {
-        case qwen(
+        case qwenRaw(
             model: AnySpeechModel,
             profile: StoredProfile,
             materialization: StoredProfileMaterialization,
             refAudio: MLXArray?
+        )
+        case qwenPrepared(
+            model: AnySpeechModel,
+            profile: StoredProfile,
+            conditioning: Qwen3TTSModel.Qwen3TTSReferenceConditioning
         )
         case marvis(
             model: AnySpeechModel,
@@ -148,28 +154,45 @@ extension SpeakSwiftly.Runtime {
         switch speechBackend {
         case .qwen3, .qwen3CustomVoice:
             let residentModel = try residentQwenModelOrThrow()
-            let materialization = try profile.qwenMaterialization()
-            let refAudioLoadStartedAt = dependencies.now()
-            let refAudio = try dependencies.loadAudioSamples(materialization.referenceAudioURL, residentModel.sampleRate)
-            await logRequestEvent(
-                "reference_audio_loaded",
-                requestID: id,
-                op: op,
-                profileName: profileName,
-                details: [
-                    "speech_backend": .string(speechBackend.rawValue),
-                    "path": .string(materialization.referenceAudioURL.path),
-                    "duration_ms": .int(elapsedMS(since: refAudioLoadStartedAt)),
-                    "sample_rate": .int(residentModel.sampleRate),
-                ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
-            )
-            try Task.checkCancellation()
-            return .qwen(
-                model: residentModel,
-                profile: profile,
-                materialization: materialization,
-                refAudio: refAudio
-            )
+            switch qwenConditioningStrategy {
+            case .legacyRaw:
+                let materialization = try profile.qwenMaterialization(for: speechBackend)
+                let refAudioLoadStartedAt = dependencies.now()
+                let refAudio = try dependencies.loadAudioSamples(materialization.referenceAudioURL, residentModel.sampleRate)
+                await logRequestEvent(
+                    "reference_audio_loaded",
+                    requestID: id,
+                    op: op,
+                    profileName: profileName,
+                    details: [
+                        "speech_backend": .string(speechBackend.rawValue),
+                        "conditioning_strategy": .string(qwenConditioningStrategy.rawValue),
+                        "path": .string(materialization.referenceAudioURL.path),
+                        "duration_ms": .int(elapsedMS(since: refAudioLoadStartedAt)),
+                        "sample_rate": .int(residentModel.sampleRate),
+                    ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
+                )
+                try Task.checkCancellation()
+                return .qwenRaw(
+                    model: residentModel,
+                    profile: profile,
+                    materialization: materialization,
+                    refAudio: refAudio
+                )
+
+            case .preparedConditioning:
+                let conditioning = try await loadPreparedQwenConditioning(
+                    requestID: id,
+                    op: op,
+                    profile: profile,
+                    model: residentModel
+                )
+                return .qwenPrepared(
+                    model: residentModel,
+                    profile: profile,
+                    conditioning: conditioning
+                )
+            }
 
         case .marvis:
             let (residentModel, voice) = try residentMarvisModelOrThrow(for: profile.manifest.vibe)
@@ -196,13 +219,22 @@ extension SpeakSwiftly.Runtime {
         streamingInterval: Double
     ) -> AsyncThrowingStream<[Float], Error> {
         switch inputs {
-        case .qwen(let model, _, let materialization, let refAudio):
+        case .qwenRaw(let model, _, let materialization, let refAudio):
             qwenGenerationStream(
                 requestID: requestID,
                 model: model,
                 text: text,
                 materialization: materialization,
                 refAudio: refAudio,
+                generationParameters: generationParameters,
+                streamingInterval: streamingInterval
+            )
+        case .qwenPrepared(let model, _, let conditioning):
+            qwenGenerationStream(
+                requestID: requestID,
+                model: model,
+                text: text,
+                conditioning: conditioning,
                 generationParameters: generationParameters,
                 streamingInterval: streamingInterval
             )
@@ -216,13 +248,150 @@ extension SpeakSwiftly.Runtime {
             )
         }
     }
+
+    func loadPreparedQwenConditioning(
+        requestID id: String,
+        op: String,
+        profile: StoredProfile,
+        model: AnySpeechModel
+    ) async throws -> Qwen3TTSModel.Qwen3TTSReferenceConditioning {
+        if let storedArtifact = profile.qwenConditioningArtifact(for: speechBackend) {
+            let cacheKey = qwenConditioningCacheKey(
+                for: profile.manifest.profileName,
+                artifact: storedArtifact
+            )
+            if let cachedConditioning = qwenConditioningCache[cacheKey] {
+                await logRequestEvent(
+                    "qwen_reference_conditioning_cache_hit",
+                    requestID: id,
+                    op: op,
+                    profileName: profile.manifest.profileName,
+                    details: [
+                        "speech_backend": .string(speechBackend.rawValue),
+                        "conditioning_strategy": .string(qwenConditioningStrategy.rawValue),
+                        "artifact_path": .string(storedArtifact.artifactURL.path),
+                    ]
+                )
+                return cachedConditioning
+            }
+
+            let artifactLoadStartedAt = dependencies.now()
+            let loadedConditioning = try profileStore.loadQwenConditioningArtifact(storedArtifact)
+            qwenConditioningCache[cacheKey] = loadedConditioning
+            await logRequestEvent(
+                "qwen_reference_conditioning_loaded",
+                requestID: id,
+                op: op,
+                profileName: profile.manifest.profileName,
+                details: [
+                    "speech_backend": .string(speechBackend.rawValue),
+                    "conditioning_strategy": .string(qwenConditioningStrategy.rawValue),
+                    "artifact_path": .string(storedArtifact.artifactURL.path),
+                    "duration_ms": .int(elapsedMS(since: artifactLoadStartedAt)),
+                ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
+            )
+            return loadedConditioning
+        }
+
+        let materialization = try profile.qwenMaterialization(for: speechBackend)
+        let refAudioLoadStartedAt = dependencies.now()
+        let refAudio = try dependencies.loadAudioSamples(materialization.referenceAudioURL, model.sampleRate)
+        guard let refAudio else {
+            throw WorkerError(
+                code: .filesystemError,
+                message: "Profile '\(profile.manifest.profileName)' uses the prepared Qwen conditioning path, but SpeakSwiftly could not load any reference audio samples from '\(materialization.referenceAudioURL.path)'. Recreate or reroll the profile to restore its canonical reference audio."
+            )
+        }
+        await logRequestEvent(
+            "reference_audio_loaded",
+            requestID: id,
+            op: op,
+            profileName: profile.manifest.profileName,
+            details: [
+                "speech_backend": .string(speechBackend.rawValue),
+                "conditioning_strategy": .string(qwenConditioningStrategy.rawValue),
+                "path": .string(materialization.referenceAudioURL.path),
+                "duration_ms": .int(elapsedMS(since: refAudioLoadStartedAt)),
+                "sample_rate": .int(model.sampleRate),
+            ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
+        )
+        try Task.checkCancellation()
+
+        let preparationStartedAt = dependencies.now()
+        let preparedConditioning = try model.prepareQwenReferenceConditioning(
+            refAudio: refAudio,
+            refText: materialization.manifest.referenceText,
+            language: "English"
+        )
+        await logRequestEvent(
+            "qwen_reference_conditioning_prepared",
+            requestID: id,
+            op: op,
+            profileName: profile.manifest.profileName,
+            details: [
+                "speech_backend": .string(speechBackend.rawValue),
+                "conditioning_strategy": .string(qwenConditioningStrategy.rawValue),
+                "duration_ms": .int(elapsedMS(since: preparationStartedAt)),
+            ].merging(memoryDetails(), uniquingKeysWith: { _, new in new })
+        )
+        try Task.checkCancellation()
+
+        let persistenceStartedAt = dependencies.now()
+        let updatedProfile = try profileStore.storeQwenConditioningArtifact(
+            named: profile.manifest.profileName,
+            backend: speechBackend,
+            modelRepo: ModelFactory.residentModelRepo(for: speechBackend),
+            conditioning: preparedConditioning
+        )
+        guard let storedArtifact = updatedProfile.qwenConditioningArtifact(for: speechBackend) else {
+            throw WorkerError(
+                code: .filesystemError,
+                message: "Profile '\(profile.manifest.profileName)' was updated after Qwen conditioning preparation, but SpeakSwiftly could not find the stored conditioning artifact for the '\(speechBackend.rawValue)' backend. This indicates a profile-store bug."
+            )
+        }
+
+        let cacheKey = qwenConditioningCacheKey(
+            for: updatedProfile.manifest.profileName,
+            artifact: storedArtifact
+        )
+        qwenConditioningCache[cacheKey] = preparedConditioning
+        await logRequestEvent(
+            "qwen_reference_conditioning_persisted",
+            requestID: id,
+            op: op,
+            profileName: updatedProfile.manifest.profileName,
+            details: [
+                "speech_backend": .string(speechBackend.rawValue),
+                "conditioning_strategy": .string(qwenConditioningStrategy.rawValue),
+                "artifact_path": .string(storedArtifact.artifactURL.path),
+                "duration_ms": .int(elapsedMS(since: persistenceStartedAt)),
+            ]
+        )
+
+        return preparedConditioning
+    }
 }
 
 extension SpeakSwiftly.Runtime.ResidentSpeechInputs {
     var model: AnySpeechModel {
         switch self {
-        case .qwen(let model, _, _, _), .marvis(let model, _, _):
+        case .qwenRaw(let model, _, _, _), .qwenPrepared(let model, _, _), .marvis(let model, _, _):
             model
         }
+    }
+}
+
+private extension SpeakSwiftly.Runtime {
+    func qwenConditioningCacheKey(
+        for profileName: String,
+        artifact: StoredQwenConditioningArtifact
+    ) -> QwenConditioningCacheKey {
+        QwenConditioningCacheKey(
+            profileName: profileName,
+            backend: artifact.manifest.backend,
+            modelRepo: artifact.manifest.modelRepo,
+            artifactVersion: artifact.manifest.artifactVersion,
+            artifactFile: artifact.manifest.artifactFile
+        )
     }
 }

--- a/Sources/SpeakSwiftly/Generation/ModelClients.swift
+++ b/Sources/SpeakSwiftly/Generation/ModelClients.swift
@@ -58,6 +58,19 @@ final class AnySpeechModel: @unchecked Sendable {
         _ streamingInterval: Double
     ) -> AsyncThrowingStream<ModelGenerationEvent, Error>
 
+    typealias PrepareQwenReferenceConditioningClosure = @Sendable (
+        _ refAudio: MLXArray,
+        _ refText: String,
+        _ language: String?
+    ) throws -> Qwen3TTSModel.Qwen3TTSReferenceConditioning
+
+    typealias GenerateConditionedEventStreamClosure = @Sendable (
+        _ text: String,
+        _ conditioning: Qwen3TTSModel.Qwen3TTSReferenceConditioning,
+        _ generationParameters: GenerateParameters,
+        _ streamingInterval: Double
+    ) -> AsyncThrowingStream<ModelGenerationEvent, Error>
+
     private let sampleRateValue: Int
     private let generateImpl: @Sendable (
         _ text: String,
@@ -69,6 +82,8 @@ final class AnySpeechModel: @unchecked Sendable {
     ) async throws -> [Float]
     private let generateSamplesStreamImpl: GenerateSamplesStreamClosure
     private let generateEventStreamImpl: GenerateEventStreamClosure
+    private let prepareQwenReferenceConditioningImpl: PrepareQwenReferenceConditioningClosure?
+    private let generateConditionedEventStreamImpl: GenerateConditionedEventStreamClosure?
 
     var sampleRate: Int {
         sampleRateValue
@@ -85,7 +100,9 @@ final class AnySpeechModel: @unchecked Sendable {
             _ generationParameters: GenerateParameters
         ) async throws -> [Float],
         generateSamplesStream: @escaping GenerateSamplesStreamClosure,
-        generateEventStream: GenerateEventStreamClosure? = nil
+        generateEventStream: GenerateEventStreamClosure? = nil,
+        prepareQwenReferenceConditioning: PrepareQwenReferenceConditioningClosure? = nil,
+        generateConditionedEventStream: GenerateConditionedEventStreamClosure? = nil
     ) {
         sampleRateValue = sampleRate
         generateImpl = generate
@@ -116,10 +133,69 @@ final class AnySpeechModel: @unchecked Sendable {
                 continuation.onTermination = { _ in task.cancel() }
             }
         }
+        prepareQwenReferenceConditioningImpl = prepareQwenReferenceConditioning
+        generateConditionedEventStreamImpl = generateConditionedEventStream
     }
 
     convenience init(model: any SpeechGenerationModel) {
         let box = UnsafeSpeechGenerationModelBox(model: model)
+        let qwenModel = box.model as? Qwen3TTSModel
+        let prepareQwenReferenceConditioning: PrepareQwenReferenceConditioningClosure? = if let qwenModel {
+            { refAudio, refText, language in
+                try qwenModel.prepareReferenceConditioning(
+                    refAudio: refAudio,
+                    refText: refText,
+                    language: language
+                )
+            }
+        } else {
+            nil
+        }
+        let generateConditionedEventStream: GenerateConditionedEventStreamClosure? = if let qwenModel {
+            { text, conditioning, generationParameters, streamingInterval in
+                let stream = qwenModel.generateStream(
+                    text: text,
+                    conditioning: conditioning,
+                    generationParameters: generationParameters,
+                    streamingInterval: streamingInterval
+                )
+                return AsyncThrowingStream { continuation in
+                    let task = Task {
+                        do {
+                            for try await event in stream {
+                                switch event {
+                                case .token(let token):
+                                    continuation.yield(.token(token))
+                                case .info(let info):
+                                    continuation.yield(
+                                        .info(
+                                            .init(
+                                                promptTokenCount: info.promptTokenCount,
+                                                generationTokenCount: info.generationTokenCount,
+                                                prefillTime: info.prefillTime,
+                                                generateTime: info.generateTime,
+                                                tokensPerSecond: info.tokensPerSecond,
+                                                peakMemoryUsage: info.peakMemoryUsage
+                                            )
+                                        )
+                                    )
+                                case .audio(let samples):
+                                    continuation.yield(.audio(samples.asArray(Float.self)))
+                                }
+                            }
+                            continuation.finish()
+                        } catch is CancellationError {
+                            continuation.finish(throwing: CancellationError())
+                        } catch {
+                            continuation.finish(throwing: error)
+                        }
+                    }
+                    continuation.onTermination = { _ in task.cancel() }
+                }
+            }
+        } else {
+            nil
+        }
 
         self.init(
             sampleRate: box.model.sampleRate,
@@ -187,7 +263,9 @@ final class AnySpeechModel: @unchecked Sendable {
                     }
                     continuation.onTermination = { _ in task.cancel() }
                 }
-            }
+            },
+            prepareQwenReferenceConditioning: prepareQwenReferenceConditioning,
+            generateConditionedEventStream: generateConditionedEventStream
         )
     }
 
@@ -224,6 +302,46 @@ final class AnySpeechModel: @unchecked Sendable {
         streamingInterval: Double
     ) -> AsyncThrowingStream<ModelGenerationEvent, Error> {
         generateEventStreamImpl(text, voice, refAudio, refText, language, generationParameters, streamingInterval)
+    }
+
+    func prepareQwenReferenceConditioning(
+        refAudio: MLXArray,
+        refText: String,
+        language: String?
+    ) throws -> Qwen3TTSModel.Qwen3TTSReferenceConditioning {
+        guard let prepareQwenReferenceConditioningImpl else {
+            throw WorkerError(
+                code: .internalError,
+                message: "SpeakSwiftly attempted to prepare reusable Qwen reference conditioning with a resident model that does not support the Qwen conditioning API. This indicates a model-routing bug."
+            )
+        }
+
+        return try prepareQwenReferenceConditioningImpl(refAudio, refText, language)
+    }
+
+    func generateConditionedEventStream(
+        text: String,
+        conditioning: Qwen3TTSModel.Qwen3TTSReferenceConditioning,
+        generationParameters: GenerateParameters,
+        streamingInterval: Double
+    ) -> AsyncThrowingStream<ModelGenerationEvent, Error> {
+        guard let generateConditionedEventStreamImpl else {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(
+                    throwing: WorkerError(
+                        code: .internalError,
+                        message: "SpeakSwiftly attempted to start conditioned Qwen generation with a resident model that does not support the Qwen conditioning API. This indicates a model-routing bug."
+                    )
+                )
+            }
+        }
+
+        return generateConditionedEventStreamImpl(
+            text,
+            conditioning,
+            generationParameters,
+            streamingInterval
+        )
     }
 }
 

--- a/Sources/SpeakSwiftly/Generation/QwenSpeechGeneration.swift
+++ b/Sources/SpeakSwiftly/Generation/QwenSpeechGeneration.swift
@@ -1,5 +1,6 @@
 import Foundation
 @preconcurrency import MLX
+import MLXAudioTTS
 @preconcurrency import MLXLMCommon
 
 // MARK: - Qwen Speech Generation
@@ -31,6 +32,46 @@ extension SpeakSwiftly.Runtime {
             refAudio: refAudio,
             refText: materialization.manifest.referenceText,
             language: "English",
+            generationParameters: generationParameters,
+            streamingInterval: streamingInterval
+        )
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    for try await event in eventStream {
+                        switch event {
+                        case .token(let token):
+                            recordGenerationEvent(.token(token), for: requestID)
+                        case .info(let info):
+                            recordGenerationEvent(.info(generationEventInfo(from: info)), for: requestID)
+                        case .audio(let samples):
+                            recordGenerationEvent(.audioChunk(sampleCount: samples.count), for: requestID)
+                            continuation.yield(samples)
+                        }
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    func qwenGenerationStream(
+        requestID: String,
+        model: AnySpeechModel,
+        text: String,
+        conditioning: Qwen3TTSModel.Qwen3TTSReferenceConditioning,
+        generationParameters: GenerateParameters,
+        streamingInterval: Double
+    ) -> AsyncThrowingStream<[Float], Error> {
+        let eventStream = model.generateConditionedEventStream(
+            text: text,
+            conditioning: conditioning,
             generationParameters: generationParameters,
             streamingInterval: streamingInterval
         )

--- a/Sources/SpeakSwiftly/Generation/SpeechBackend.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechBackend.swift
@@ -44,4 +44,13 @@ extension SpeakSwiftly.SpeechBackend {
             ModelFactory.marvisResidentModelRepo
         }
     }
+
+    var isQwenFamily: Bool {
+        switch self {
+        case .qwen3, .qwen3CustomVoice:
+            true
+        case .marvis:
+            false
+        }
+    }
 }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MLXAudioTTS
 import TextForSpeech
 
 // MARK: - Worker Runtime
@@ -37,6 +38,14 @@ public extension SpeakSwiftly {
         let token: UUID
         let request: WorkerRequest
         let task: Task<Void, Never>
+    }
+
+    struct QwenConditioningCacheKey: Hashable, Sendable {
+        let profileName: String
+        let backend: SpeakSwiftly.SpeechBackend
+        let modelRepo: String
+        let artifactVersion: Int
+        let artifactFile: String
     }
 
     struct RequestBroker {
@@ -279,6 +288,7 @@ public extension SpeakSwiftly {
 
     let dependencies: WorkerDependencies
     var speechBackend: SpeakSwiftly.SpeechBackend
+    var qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy
     let encoder = JSONEncoder()
     let profileStore: ProfileStore
     let generatedFileStore: GeneratedFileStore
@@ -299,12 +309,14 @@ public extension SpeakSwiftly {
     var terminalRequestBrokerOrder = [String]()
     var activeGenerations = [UUID: ActiveRequest]()
     var lastLoggedMarvisSchedulerState: String?
+    var qwenConditioningCache = [QwenConditioningCacheKey: Qwen3TTSModel.Qwen3TTSReferenceConditioning]()
 
     // MARK: Initialization
 
     init(
         dependencies: WorkerDependencies,
         speechBackend: SpeakSwiftly.SpeechBackend,
+        qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .legacyRaw,
         profileStore: ProfileStore,
         generatedFileStore: GeneratedFileStore,
         generationJobStore: GenerationJobStore,
@@ -313,6 +325,7 @@ public extension SpeakSwiftly {
     ) {
         self.dependencies = dependencies
         self.speechBackend = speechBackend
+        self.qwenConditioningStrategy = qwenConditioningStrategy
         self.profileStore = profileStore
         self.generatedFileStore = generatedFileStore
         self.generationJobStore = generationJobStore

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeLifecycle.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeLifecycle.swift
@@ -53,10 +53,18 @@ extension SpeakSwiftly.Runtime {
     ) async -> SpeakSwiftly.Runtime {
         let dependencies = WorkerDependencies.live()
         let environment = ProcessInfo.processInfo.environment
-        let configuredSpeechBackend = resolvedSpeechBackend(
+        let persistedConfiguration = resolvedPersistedConfiguration(
             dependencies: dependencies,
+            environment: environment
+        )
+        let configuredSpeechBackend = resolvedSpeechBackend(
             environment: environment,
             configuration: configuration
+                ?? persistedConfiguration
+        )
+        let configuredQwenConditioningStrategy = resolvedQwenConditioningStrategy(
+            configuration: configuration
+                ?? persistedConfiguration
         )
         let profileStore = ProfileStore(
             rootURL: ProfileStore.defaultRootURL(
@@ -82,6 +90,7 @@ extension SpeakSwiftly.Runtime {
         let runtime = SpeakSwiftly.Runtime(
             dependencies: dependencies,
             speechBackend: configuredSpeechBackend,
+            qwenConditioningStrategy: configuredQwenConditioningStrategy,
             profileStore: profileStore,
             generatedFileStore: generatedFileStore,
             generationJobStore: generationJobStore,
@@ -93,7 +102,6 @@ extension SpeakSwiftly.Runtime {
     }
 
     static func resolvedSpeechBackend(
-        dependencies: WorkerDependencies,
         environment: [String: String],
         configuration: SpeakSwiftly.Configuration?
     ) -> SpeakSwiftly.SpeechBackend {
@@ -105,23 +113,44 @@ extension SpeakSwiftly.Runtime {
             return environmentBackend
         }
 
+        return .qwen3
+    }
+
+    static func resolvedSpeechBackend(
+        dependencies _: WorkerDependencies,
+        environment: [String: String],
+        configuration: SpeakSwiftly.Configuration?
+    ) -> SpeakSwiftly.SpeechBackend {
+        resolvedSpeechBackend(
+            environment: environment,
+            configuration: configuration
+        )
+    }
+
+    static func resolvedQwenConditioningStrategy(
+        configuration: SpeakSwiftly.Configuration?
+    ) -> SpeakSwiftly.QwenConditioningStrategy {
+        configuration?.qwenConditioningStrategy ?? .legacyRaw
+    }
+
+    private static func resolvedPersistedConfiguration(
+        dependencies: WorkerDependencies,
+        environment: [String: String]
+    ) -> SpeakSwiftly.Configuration? {
         do {
-            if let persistedConfiguration = try SpeakSwiftly.Configuration.loadDefault(
+            return try SpeakSwiftly.Configuration.loadDefault(
                 fileManager: dependencies.fileManager,
                 profileRootOverride: environment[Environment.profileRootOverride]
-            ) {
-                return persistedConfiguration.speechBackend
-            }
+            )
         } catch {
             let configurationPath = SpeakSwiftly.Configuration.defaultPersistenceURL(
                 fileManager: dependencies.fileManager,
                 profileRootOverride: environment[Environment.profileRootOverride]
             ).path
-            let message = "SpeakSwiftly could not load persisted runtime configuration from '\(configurationPath)'. Falling back to the default speech backend. \(error.localizedDescription)\n"
+            let message = "SpeakSwiftly could not load persisted runtime configuration from '\(configurationPath)'. Falling back to the default runtime configuration. \(error.localizedDescription)\n"
             dependencies.writeStderr(message)
+            return nil
         }
-
-        return .qwen3
     }
 
     func installPlaybackHooks() async {

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing.swift
@@ -129,6 +129,7 @@ extension SpeakSwiftly.Runtime {
                     outputPath: outputPath,
                     cwd: cwd
                 )
+                invalidateQwenConditioningCache()
                 disposition = .requestCompleted(.success(
                     WorkerSuccessPayload(
                         id: id,
@@ -146,6 +147,7 @@ extension SpeakSwiftly.Runtime {
                     transcript: transcript,
                     cwd: cwd
                 )
+                invalidateQwenConditioningCache()
                 disposition = .requestCompleted(.success(
                     WorkerSuccessPayload(
                         id: id,
@@ -173,6 +175,7 @@ extension SpeakSwiftly.Runtime {
                 await emitProgress(id: id, stage: .writingProfileAssets)
                 let renameStartedAt = dependencies.now()
                 let storedProfile = try profileStore.renameProfile(named: profileName, to: newProfileName)
+                invalidateQwenConditioningCache()
                 await logRequestEvent(
                     "profile_renamed",
                     requestID: id,
@@ -195,6 +198,7 @@ extension SpeakSwiftly.Runtime {
 
             case .rerollProfile(let id, let profileName):
                 let storedProfile = try await handleRerollProfile(id: id, profileName: profileName)
+                invalidateQwenConditioningCache()
                 disposition = .requestCompleted(.success(
                     WorkerSuccessPayload(
                         id: id,
@@ -207,6 +211,7 @@ extension SpeakSwiftly.Runtime {
                 await emitProgress(id: id, stage: .removingProfile)
                 let removeStartedAt = dependencies.now()
                 try profileStore.removeProfile(named: profileName)
+                invalidateQwenConditioningCache()
                 await logRequestEvent(
                     "profile_removed",
                     requestID: id,
@@ -870,6 +875,7 @@ extension SpeakSwiftly.Runtime {
     ) async throws -> WorkerStatusEvent? {
         preloadTask?.cancel()
         preloadTask = nil
+        invalidateQwenConditioningCache()
         speechBackend = requestedSpeechBackend
         residentState = .warming
         startResidentPreload()
@@ -888,6 +894,7 @@ extension SpeakSwiftly.Runtime {
     func performOrderedModelReload() async throws -> WorkerStatusEvent? {
         preloadTask?.cancel()
         preloadTask = nil
+        invalidateQwenConditioningCache()
         residentState = .warming
         startResidentPreload()
         await preloadTask?.value
@@ -904,9 +911,14 @@ extension SpeakSwiftly.Runtime {
         preloadTask?.cancel()
         preloadTask = nil
         residentPreloadToken = nil
+        invalidateQwenConditioningCache()
         residentState = .unloaded
         await emitStatus(.residentModelsUnloaded)
         return currentStatusSnapshot()
+    }
+
+    func invalidateQwenConditioningCache() {
+        qwenConditioningCache.removeAll(keepingCapacity: true)
     }
 
     func primaryResidentSampleRate(for models: ResidentSpeechModels) -> Int {

--- a/Sources/SpeakSwiftly/Storage/ProfileStore.swift
+++ b/Sources/SpeakSwiftly/Storage/ProfileStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MLXAudioTTS
 
 // MARK: - Voice & Clone Profile Models
 
@@ -27,6 +28,65 @@ struct ProfileManifest: Codable, Sendable, Equatable {
     let sourceText: String
     let sampleRate: Int
     let backendMaterializations: [ProfileMaterializationManifest]
+    let qwenConditioningArtifacts: [QwenConditioningArtifactManifest]
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case profileName
+        case vibe
+        case createdAt
+        case sourceKind
+        case modelRepo
+        case voiceDescription
+        case sourceText
+        case sampleRate
+        case backendMaterializations
+        case qwenConditioningArtifacts
+    }
+
+    init(
+        version: Int,
+        profileName: String,
+        vibe: SpeakSwiftly.Vibe,
+        createdAt: Date,
+        sourceKind: ProfileSourceKind,
+        modelRepo: String,
+        voiceDescription: String,
+        sourceText: String,
+        sampleRate: Int,
+        backendMaterializations: [ProfileMaterializationManifest],
+        qwenConditioningArtifacts: [QwenConditioningArtifactManifest]
+    ) {
+        self.version = version
+        self.profileName = profileName
+        self.vibe = vibe
+        self.createdAt = createdAt
+        self.sourceKind = sourceKind
+        self.modelRepo = modelRepo
+        self.voiceDescription = voiceDescription
+        self.sourceText = sourceText
+        self.sampleRate = sampleRate
+        self.backendMaterializations = backendMaterializations
+        self.qwenConditioningArtifacts = qwenConditioningArtifacts
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decode(Int.self, forKey: .version)
+        profileName = try container.decode(String.self, forKey: .profileName)
+        vibe = try container.decode(SpeakSwiftly.Vibe.self, forKey: .vibe)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        sourceKind = try container.decode(ProfileSourceKind.self, forKey: .sourceKind)
+        modelRepo = try container.decode(String.self, forKey: .modelRepo)
+        voiceDescription = try container.decode(String.self, forKey: .voiceDescription)
+        sourceText = try container.decode(String.self, forKey: .sourceText)
+        sampleRate = try container.decode(Int.self, forKey: .sampleRate)
+        backendMaterializations = try container.decode([ProfileMaterializationManifest].self, forKey: .backendMaterializations)
+        qwenConditioningArtifacts = try container.decodeIfPresent(
+            [QwenConditioningArtifactManifest].self,
+            forKey: .qwenConditioningArtifacts
+        ) ?? []
+    }
 }
 
 private struct LegacyProfileManifest: Codable, Sendable, Equatable {
@@ -102,20 +162,35 @@ struct StoredProfile: Sendable, Equatable {
     let manifest: ProfileManifest
     let directoryURL: URL
     let materializations: [StoredProfileMaterialization]
+    let conditioningArtifacts: [StoredQwenConditioningArtifact]
 
     var referenceAudioURL: URL {
-        try! qwenMaterialization().referenceAudioURL
+        try! qwenMaterialization(for: .qwen3).referenceAudioURL
     }
 
-    func qwenMaterialization() throws -> StoredProfileMaterialization {
-        if let materialization = materializations.first(where: { $0.manifest.backend == .qwen3 }) {
+    func qwenMaterialization(for backend: SpeakSwiftly.SpeechBackend) throws -> StoredProfileMaterialization {
+        if let materialization = materializations.first(where: { $0.manifest.backend == backend }) {
+            return materialization
+        }
+
+        if let materialization = materializations.first(where: { $0.manifest.backend.isQwenFamily }) {
             return materialization
         }
 
         throw WorkerError(
             code: .profileNotFound,
-            message: "Profile '\(manifest.profileName)' does not contain a stored 'qwen3' materialization. Recreate the profile to prepare Qwen assets for that profile."
+            message: "Profile '\(manifest.profileName)' does not contain a stored Qwen reference materialization for the '\(backend.rawValue)' backend. Recreate or reroll the profile to restore the canonical Qwen reference assets."
         )
+    }
+
+    func qwenMaterialization() throws -> StoredProfileMaterialization {
+        try qwenMaterialization(for: .qwen3)
+    }
+
+    func qwenConditioningArtifact(
+        for backend: SpeakSwiftly.SpeechBackend
+    ) -> StoredQwenConditioningArtifact? {
+        conditioningArtifacts.first(where: { $0.manifest.backend == backend })
     }
 }
 
@@ -128,7 +203,7 @@ struct ProfileStore: @unchecked Sendable {
     static let configurationFileName = "configuration.json"
     static let manifestFileName = "profile.json"
     static let audioFileName = "reference.wav"
-    static let manifestVersion = 3
+    static let manifestVersion = 4
 
     let rootURL: URL
     let fileManager: FileManager
@@ -246,7 +321,8 @@ struct ProfileStore: @unchecked Sendable {
                     referenceText: $0.referenceText,
                     sampleRate: $0.sampleRate
                 )
-            }
+            },
+            qwenConditioningArtifacts: []
         )
 
         do {
@@ -283,10 +359,17 @@ struct ProfileStore: @unchecked Sendable {
                     referenceAudioURL: referenceAudioURL(for: directoryURL, fileName: $0.referenceAudioFile)
                 )
             }
+            let conditioningArtifacts = manifest.qwenConditioningArtifacts.map {
+                StoredQwenConditioningArtifact(
+                    manifest: $0,
+                    artifactURL: qwenConditioningArtifactURL(for: directoryURL, fileName: $0.artifactFile)
+                )
+            }
             return StoredProfile(
                 manifest: manifest,
                 directoryURL: directoryURL,
-                materializations: materializations
+                materializations: materializations,
+                conditioningArtifacts: conditioningArtifacts
             )
         } catch let workerError as WorkerError {
             throw workerError
@@ -397,7 +480,8 @@ struct ProfileStore: @unchecked Sendable {
             voiceDescription: storedProfile.manifest.voiceDescription,
             sourceText: storedProfile.manifest.sourceText,
             sampleRate: storedProfile.manifest.sampleRate,
-            backendMaterializations: storedProfile.manifest.backendMaterializations
+            backendMaterializations: storedProfile.manifest.backendMaterializations,
+            qwenConditioningArtifacts: storedProfile.manifest.qwenConditioningArtifacts
         )
 
         do {
@@ -513,7 +597,8 @@ struct ProfileStore: @unchecked Sendable {
                     referenceText: $0.referenceText,
                     sampleRate: $0.sampleRate
                 )
-            }
+            },
+            qwenConditioningArtifacts: []
         )
 
         do {
@@ -566,6 +651,81 @@ struct ProfileStore: @unchecked Sendable {
         }
     }
 
+    func storeQwenConditioningArtifact(
+        named profileName: String,
+        backend: SpeakSwiftly.SpeechBackend,
+        modelRepo: String,
+        conditioning: Qwen3TTSModel.Qwen3TTSReferenceConditioning,
+        createdAt: Date = Date()
+    ) throws -> StoredProfile {
+        let storedProfile = try loadProfile(named: profileName)
+        let artifactFile = Self.qwenConditioningArtifactFileName(for: backend)
+        let persistedArtifact = PersistedQwenConditioningArtifact(conditioning: conditioning)
+        let updatedArtifactManifest = QwenConditioningArtifactManifest(
+            backend: backend,
+            modelRepo: modelRepo,
+            createdAt: createdAt,
+            artifactVersion: PersistedQwenConditioningArtifact.currentVersion,
+            artifactFile: artifactFile
+        )
+        let updatedArtifacts = (
+            storedProfile.manifest.qwenConditioningArtifacts.filter { $0.backend != backend } + [updatedArtifactManifest]
+        )
+        .sorted { $0.backend.rawValue < $1.backend.rawValue }
+        let updatedManifest = ProfileManifest(
+            version: Self.manifestVersion,
+            profileName: storedProfile.manifest.profileName,
+            vibe: storedProfile.manifest.vibe,
+            createdAt: storedProfile.manifest.createdAt,
+            sourceKind: storedProfile.manifest.sourceKind,
+            modelRepo: storedProfile.manifest.modelRepo,
+            voiceDescription: storedProfile.manifest.voiceDescription,
+            sourceText: storedProfile.manifest.sourceText,
+            sampleRate: storedProfile.manifest.sampleRate,
+            backendMaterializations: storedProfile.manifest.backendMaterializations,
+            qwenConditioningArtifacts: updatedArtifacts
+        )
+
+        do {
+            try writeQwenConditioningArtifact(
+                persistedArtifact,
+                to: storedProfile.directoryURL,
+                fileName: artifactFile
+            )
+            try writeManifest(updatedManifest, to: storedProfile.directoryURL)
+        } catch {
+            throw WorkerError(
+                code: .filesystemError,
+                message: "Profile '\(profileName)' could not persist the prepared Qwen conditioning artifact for the '\(backend.rawValue)' backend. \(error.localizedDescription)"
+            )
+        }
+
+        return try loadProfile(named: profileName)
+    }
+
+    func loadQwenConditioningArtifact(
+        _ storedArtifact: StoredQwenConditioningArtifact
+    ) throws -> Qwen3TTSModel.Qwen3TTSReferenceConditioning {
+        do {
+            let data = try Data(contentsOf: storedArtifact.artifactURL)
+            let artifact = try decoder.decode(PersistedQwenConditioningArtifact.self, from: data)
+            guard artifact.version == PersistedQwenConditioningArtifact.currentVersion else {
+                throw WorkerError(
+                    code: .filesystemError,
+                    message: "SpeakSwiftly found a prepared Qwen conditioning artifact at '\(storedArtifact.artifactURL.path)', but the artifact version '\(artifact.version)' is not supported by this runtime. Recreate or reroll the profile to rebuild the artifact."
+                )
+            }
+            return artifact.makeConditioning()
+        } catch let workerError as WorkerError {
+            throw workerError
+        } catch {
+            throw WorkerError(
+                code: .filesystemError,
+                message: "SpeakSwiftly could not load the prepared Qwen conditioning artifact at '\(storedArtifact.artifactURL.path)' for the '\(storedArtifact.manifest.backend.rawValue)' backend. \(error.localizedDescription)"
+            )
+        }
+    }
+
     func profileDirectoryURL(for profileName: String) -> URL {
         rootURL.appendingPathComponent(profileName, isDirectory: true)
     }
@@ -575,6 +735,13 @@ struct ProfileStore: @unchecked Sendable {
     }
 
     func referenceAudioURL(for directoryURL: URL, fileName: String = Self.audioFileName) -> URL {
+        directoryURL.appendingPathComponent(fileName)
+    }
+
+    func qwenConditioningArtifactURL(
+        for directoryURL: URL,
+        fileName: String
+    ) -> URL {
         directoryURL.appendingPathComponent(fileName)
     }
 
@@ -625,7 +792,11 @@ struct ProfileStore: @unchecked Sendable {
         let manifestData = try Data(contentsOf: manifestPath)
 
         if let manifest = try? decoder.decode(ProfileManifest.self, from: manifestData) {
-            return manifest
+            let upgradedManifest = upgradeStoredManifest(manifest)
+            if upgradedManifest != manifest {
+                try writeManifest(upgradedManifest, to: directoryURL)
+            }
+            return upgradedManifest
         }
 
         if let legacyManifest = try? decoder.decode(LegacyMultiBackendProfileManifest.self, from: manifestData) {
@@ -672,7 +843,8 @@ struct ProfileStore: @unchecked Sendable {
             voiceDescription: legacyManifest.voiceDescription,
             sourceText: legacyManifest.sourceText,
             sampleRate: legacyManifest.sampleRate,
-            backendMaterializations: materializations
+            backendMaterializations: materializations,
+            qwenConditioningArtifacts: []
         )
     }
 
@@ -706,7 +878,28 @@ struct ProfileStore: @unchecked Sendable {
             voiceDescription: legacyManifest.voiceDescription,
             sourceText: legacyManifest.sourceText,
             sampleRate: legacyManifest.sampleRate,
-            backendMaterializations: materializations
+            backendMaterializations: materializations,
+            qwenConditioningArtifacts: []
+        )
+    }
+
+    private func upgradeStoredManifest(_ manifest: ProfileManifest) -> ProfileManifest {
+        guard manifest.version < Self.manifestVersion else {
+            return manifest
+        }
+
+        return ProfileManifest(
+            version: Self.manifestVersion,
+            profileName: manifest.profileName,
+            vibe: manifest.vibe,
+            createdAt: manifest.createdAt,
+            sourceKind: manifest.sourceKind,
+            modelRepo: manifest.modelRepo,
+            voiceDescription: manifest.voiceDescription,
+            sourceText: manifest.sourceText,
+            sampleRate: manifest.sampleRate,
+            backendMaterializations: manifest.backendMaterializations,
+            qwenConditioningArtifacts: manifest.qwenConditioningArtifacts
         )
     }
 
@@ -756,6 +949,18 @@ struct ProfileStore: @unchecked Sendable {
         }
     }
 
+    private func writeQwenConditioningArtifact(
+        _ artifact: PersistedQwenConditioningArtifact,
+        to directoryURL: URL,
+        fileName: String
+    ) throws {
+        let data = try encoder.encode(artifact)
+        try data.write(
+            to: qwenConditioningArtifactURL(for: directoryURL, fileName: fileName),
+            options: .atomic
+        )
+    }
+
     private func writeManifest(_ manifest: ProfileManifest, to directoryURL: URL) throws {
         let manifestData = try encoder.encode(manifest)
         try manifestData.write(to: manifestURL(for: directoryURL), options: .atomic)
@@ -777,5 +982,11 @@ struct ProfileStore: @unchecked Sendable {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return decoder
+    }
+
+    private static func qwenConditioningArtifactFileName(
+        for backend: SpeakSwiftly.SpeechBackend
+    ) -> String {
+        "qwen-conditioning-\(backend.rawValue).json"
     }
 }

--- a/Sources/SpeakSwiftly/Storage/QwenConditioningArtifacts.swift
+++ b/Sources/SpeakSwiftly/Storage/QwenConditioningArtifacts.swift
@@ -1,0 +1,76 @@
+import Foundation
+@preconcurrency import MLX
+import MLXAudioTTS
+
+// MARK: - Qwen Conditioning Artifact Models
+
+struct QwenConditioningArtifactManifest: Codable, Sendable, Equatable {
+    let backend: SpeakSwiftly.SpeechBackend
+    let modelRepo: String
+    let createdAt: Date
+    let artifactVersion: Int
+    let artifactFile: String
+}
+
+struct StoredQwenConditioningArtifact: Sendable, Equatable {
+    let manifest: QwenConditioningArtifactManifest
+    let artifactURL: URL
+}
+
+struct QwenConditioningFloatTensor: Codable, Sendable, Equatable {
+    let values: [Float]
+    let shape: [Int]
+
+    init(array: MLXArray) {
+        values = array.asArray(Float.self)
+        shape = array.shape.map { Int($0) }
+    }
+
+    func makeArray() -> MLXArray {
+        MLXArray(values).reshaped(shape)
+    }
+}
+
+struct QwenConditioningInt32Tensor: Codable, Sendable, Equatable {
+    let values: [Int32]
+    let shape: [Int]
+
+    init(array: MLXArray) {
+        values = array.asArray(Int32.self)
+        shape = array.shape.map { Int($0) }
+    }
+
+    func makeArray() -> MLXArray {
+        MLXArray(values).reshaped(shape)
+    }
+}
+
+struct PersistedQwenConditioningArtifact: Codable, Sendable, Equatable {
+    static let currentVersion = 1
+
+    let version: Int
+    let speakerEmbedding: QwenConditioningFloatTensor?
+    let referenceSpeechCodes: QwenConditioningInt32Tensor
+    let referenceTextTokenIDs: QwenConditioningInt32Tensor
+    let resolvedLanguage: String
+    let codecLanguageID: Int?
+
+    init(conditioning: Qwen3TTSModel.Qwen3TTSReferenceConditioning) {
+        version = Self.currentVersion
+        speakerEmbedding = conditioning.speakerEmbedding.map(QwenConditioningFloatTensor.init)
+        referenceSpeechCodes = QwenConditioningInt32Tensor(array: conditioning.referenceSpeechCodes)
+        referenceTextTokenIDs = QwenConditioningInt32Tensor(array: conditioning.referenceTextTokenIDs)
+        resolvedLanguage = conditioning.resolvedLanguage
+        codecLanguageID = conditioning.codecLanguageID
+    }
+
+    func makeConditioning() -> Qwen3TTSModel.Qwen3TTSReferenceConditioning {
+        Qwen3TTSModel.Qwen3TTSReferenceConditioning(
+            speakerEmbedding: speakerEmbedding?.makeArray(),
+            referenceSpeechCodes: referenceSpeechCodes.makeArray(),
+            referenceTextTokenIDs: referenceTextTokenIDs.makeArray(),
+            resolvedLanguage: resolvedLanguage,
+            codecLanguageID: codecLanguageID
+        )
+    }
+}

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -16,8 +16,12 @@ import TextForSpeech
 }
 
 @Test func publicLibrarySurfaceConstructsConfiguration() {
-    let configuration = SpeakSwiftly.Configuration(speechBackend: .marvis)
+    let configuration = SpeakSwiftly.Configuration(
+        speechBackend: .marvis,
+        qwenConditioningStrategy: .preparedConditioning
+    )
     #expect(configuration.speechBackend == .marvis)
+    #expect(configuration.qwenConditioningStrategy == .preparedConditioning)
     #expect(configuration.textNormalizer == nil)
 }
 
@@ -27,12 +31,16 @@ import TextForSpeech
     defer { try? FileManager.default.removeItem(at: rootURL) }
 
     let persistenceURL = rootURL.appendingPathComponent("configuration.json")
-    let configuration = SpeakSwiftly.Configuration(speechBackend: .marvis)
+    let configuration = SpeakSwiftly.Configuration(
+        speechBackend: .marvis,
+        qwenConditioningStrategy: .preparedConditioning
+    )
 
     try configuration.save(to: persistenceURL)
     let loaded = try SpeakSwiftly.Configuration.load(from: persistenceURL)
 
     #expect(loaded.speechBackend == configuration.speechBackend)
+    #expect(loaded.qwenConditioningStrategy == configuration.qwenConditioningStrategy)
     #expect(loaded.textNormalizer == nil)
 }
 
@@ -50,10 +58,12 @@ import TextForSpeech
     let normalizer = try SpeakSwiftly.Normalizer()
     let configuration = SpeakSwiftly.Configuration(
         speechBackend: .marvis,
+        qwenConditioningStrategy: .legacyRaw,
         textNormalizer: normalizer
     )
 
     #expect(configuration.speechBackend == .marvis)
+    #expect(configuration.qwenConditioningStrategy == .legacyRaw)
     #expect(configuration.textNormalizer != nil)
 }
 

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenWorkflowE2ETests.swift
@@ -58,6 +58,76 @@ extension SpeakSwiftlyE2ETests {
             }
         }
 
+        @Test func preparedConditioningPersistsAndReloadsAcrossWorkerRestart() async throws {
+            guard SpeakSwiftlyE2ETests.isE2EEnabled else { return }
+
+            let sandbox = try E2ESandbox()
+            defer { sandbox.cleanup() }
+            let profileName = "prepared-conditioning-profile"
+            let runtimeConfiguration = SpeakSwiftly.Configuration(
+                speechBackend: .qwen3,
+                qwenConditioningStrategy: .preparedConditioning
+            )
+
+            do {
+                let worker = try WorkerProcess(
+                    profileRootURL: sandbox.profileRootURL,
+                    silentPlayback: true,
+                    configuration: runtimeConfiguration
+                )
+                defer { Task { await worker.stop() } }
+
+                try await SpeakSwiftlyE2ETests.awaitWorkerReady(worker, expectPlaybackEngine: false)
+                try await SpeakSwiftlyE2ETests.createVoiceDesignProfile(
+                    on: worker,
+                    id: "req-create-prepared-conditioning-profile",
+                    profileName: profileName,
+                    text: SpeakSwiftlyE2ETests.testingProfileText,
+                    vibe: .masc,
+                    voiceDescription: SpeakSwiftlyE2ETests.testingProfileVoiceDescription
+                )
+                try await SpeakSwiftlyE2ETests.runSilentSpeech(
+                    on: worker,
+                    id: "req-live-prepared-conditioning-first-pass",
+                    text: SpeakSwiftlyE2ETests.testingPlaybackText,
+                    profileName: profileName
+                )
+                #expect(try await worker.waitForStderrJSONObject(timeout: e2eTimeout) {
+                    $0["event"] as? String == "qwen_reference_conditioning_persisted"
+                        && $0["request_id"] as? String == "req-live-prepared-conditioning-first-pass"
+                } != nil)
+                try worker.closeInput()
+                try await worker.waitForExit(timeout: .seconds(30))
+            }
+
+            let store = ProfileStore(rootURL: sandbox.profileRootURL)
+            let storedProfile = try store.loadProfile(named: profileName)
+            #expect(storedProfile.qwenConditioningArtifact(for: .qwen3) != nil)
+
+            do {
+                let worker = try WorkerProcess(
+                    profileRootURL: sandbox.profileRootURL,
+                    silentPlayback: true,
+                    configuration: runtimeConfiguration
+                )
+                defer { Task { await worker.stop() } }
+
+                try await SpeakSwiftlyE2ETests.awaitWorkerReady(worker, expectPlaybackEngine: false)
+                try await SpeakSwiftlyE2ETests.runSilentSpeech(
+                    on: worker,
+                    id: "req-live-prepared-conditioning-second-pass",
+                    text: SpeakSwiftlyE2ETests.testingPlaybackText,
+                    profileName: profileName
+                )
+                #expect(try await worker.waitForStderrJSONObject(timeout: e2eTimeout) {
+                    $0["event"] as? String == "qwen_reference_conditioning_loaded"
+                        && $0["request_id"] as? String == "req-live-prepared-conditioning-second-pass"
+                } != nil)
+                try worker.closeInput()
+                try await worker.waitForExit(timeout: .seconds(30))
+            }
+        }
+
         @Test func cloneWithProvidedTranscript() async throws {
             guard SpeakSwiftlyE2ETests.isE2EEnabled else { return }
 

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
@@ -703,11 +703,13 @@ final class WorkerProcess: @unchecked Sendable {
         silentPlayback: Bool,
         playbackTrace: Bool = false,
         speechBackend: SpeakSwiftly.SpeechBackend? = nil,
+        configuration: SpeakSwiftly.Configuration? = nil,
         caller: StaticString = #function
     ) throws {
         let packageRootURL = try Self.packageRootURL()
-        let configuration = "Debug"
-        try Self.publishWorkerRuntime(packageRootURL: packageRootURL, configuration: configuration)
+        let buildConfiguration = "Debug"
+        let runtimeConfiguration = configuration
+        try Self.publishWorkerRuntime(packageRootURL: packageRootURL, configuration: buildConfiguration)
 
         process = Process()
         stdinPipe = Pipe()
@@ -720,15 +722,24 @@ final class WorkerProcess: @unchecked Sendable {
 
         let executableURL = try Self.workerExecutableURL(
             packageRootURL: packageRootURL,
-            configuration: configuration
+            configuration: buildConfiguration
         )
         artifacts = try E2EWorkerArtifacts(
             packageRootURL: packageRootURL,
-            configuration: configuration,
+            configuration: buildConfiguration,
             caller: String(describing: caller),
             executableURL: executableURL,
             profileRootURL: profileRootURL
         )
+        if let runtimeConfiguration {
+            try runtimeConfiguration.save(
+                to: SpeakSwiftly.Configuration.defaultPersistenceURL(
+                    fileManager: .default,
+                    profileRootOverride: profileRootURL.path
+                )
+            )
+        }
+
         process.executableURL = executableURL
         process.standardInput = stdinPipe
         process.standardOutput = stdoutPipe

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @preconcurrency import MLX
+import MLXAudioTTS
 import Testing
 @testable import SpeakSwiftlyCore
 import TextForSpeech
@@ -729,6 +730,158 @@ import TextForSpeech
 
     #expect(residentRecorder.lastRefAudioWasProvided == true)
     #expect(residentRecorder.audioLoadCallCount == 1)
+}
+
+@Test func speakLivePreparedQwenConditioningPersistsAndReloadsAcrossRuntimeRestarts() async throws {
+    guard mlxConditioningPersistenceTestsEnabled() else { return }
+
+    let output = OutputRecorder()
+    let storeRoot = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: storeRoot) }
+
+    let store = try makeProfileStore(rootURL: storeRoot)
+    _ = try store.createProfile(
+        profileName: "default-femme",
+        modelRepo: "test-model",
+        voiceDescription: "Warm and bright.",
+        sourceText: "Reference transcript",
+        sampleRate: 24_000,
+        canonicalAudioData: Data([0x01, 0x02])
+    )
+
+    let firstRecorder = ResidentModelRecorder()
+    let firstRuntime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: output,
+        playback: PlaybackSpy(),
+        qwenConditioningStrategy: .preparedConditioning,
+        audioLoadRecorder: firstRecorder,
+        loadedAudioSamples: MLXArray([Float(0.1), 0.2]).reshaped([1, 2]),
+        residentModelLoader: { _ in
+            makeResidentModel(recorder: firstRecorder)
+        }
+    )
+
+    await firstRuntime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    await firstRuntime.accept(line: #"{"id":"req-1","op":"generate_speech","text":"Hello there","profile_name":"default-femme"}"#)
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == "req-1"
+                && $0["ok"] as? Bool == true
+        }
+    })
+
+    let storedAfterFirstRun = try store.loadProfile(named: "default-femme")
+    #expect(storedAfterFirstRun.qwenConditioningArtifact(for: .qwen3) != nil)
+    #expect(firstRecorder.prepareConditioningCallCount == 1)
+    #expect(firstRecorder.conditionedGenerationCallCount == 1)
+    #expect(firstRecorder.audioLoadCallCount == 1)
+
+    let secondOutput = OutputRecorder()
+    let secondRecorder = ResidentModelRecorder()
+    let secondRuntime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: secondOutput,
+        playback: PlaybackSpy(),
+        qwenConditioningStrategy: .preparedConditioning,
+        audioLoadRecorder: secondRecorder,
+        loadedAudioSamples: MLXArray([Float(0.3), 0.4]).reshaped([1, 2]),
+        residentModelLoader: { _ in
+            makeResidentModel(recorder: secondRecorder)
+        }
+    )
+
+    await secondRuntime.start()
+    #expect(await waitUntil {
+        secondOutput.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    await secondRuntime.accept(line: #"{"id":"req-2","op":"generate_speech","text":"Hello again","profile_name":"default-femme"}"#)
+    #expect(await waitUntil {
+        secondOutput.containsJSONObject {
+            $0["id"] as? String == "req-2"
+                && $0["ok"] as? Bool == true
+        }
+    })
+
+    #expect(secondRecorder.prepareConditioningCallCount == 0)
+    #expect(secondRecorder.conditionedGenerationCallCount == 1)
+    #expect(secondRecorder.audioLoadCallCount == 0)
+}
+
+@Test func speakLiveLegacyRawStrategyIgnoresPreparedQwenConditioningArtifacts() async throws {
+    guard mlxConditioningPersistenceTestsEnabled() else { return }
+
+    let output = OutputRecorder()
+    let residentRecorder = ResidentModelRecorder()
+    let storeRoot = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: storeRoot) }
+
+    let store = try makeProfileStore(rootURL: storeRoot)
+    _ = try store.createProfile(
+        profileName: "default-femme",
+        modelRepo: "test-model",
+        voiceDescription: "Warm and bright.",
+        sourceText: "Reference transcript",
+        sampleRate: 24_000,
+        canonicalAudioData: Data([0x01, 0x02])
+    )
+    _ = try store.storeQwenConditioningArtifact(
+        named: "default-femme",
+        backend: .qwen3,
+        modelRepo: ModelFactory.residentModelRepo(for: .qwen3),
+        conditioning: Qwen3TTSModel.Qwen3TTSReferenceConditioning(
+            speakerEmbedding: MLXArray([Float(0.25), 0.5]).reshaped([1, 2]),
+            referenceSpeechCodes: MLXArray([Int32(10), 11, 12, 13]).reshaped([1, 2, 2]),
+            referenceTextTokenIDs: MLXArray([Int32(101), 102, 103]).reshaped([1, 3]),
+            resolvedLanguage: "English",
+            codecLanguageID: 7
+        )
+    )
+
+    let runtime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: output,
+        playback: PlaybackSpy(),
+        qwenConditioningStrategy: .legacyRaw,
+        audioLoadRecorder: residentRecorder,
+        loadedAudioSamples: MLXArray([Float(0.1), 0.2]).reshaped([1, 2]),
+        residentModelLoader: { _ in
+            makeResidentModel(recorder: residentRecorder)
+        }
+    )
+
+    await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    await runtime.accept(line: #"{"id":"req-1","op":"generate_speech","text":"Hello there","profile_name":"default-femme"}"#)
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == "req-1"
+                && $0["ok"] as? Bool == true
+        }
+    })
+
+    #expect(residentRecorder.prepareConditioningCallCount == 0)
+    #expect(residentRecorder.conditionedGenerationCallCount == 0)
+    #expect(residentRecorder.audioLoadCallCount == 1)
+    #expect(residentRecorder.lastRefAudioWasProvided == true)
+    #expect(residentRecorder.lastRefText == "Reference transcript")
 }
 
 @Test func speakLiveNormalizesCodeHeavyMarkdownBeforeResidentGeneration() async throws {

--- a/Tests/SpeakSwiftlyTests/Generation/ProfileStoreTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ProfileStoreTests.swift
@@ -1,6 +1,8 @@
 import Foundation
+@preconcurrency import MLX
 import Testing
 @testable import SpeakSwiftlyCore
+import MLXAudioTTS
 
 // MARK: - Profile Lifecycle
 
@@ -284,4 +286,55 @@ import Testing
     #expect(loaded.manifest.backendMaterializations.count == 1)
     #expect(try loaded.qwenMaterialization().referenceAudioURL.lastPathComponent == "reference.wav")
     #expect(try loaded.qwenMaterialization().manifest.referenceText == "Legacy transcript")
+}
+
+@Test func storesAndLoadsPreparedQwenConditioningArtifacts() throws {
+    guard mlxConditioningPersistenceTestsEnabled() else { return }
+
+    let fileManager = FileManager.default
+    let tempRoot = makeTempDirectoryURL()
+    defer { try? fileManager.removeItem(at: tempRoot) }
+
+    let store = ProfileStore(rootURL: tempRoot, fileManager: fileManager)
+    let audioData = Data([0x52, 0x49, 0x46, 0x46])
+
+    _ = try store.createProfile(
+        profileName: "default-femme",
+        vibe: .femme,
+        modelRepo: "test-model",
+        voiceDescription: "Warm and bright.",
+        sourceText: "Hello there",
+        sampleRate: 24_000,
+        canonicalAudioData: audioData
+    )
+
+    let conditioning = Qwen3TTSModel.Qwen3TTSReferenceConditioning(
+        speakerEmbedding: MLXArray([Float(0.25), 0.5]).reshaped([1, 2]),
+        referenceSpeechCodes: MLXArray([Int32(10), 11, 12, 13]).reshaped([1, 2, 2]),
+        referenceTextTokenIDs: MLXArray([Int32(101), 102, 103]).reshaped([1, 3]),
+        resolvedLanguage: "English",
+        codecLanguageID: 7
+    )
+
+    let stored = try store.storeQwenConditioningArtifact(
+        named: "default-femme",
+        backend: .qwen3CustomVoice,
+        modelRepo: ModelFactory.residentModelRepo(for: .qwen3CustomVoice),
+        conditioning: conditioning,
+        createdAt: Date(timeIntervalSince1970: 1_712_800_000)
+    )
+
+    let artifact = try #require(stored.qwenConditioningArtifact(for: .qwen3CustomVoice))
+    #expect(stored.manifest.qwenConditioningArtifacts.count == 1)
+    #expect(fileManager.fileExists(atPath: artifact.artifactURL.path))
+
+    let reloadedConditioning = try store.loadQwenConditioningArtifact(artifact)
+
+    #expect(reloadedConditioning.resolvedLanguage == "English")
+    #expect(reloadedConditioning.codecLanguageID == 7)
+    #expect(reloadedConditioning.referenceSpeechCodes.asArray(Int32.self) == [10, 11, 12, 13])
+    #expect(reloadedConditioning.referenceSpeechCodes.shape == [1, 2, 2])
+    #expect(reloadedConditioning.referenceTextTokenIDs.asArray(Int32.self) == [101, 102, 103])
+    #expect(reloadedConditioning.referenceTextTokenIDs.shape == [1, 3])
+    #expect(reloadedConditioning.speakerEmbedding?.asArray(Float.self) == [0.25, 0.5])
 }

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeShutdownTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeShutdownTests.swift
@@ -396,6 +396,7 @@ final class LockedFlag: @unchecked Sendable {
             readRuntimeMemory: { nil }
         ),
         speechBackend: .qwen3,
+        qwenConditioningStrategy: .legacyRaw,
         profileStore: try makeProfileStore(rootURL: storeRoot),
         generatedFileStore: try makeGeneratedFileStore(rootURL: storeRoot),
         generationJobStore: try makeGenerationJobStore(rootURL: storeRoot),
@@ -504,6 +505,7 @@ final class LockedFlag: @unchecked Sendable {
     let runtime = WorkerRuntime(
         dependencies: dependencies,
         speechBackend: .qwen3,
+        qwenConditioningStrategy: .legacyRaw,
         profileStore: profileStore,
         generatedFileStore: generatedFileStore,
         generationJobStore: generationJobStore,

--- a/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
@@ -1,9 +1,16 @@
 import Foundation
 @preconcurrency import MLX
 @preconcurrency import MLXLMCommon
+import MLXAudioTTS
 import Testing
 @testable import SpeakSwiftlyCore
 import TextForSpeech
+
+// MARK: - Opt-In Test Gates
+
+func mlxConditioningPersistenceTestsEnabled() -> Bool {
+    ProcessInfo.processInfo.environment["SPEAKSWIFTLY_MLX_PERSISTENCE_TESTS"] == "1"
+}
 
 // MARK: - Locking Helpers
 
@@ -404,6 +411,8 @@ final class ResidentModelRecorder: @unchecked Sendable {
     private(set) var lastRefText: String?
     private(set) var lastRefAudioWasProvided = false
     private(set) var audioLoadCallCount = 0
+    private(set) var prepareConditioningCallCount = 0
+    private(set) var conditionedGenerationCallCount = 0
     private(set) var lastGenerationParameters: GenerateParameters?
 
     func record(
@@ -427,12 +436,36 @@ final class ResidentModelRecorder: @unchecked Sendable {
             audioLoadCallCount += 1
         }
     }
+
+    func recordConditioningPreparation() {
+        lock.withLock {
+            prepareConditioningCallCount += 1
+        }
+    }
+
+    func recordConditionedGeneration(
+        text: String,
+        generationParameters: GenerateParameters
+    ) {
+        lock.withLock {
+            conditionedGenerationCallCount += 1
+            lastText = text
+            lastVoice = nil
+            lastRefAudioWasProvided = false
+            lastRefText = nil
+            lastGenerationParameters = generationParameters
+        }
+    }
 }
 
 // MARK: - Test Model and Runtime Factories
 
 func makeResidentModel(recorder: ResidentModelRecorder? = nil, chunkCount: Int = 1) -> AnySpeechModel {
-    AnySpeechModel(
+    let conditionedReferenceAudio = MLXArray([Int32(11), 12, 13, 14]).reshaped([1, 2, 2])
+    let conditionedReferenceText = MLXArray([Int32(101), 102, 103]).reshaped([1, 3])
+    let conditionedSpeakerEmbedding = MLXArray([Float(0.25), 0.5]).reshaped([1, 2])
+
+    return AnySpeechModel(
         sampleRate: 24_000,
         generate: { _, _, _, _, _, _ in
             [0.1, 0.2]
@@ -474,6 +507,43 @@ func makeResidentModel(recorder: ResidentModelRecorder? = nil, chunkCount: Int =
                             generateTime: 0.34,
                             tokensPerSecond: 56.7,
                             peakMemoryUsage: 1.23
+                        )
+                    )
+                )
+                for chunkIndex in 0..<chunkCount {
+                    let base = Float(chunkIndex + 1) / 10
+                    continuation.yield(.audio([base, base + 0.1]))
+                }
+                continuation.finish()
+            }
+        },
+        prepareQwenReferenceConditioning: { _, _, language in
+            recorder?.recordConditioningPreparation()
+            return Qwen3TTSModel.Qwen3TTSReferenceConditioning(
+                speakerEmbedding: conditionedSpeakerEmbedding,
+                referenceSpeechCodes: conditionedReferenceAudio,
+                referenceTextTokenIDs: conditionedReferenceText,
+                resolvedLanguage: language ?? "English",
+                codecLanguageID: 7
+            )
+        },
+        generateConditionedEventStream: { text, _, generationParameters, _ in
+            recorder?.recordConditionedGeneration(
+                text: text,
+                generationParameters: generationParameters
+            )
+
+            return AsyncThrowingStream { continuation in
+                continuation.yield(.token(202))
+                continuation.yield(
+                    .info(
+                        .init(
+                            promptTokenCount: 8,
+                            generationTokenCount: chunkCount * 4,
+                            prefillTime: 0.08,
+                            generateTime: 0.21,
+                            tokensPerSecond: 73.2,
+                            peakMemoryUsage: 0.92
                         )
                     )
                 )
@@ -560,6 +630,7 @@ func makeRuntime<ResidentModelResult>(
     output: OutputRecorder,
     playback: PlaybackSpy,
     speechBackend: SpeakSwiftly.SpeechBackend = .qwen3,
+    qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .legacyRaw,
     audioLoadRecorder: ResidentModelRecorder? = nil,
     loadedAudioSamples: MLXArray? = nil,
     loadedCloneAudioSamples: [Float] = [],
@@ -626,6 +697,7 @@ func makeRuntime<ResidentModelResult>(
     let runtime = WorkerRuntime(
         dependencies: dependencies,
         speechBackend: speechBackend,
+        qwenConditioningStrategy: qwenConditioningStrategy,
         profileStore: store,
         generatedFileStore: generatedFileStore,
         generationJobStore: generationJobStore,


### PR DESCRIPTION
What changed
- adds a stored Qwen conditioning path beside the existing legacy raw reference-audio path
- adds a runtime configuration toggle so hosts can choose legacy raw or prepared conditioning intentionally
- persists prepared Qwen conditioning artifacts on voice profiles and reloads them across worker restarts
- freezes the temporary mlx-audio-swift fork dependency to one exact revision instead of a moving branch
- documents the new configuration surface, the real qwen prepared-conditioning e2e check, and the temporary fork bridge

Why
- this lets SpeakSwiftly use the new Qwen reference-conditioning API now while keeping the old path available during upstreaming
- it turns the dependency on Gale's mlx-audio-swift fork into an explicit stopgap instead of a floating branch dependency

Temporary fork bridge
- SpeakSwiftly is temporarily pinned to Gale's mlx-audio-swift fork revision 478707e1d726b011a44e9d61f15abefbf4aec137
- that revision corresponds to the fork tag qwen-reference-conditioning-2026-04-11
- this should be replaced with upstream mlx-audio-swift once the matching Qwen3TTS conditioning API lands there

Verification
- swift test
- SPEAKSWIFTLY_E2E=1 swift test --filter SpeakSwiftlyE2ETests/QwenWorkflowSuite/preparedConditioningPersistsAndReloadsAcrossWorkerRestart