### PR TITLE
runtime: harden marvis release path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -621,6 +621,7 @@ For the targeted first-request Marvis tuning lane, the current reliable rerun pa
 - direct `swift test` is still blocked by the vendored `mlx-audio-swift` parser failure in `EnglishG2P.swift`
 - direct `xcodebuild test` does not currently carry `SPEAKSWIFTLY_E2E=1` through the Swift Testing suite gate on its own
 - the working path is `xcodebuild build-for-testing`, then an `.xctestrun` override that injects `SPEAKSWIFTLY_E2E=1` and `SPEAKSWIFTLY_PLAYBACK_TRACE=1`, then `xcodebuild test-without-building` against this exact test identifier:
+- on current Xcode manifests, that override lives under `TestConfigurations -> TestTargets -> EnvironmentVariables`
 
 ```text
 SpeakSwiftlyTests/SpeakSwiftlyE2ETests/MarvisWorkflowSuite/`prequeued jobs drain in order`()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ The current intended runtime shape is:
 
 - a long-lived executable owned by another process
 - newline-delimited JSON over `stdin` and `stdout`
-- resident backend selection between `qwen3`, `qwen3_custom_voice`, and `marvis`
+- resident backend selection between `qwen3` and `marvis`
 - stored voice profiles selected by name
 - text-normalization profiles that can be edited independently
 - persisted runtime configuration for the preferred resident backend
@@ -152,14 +152,18 @@ The same namespace split applies to the default profile store and `text-profiles
 Backend resolution precedence is:
 
 1. explicit `configuration.speechBackend` passed to `SpeakSwiftly.liftoff(...)`
-2. `SPEAKSWIFTLY_SPEECH_BACKEND`
-3. persisted `configuration.json`
+2. persisted `configuration.json`
+3. `SPEAKSWIFTLY_SPEECH_BACKEND`
 4. fallback `.qwen3`
+
+Legacy serialized or environment `qwen3_custom_voice` backend values are still accepted and normalized onto `.qwen3` so existing runtime config and stored profile manifests keep loading cleanly after the backend collapse.
 
 Qwen conditioning strategy values are:
 
 - `.legacyRaw`: keep passing raw `refAudio` and `refText` into the resident Qwen model on every request
 - `.preparedConditioning`: prepare Qwen reference conditioning once, persist it on the profile, cache it in memory after load, and reuse it on later requests
+
+The default runtime configuration now uses `.preparedConditioning`.
 
 The runtime currently reads `qwenConditioningStrategy` only from the explicit or persisted `SpeakSwiftly.Configuration` surface. There is no separate environment-variable override for that setting.
 
@@ -653,7 +657,7 @@ SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1 swift test --filter SpeakSw
 
 Without `SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1`, the benchmark suite is skipped during ordinary `SPEAKSWIFTLY_E2E=1` runs so the default full e2e lane stays release-safe.
 
-Run multiple comparison samples per backend:
+Run multiple comparison samples per Qwen conditioning strategy:
 
 ```bash
 SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1 SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS=3 swift test --filter SpeakSwiftlyE2ETests/QwenBenchmarkSuite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -501,6 +501,13 @@ The eleventh Milestone 22 pass landed on `2026-04-15` as the first explicit over
 - Even with the cleaner rerun, the first audible request was still subjectively too rough to justify fixed follower slowdown as the main policy. The working read is now that the unstable part on Gale's machine is the transition into simultaneous overlap itself, not just the follower's steady-state cadence after overlap opens.
 - The next useful design should therefore stay dynamic rather than fixed. Keep the truthful overlap gate and the explicit follower-cadence role, but add a short-lived `fragile first playback` window for the first drained live Marvis request so the second lane stays parked or lighter until reserve has crossed and briefly held a healthier target, then backs off again if reserve starts collapsing.
 
+The twelfth Milestone 22 pass landed on `2026-04-16` as that first explicit fragile-overlap policy pass.
+
+- That pass kept the scheduler contract narrow and implemented the new behavior inside `PlaybackController` as a short-lived fragile overlap window for the first drained live Marvis request.
+- The first request now has to earn two healthy `buffer_scheduled` updates above a stronger hold target before playback reports `allowsConcurrentGeneration = true`, and that same guard re-engages if buffered reserve later drops back below the healthier hold target.
+- The important architecture result is that overlap control still stays playback-owned and truth-based. The runtime scheduler still sees one yes-or-no admission surface, but the first drained request can now back off from overlap pressure before a full rebuffer pause forms instead of only after crossing the ordinary reserve target once.
+- The focused regression coverage for this pass lives in `Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift`, including the new pure admission-resolution checks for the fragile overlap window.
+
 ## Repository Layout
 
 The package source tree is organized by responsibility:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "facda62b22d9833a05de08bec630cc836a4adff7912344179e3fb82f1b0ba25c",
+  "originHash" : "8edceba8be651594120b702ab42b6deca9b20698789d904d108c044ba191a4a6",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/mlx-audio-swift.git",
       "state" : {
-        "revision" : "b0a75a89562c8514d68892498955354a62380b83",
-        "version" : "69.1.3"
+        "revision" : "42fc7c25c07d8c4817dfdc9b125338fd8aff3a9e",
+        "version" : "69.1.4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8edceba8be651594120b702ab42b6deca9b20698789d904d108c044ba191a4a6",
+  "originHash" : "e2ef77119e6c03820b3258a315b1470347ace88655b16b92db7aaf9bacb24bf2",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/mlx-audio-swift.git",
       "state" : {
-        "revision" : "42fc7c25c07d8c4817dfdc9b125338fd8aff3a9e",
-        "version" : "69.1.4"
+        "revision" : "ce483e503595c2e01a11efaa6716ffd1ebc496c1",
+        "version" : "69.1.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",
-            from: "69.1.3",
+            from: "69.1.4",
         ),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",
-            from: "69.1.4",
+            from: "69.1.5",
         ),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SpeakSwiftly currently includes:
 - a typed runtime rooted at `SpeakSwiftly.liftoff(...)`
 - a JSONL worker surface for non-Swift hosts
 - stored voice profiles and text-normalization profiles
-- resident backend switching between `qwen3`, `qwen3_custom_voice`, and `marvis`
+- resident backend switching between `qwen3` and `marvis`
 - resident model unload and reload controls
 - retained generated-file and generated-batch artifacts
 
@@ -123,7 +123,7 @@ Runtime preferences have a matching typed surface:
 import SpeakSwiftly
 
 let configuration = SpeakSwiftly.Configuration(
-    speechBackend: .qwen3CustomVoice,
+    speechBackend: .qwen3,
     qwenConditioningStrategy: .preparedConditioning
 )
 try configuration.save(to: URL(fileURLWithPath: "/tmp/speakswiftly-configuration.json"))
@@ -131,7 +131,7 @@ try configuration.save(to: URL(fileURLWithPath: "/tmp/speakswiftly-configuration
 let runtime = await SpeakSwiftly.liftoff(configuration: configuration)
 ```
 
-For Qwen backends, `qwenConditioningStrategy` controls whether the runtime keeps using raw `refAudio` and `refText` on each request or persists reusable prepared conditioning on the voice profile.
+For Qwen generation, `qwenConditioningStrategy` controls whether the runtime keeps using raw `refAudio` and `refText` on each request or persists reusable prepared conditioning on the voice profile. The default configuration now uses `.preparedConditioning`, and legacy serialized `qwen3_custom_voice` backend values are normalized onto `qwen3` during load.
 
 If a host needs the packaged MLX bundle or metallib path directly, use the support-resource surface:
 

--- a/Sources/SpeakSwiftly/API/Configuration.swift
+++ b/Sources/SpeakSwiftly/API/Configuration.swift
@@ -50,7 +50,7 @@ public extension SpeakSwiftly {
         /// Creates a runtime configuration value.
         public init(
             speechBackend: SpeakSwiftly.SpeechBackend = .qwen3,
-            qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .legacyRaw,
+            qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .preparedConditioning,
             textNormalizer: SpeakSwiftly.Normalizer? = nil,
         ) {
             self.speechBackend = speechBackend
@@ -64,7 +64,7 @@ public extension SpeakSwiftly {
             qwenConditioningStrategy = try container.decodeIfPresent(
                 SpeakSwiftly.QwenConditioningStrategy.self,
                 forKey: .qwenConditioningStrategy,
-            ) ?? .legacyRaw
+            ) ?? .preparedConditioning
             textNormalizer = nil
         }
 

--- a/Sources/SpeakSwiftly/Generation/FileGenerationOperations+ResidentInputs.swift
+++ b/Sources/SpeakSwiftly/Generation/FileGenerationOperations+ResidentInputs.swift
@@ -45,7 +45,7 @@ extension SpeakSwiftly.Runtime {
         try Task.checkCancellation()
 
         switch speechBackend {
-            case .qwen3, .qwen3CustomVoice:
+            case .qwen3:
                 let residentModel = try residentQwenModelOrThrow()
                 switch qwenConditioningStrategy {
                     case .legacyRaw:

--- a/Sources/SpeakSwiftly/Generation/ModelClients.swift
+++ b/Sources/SpeakSwiftly/Generation/ModelClients.swift
@@ -63,7 +63,7 @@ enum GenerationPolicy {
 
 enum ModelFactory {
     static let qwenResidentModelRepo = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit"
-    static let qwenCustomVoiceResidentModelRepo = "mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-bf16"
+    static let legacyQwenCustomVoiceResidentModelRepo = "mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-bf16"
     static let marvisResidentModelRepo = "Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit"
     static let profileModelRepo = "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16"
     static let cloneTranscriptionModelRepo = "mlx-community/GLM-ASR-Nano-2512-4bit"
@@ -74,7 +74,7 @@ enum ModelFactory {
 
     static func loadResidentModels(for backend: SpeakSwiftly.SpeechBackend) async throws -> ResidentSpeechModels {
         switch backend {
-            case .qwen3, .qwen3CustomVoice:
+            case .qwen3:
                 return try await .qwen3(loadModel(modelRepo: residentModelRepo(for: backend)))
             case .marvis:
                 // Marvis keeps mutable generation caches on the model instance, so each

--- a/Sources/SpeakSwiftly/Generation/SpeechBackend.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechBackend.swift
@@ -7,7 +7,6 @@ public extension SpeakSwiftly {
 
     enum SpeechBackend: String, Codable, Sendable, Equatable, CaseIterable {
         case qwen3
-        case qwen3CustomVoice = "qwen3_custom_voice"
         case marvis
     }
 }
@@ -16,18 +15,27 @@ public extension SpeakSwiftly.SpeechBackend {
     // MARK: Environment
 
     static let environmentVariable = "SPEAKSWIFTLY_SPEECH_BACKEND"
+    static let legacyQwenCustomVoiceRawValue = "qwen3_custom_voice"
+
+    static func normalized(rawValue: String) -> Self? {
+        let normalizedValue = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch normalizedValue {
+            case legacyQwenCustomVoiceRawValue:
+                return .qwen3
+            default:
+                return Self(rawValue: normalizedValue)
+        }
+    }
 
     static func configured(in environment: [String: String]) -> Self? {
-        guard let rawValue = environment[environmentVariable]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased(),
-            !rawValue.isEmpty,
-            let backend = Self(rawValue: rawValue)
-        else {
+        guard let rawValue = environment[environmentVariable], !rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return nil
         }
 
-        return backend
+        return normalized(rawValue: rawValue)
     }
 
     static func fromEnvironment(_ environment: [String: String]) -> Self {
@@ -38,8 +46,6 @@ public extension SpeakSwiftly.SpeechBackend {
         switch self {
             case .qwen3:
                 ModelFactory.qwenResidentModelRepo
-            case .qwen3CustomVoice:
-                ModelFactory.qwenCustomVoiceResidentModelRepo
             case .marvis:
                 ModelFactory.marvisResidentModelRepo
         }
@@ -47,10 +53,26 @@ public extension SpeakSwiftly.SpeechBackend {
 
     internal var isQwenFamily: Bool {
         switch self {
-            case .qwen3, .qwen3CustomVoice:
+            case .qwen3:
                 true
             case .marvis:
                 false
         }
+    }
+}
+
+public extension SpeakSwiftly.SpeechBackend {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+
+        guard let backend = Self.normalized(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "SpeakSwiftly could not decode speech backend '\(rawValue)' because it is not one of the supported backend identifiers.",
+            )
+        }
+
+        self = backend
     }
 }

--- a/Sources/SpeakSwiftly/Playback/PlaybackController.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackController.swift
@@ -19,6 +19,23 @@ actor PlaybackController {
         let concurrentGenerationTargetMS: Int
     }
 
+    struct FragileOverlapWindowConfiguration: Equatable {
+        let holdBufferTargetMS: Int
+        let requiredStableBufferEventCount: Int
+    }
+
+    struct FragileOverlapWindowProgress: Equatable {
+        let configuration: FragileOverlapWindowConfiguration
+        var stableBufferEventCount: Int
+        var hasSatisfiedHold: Bool
+    }
+
+    struct ConcurrencyAdmissionResolution: Equatable {
+        let allowsConcurrentGeneration: Bool
+        let effectiveTargetMS: Int
+        let fragileOverlapWindowProgress: FragileOverlapWindowProgress?
+    }
+
     struct ActivePlayback {
         let requestID: String
         let task: Task<Void, Never>
@@ -44,6 +61,7 @@ actor PlaybackController {
     private var activePlaybackStableBufferedAudioMS: Int?
     private var activePlaybackStableBufferTargetMS: Int?
     private var activePlaybackConcurrentGenerationTargetMS: Int?
+    private var activePlaybackFragileOverlapWindowProgress: FragileOverlapWindowProgress?
     private var activePlaybackIsRebuffering = false
     private var jobs = [String: LiveSpeechPlaybackState]()
     private var queue = [String]()
@@ -76,6 +94,78 @@ actor PlaybackController {
         targetMS: Int,
     ) -> Bool {
         bufferedAudioMS >= targetMS
+    }
+
+    static func fragileOverlapWindowConfiguration(
+        tuningProfile: PlaybackTuningProfile,
+        concurrentGenerationTargetMS: Int,
+        lowWaterTargetMS: Int,
+    ) -> FragileOverlapWindowConfiguration? {
+        guard tuningProfile == .firstDrainedLiveMarvis else { return nil }
+
+        let additionalHoldReserveMS = min(320, max(240, lowWaterTargetMS / 3))
+        return FragileOverlapWindowConfiguration(
+            holdBufferTargetMS: concurrentGenerationTargetMS + additionalHoldReserveMS,
+            requiredStableBufferEventCount: 2,
+        )
+    }
+
+    static func resolveConcurrentGenerationAdmission(
+        bufferedAudioMS: Int,
+        concurrentGenerationTargetMS: Int,
+        fragileOverlapWindowProgress: FragileOverlapWindowProgress?,
+    ) -> ConcurrencyAdmissionResolution {
+        guard var fragileOverlapWindowProgress else {
+            return ConcurrencyAdmissionResolution(
+                allowsConcurrentGeneration: allowsConcurrentGeneration(
+                    bufferedAudioMS: bufferedAudioMS,
+                    targetMS: concurrentGenerationTargetMS,
+                ),
+                effectiveTargetMS: concurrentGenerationTargetMS,
+                fragileOverlapWindowProgress: nil,
+            )
+        }
+
+        let fragileTargetMS = fragileOverlapWindowProgress.configuration.holdBufferTargetMS
+
+        if fragileOverlapWindowProgress.hasSatisfiedHold {
+            if bufferedAudioMS < fragileTargetMS {
+                fragileOverlapWindowProgress.hasSatisfiedHold = false
+                fragileOverlapWindowProgress.stableBufferEventCount = 0
+                return ConcurrencyAdmissionResolution(
+                    allowsConcurrentGeneration: false,
+                    effectiveTargetMS: fragileTargetMS,
+                    fragileOverlapWindowProgress: fragileOverlapWindowProgress,
+                )
+            }
+
+            return ConcurrencyAdmissionResolution(
+                allowsConcurrentGeneration: true,
+                effectiveTargetMS: concurrentGenerationTargetMS,
+                fragileOverlapWindowProgress: fragileOverlapWindowProgress,
+            )
+        }
+
+        if bufferedAudioMS >= fragileTargetMS {
+            fragileOverlapWindowProgress.stableBufferEventCount += 1
+        } else {
+            fragileOverlapWindowProgress.stableBufferEventCount = 0
+        }
+
+        if fragileOverlapWindowProgress.stableBufferEventCount >= fragileOverlapWindowProgress.configuration.requiredStableBufferEventCount {
+            fragileOverlapWindowProgress.hasSatisfiedHold = true
+            return ConcurrencyAdmissionResolution(
+                allowsConcurrentGeneration: true,
+                effectiveTargetMS: concurrentGenerationTargetMS,
+                fragileOverlapWindowProgress: fragileOverlapWindowProgress,
+            )
+        }
+
+        return ConcurrencyAdmissionResolution(
+            allowsConcurrentGeneration: false,
+            effectiveTargetMS: fragileTargetMS,
+            fragileOverlapWindowProgress: fragileOverlapWindowProgress,
+        )
     }
 
     // MARK: - Binding
@@ -257,6 +347,7 @@ actor PlaybackController {
         activePlaybackStableBufferedAudioMS = nil
         activePlaybackStableBufferTargetMS = nil
         activePlaybackConcurrentGenerationTargetMS = nil
+        activePlaybackFragileOverlapWindowProgress = nil
         activePlaybackIsRebuffering = false
         playbackState.execution.playbackTask = task
     }
@@ -333,6 +424,7 @@ actor PlaybackController {
         activePlaybackStableBufferedAudioMS = nil
         activePlaybackStableBufferTargetMS = nil
         activePlaybackConcurrentGenerationTargetMS = nil
+        activePlaybackFragileOverlapWindowProgress = nil
         activePlaybackIsRebuffering = false
         queue.removeAll { $0 == requestID }
 
@@ -359,27 +451,48 @@ actor PlaybackController {
                     lowWaterTargetMS: thresholds.lowWaterTargetMS,
                 )
                 activePlaybackConcurrentGenerationTargetMS = admissionThresholds.concurrentGenerationTargetMS
-                activePlaybackStableBufferedAudioMS = startupBufferedAudioMS
-                activePlaybackStableBufferTargetMS = admissionThresholds.concurrentGenerationTargetMS
-                activePlaybackIsStableForConcurrentGeneration = Self.allowsConcurrentGeneration(
+                if let fragileOverlapWindowConfiguration = Self.fragileOverlapWindowConfiguration(
+                    tuningProfile: requestTuningProfile,
+                    concurrentGenerationTargetMS: admissionThresholds.concurrentGenerationTargetMS,
+                    lowWaterTargetMS: thresholds.lowWaterTargetMS,
+                ) {
+                    activePlaybackFragileOverlapWindowProgress = FragileOverlapWindowProgress(
+                        configuration: fragileOverlapWindowConfiguration,
+                        stableBufferEventCount: 0,
+                        hasSatisfiedHold: false,
+                    )
+                } else {
+                    activePlaybackFragileOverlapWindowProgress = nil
+                }
+                applyConcurrentGenerationAdmission(
                     bufferedAudioMS: startupBufferedAudioMS,
-                    targetMS: admissionThresholds.concurrentGenerationTargetMS,
+                    concurrentGenerationTargetMS: admissionThresholds.concurrentGenerationTargetMS,
                 )
                 activePlaybackIsRebuffering = false
             case .rebufferStarted:
                 activePlaybackIsStableForConcurrentGeneration = false
+                if var fragileOverlapWindowProgress = activePlaybackFragileOverlapWindowProgress {
+                    fragileOverlapWindowProgress.hasSatisfiedHold = false
+                    fragileOverlapWindowProgress.stableBufferEventCount = 0
+                    activePlaybackFragileOverlapWindowProgress = fragileOverlapWindowProgress
+                    activePlaybackStableBufferTargetMS = fragileOverlapWindowProgress.configuration.holdBufferTargetMS
+                }
                 activePlaybackIsRebuffering = true
             case let .rebufferResumed(bufferedAudioMS, thresholds):
-                activePlaybackIsStableForConcurrentGeneration = Self.allowsConcurrentGeneration(
-                    bufferedAudioMS: bufferedAudioMS,
-                    targetMS: thresholds.resumeBufferTargetMS,
-                )
-                activePlaybackStableBufferedAudioMS = bufferedAudioMS
-                activePlaybackStableBufferTargetMS = thresholds.resumeBufferTargetMS
                 activePlaybackConcurrentGenerationTargetMS = thresholds.resumeBufferTargetMS
+                applyConcurrentGenerationAdmission(
+                    bufferedAudioMS: bufferedAudioMS,
+                    concurrentGenerationTargetMS: thresholds.resumeBufferTargetMS,
+                )
                 activePlaybackIsRebuffering = false
             case .starved:
                 activePlaybackIsStableForConcurrentGeneration = false
+                if var fragileOverlapWindowProgress = activePlaybackFragileOverlapWindowProgress {
+                    fragileOverlapWindowProgress.hasSatisfiedHold = false
+                    fragileOverlapWindowProgress.stableBufferEventCount = 0
+                    activePlaybackFragileOverlapWindowProgress = fragileOverlapWindowProgress
+                    activePlaybackStableBufferTargetMS = fragileOverlapWindowProgress.configuration.holdBufferTargetMS
+                }
                 activePlaybackIsRebuffering = true
             case let .trace(trace):
                 guard
@@ -389,14 +502,23 @@ actor PlaybackController {
                     let queuedAudioAfterMS = trace.queuedAudioAfterMS,
                     let concurrentGenerationTargetMS = activePlaybackConcurrentGenerationTargetMS
                 else {
+                    if
+                        trace.name == "buffer_scheduled",
+                        !activePlaybackIsRebuffering,
+                        let queuedAudioAfterMS = trace.queuedAudioAfterMS,
+                        let concurrentGenerationTargetMS = activePlaybackConcurrentGenerationTargetMS
+                    {
+                        applyConcurrentGenerationAdmission(
+                            bufferedAudioMS: queuedAudioAfterMS,
+                            concurrentGenerationTargetMS: concurrentGenerationTargetMS,
+                        )
+                    }
                     break
                 }
 
-                activePlaybackStableBufferedAudioMS = queuedAudioAfterMS
-                activePlaybackStableBufferTargetMS = concurrentGenerationTargetMS
-                activePlaybackIsStableForConcurrentGeneration = Self.allowsConcurrentGeneration(
+                applyConcurrentGenerationAdmission(
                     bufferedAudioMS: queuedAudioAfterMS,
-                    targetMS: concurrentGenerationTargetMS,
+                    concurrentGenerationTargetMS: concurrentGenerationTargetMS,
                 )
             case .firstChunk,
                  .queueDepthLow,
@@ -408,5 +530,20 @@ actor PlaybackController {
                  .bufferShapeSummary:
                 break
         }
+    }
+
+    private func applyConcurrentGenerationAdmission(
+        bufferedAudioMS: Int,
+        concurrentGenerationTargetMS: Int,
+    ) {
+        let resolution = Self.resolveConcurrentGenerationAdmission(
+            bufferedAudioMS: bufferedAudioMS,
+            concurrentGenerationTargetMS: concurrentGenerationTargetMS,
+            fragileOverlapWindowProgress: activePlaybackFragileOverlapWindowProgress,
+        )
+        activePlaybackStableBufferedAudioMS = bufferedAudioMS
+        activePlaybackStableBufferTargetMS = resolution.effectiveTargetMS
+        activePlaybackIsStableForConcurrentGeneration = resolution.allowsConcurrentGeneration
+        activePlaybackFragileOverlapWindowProgress = resolution.fragileOverlapWindowProgress
     }
 }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Bootstrap.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Bootstrap.swift
@@ -132,7 +132,7 @@ extension SpeakSwiftly.Runtime {
     static func resolvedQwenConditioningStrategy(
         configuration: SpeakSwiftly.Configuration?,
     ) -> SpeakSwiftly.QwenConditioningStrategy {
-        configuration?.qwenConditioningStrategy ?? .legacyRaw
+        configuration?.qwenConditioningStrategy ?? .preparedConditioning
     }
 
     private static func resolvedPersistedConfiguration(

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
@@ -364,7 +364,7 @@ public extension SpeakSwiftly {
         init(
             dependencies: WorkerDependencies,
             speechBackend: SpeakSwiftly.SpeechBackend,
-            qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .legacyRaw,
+            qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .preparedConditioning,
             profileStore: ProfileStore,
             generatedFileStore: GeneratedFileStore,
             generationJobStore: GenerationJobStore,

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+ResidentModels.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+ResidentModels.swift
@@ -6,7 +6,7 @@ import TextForSpeech
 extension SpeakSwiftly.Runtime {
     func preloadModelRepos(for speechBackend: SpeakSwiftly.SpeechBackend) -> [String] {
         switch speechBackend {
-            case .qwen3, .qwen3CustomVoice:
+            case .qwen3:
                 [ModelFactory.residentModelRepo(for: speechBackend)]
             case .marvis:
                 [ModelFactory.marvisResidentModelRepo]

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift
@@ -178,7 +178,7 @@ extension SpeakSwiftly.Runtime {
         switch backend {
             case .marvis:
                 2
-            case .qwen3, .qwen3CustomVoice:
+            case .qwen3:
                 1
         }
     }

--- a/Sources/SpeakSwiftly/Storage/ProfileStore+ManifestIO.swift
+++ b/Sources/SpeakSwiftly/Storage/ProfileStore+ManifestIO.swift
@@ -7,10 +7,11 @@ extension ProfileStore {
     func loadManifest(from directoryURL: URL) throws -> ProfileManifest {
         let manifestPath = manifestURL(for: directoryURL)
         let manifestData = try Data(contentsOf: manifestPath)
+        let requiresLegacyQwenNormalization = manifestDataRequiresLegacyQwenNormalization(manifestData)
 
         if let manifest = try? decoder.decode(ProfileManifest.self, from: manifestData) {
             let upgradedManifest = upgradeStoredManifest(manifest)
-            if upgradedManifest != manifest {
+            if requiresLegacyQwenNormalization || upgradedManifest != manifest {
                 try writeManifest(upgradedManifest, to: directoryURL)
             }
             return upgradedManifest
@@ -105,12 +106,12 @@ extension ProfileStore {
     }
 
     func upgradeStoredManifest(_ manifest: ProfileManifest) -> ProfileManifest {
-        guard manifest.version < Self.manifestVersion else {
-            return manifest
-        }
+        let normalizedMaterializations = manifest.backendMaterializations.map(normalizeQwenMaterialization)
+        let normalizedArtifacts = manifest.qwenConditioningArtifacts.map(normalizeQwenConditioningArtifactManifest)
+        let normalizedVersion = max(manifest.version, Self.manifestVersion)
 
         return ProfileManifest(
-            version: Self.manifestVersion,
+            version: normalizedVersion,
             profileName: manifest.profileName,
             vibe: manifest.vibe,
             createdAt: manifest.createdAt,
@@ -120,8 +121,50 @@ extension ProfileStore {
             sourceText: manifest.sourceText,
             transcriptProvenance: manifest.transcriptProvenance,
             sampleRate: manifest.sampleRate,
-            backendMaterializations: manifest.backendMaterializations,
-            qwenConditioningArtifacts: manifest.qwenConditioningArtifacts,
+            backendMaterializations: normalizedMaterializations,
+            qwenConditioningArtifacts: normalizedArtifacts,
+        )
+    }
+
+    func manifestDataRequiresLegacyQwenNormalization(_ manifestData: Data) -> Bool {
+        guard let manifestText = String(data: manifestData, encoding: .utf8) else {
+            return false
+        }
+
+        return manifestText.contains(SpeakSwiftly.SpeechBackend.legacyQwenCustomVoiceRawValue)
+            || manifestText.contains(ModelFactory.legacyQwenCustomVoiceResidentModelRepo)
+    }
+
+    func normalizeQwenMaterialization(
+        _ materialization: ProfileMaterializationManifest,
+    ) -> ProfileMaterializationManifest {
+        guard materialization.backend.isQwenFamily else {
+            return materialization
+        }
+
+        return ProfileMaterializationManifest(
+            backend: .qwen3,
+            modelRepo: ModelFactory.residentModelRepo(for: .qwen3),
+            createdAt: materialization.createdAt,
+            referenceAudioFile: materialization.referenceAudioFile,
+            referenceText: materialization.referenceText,
+            sampleRate: materialization.sampleRate,
+        )
+    }
+
+    func normalizeQwenConditioningArtifactManifest(
+        _ manifest: QwenConditioningArtifactManifest,
+    ) -> QwenConditioningArtifactManifest {
+        guard manifest.backend.isQwenFamily else {
+            return manifest
+        }
+
+        return QwenConditioningArtifactManifest(
+            backend: .qwen3,
+            modelRepo: ModelFactory.residentModelRepo(for: .qwen3),
+            createdAt: manifest.createdAt,
+            artifactVersion: manifest.artifactVersion,
+            artifactFile: manifest.artifactFile,
         )
     }
 

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -25,6 +25,13 @@ import TextForSpeech
     #expect(configuration.textNormalizer == nil)
 }
 
+@Test func `public configuration defaults qwen to prepared conditioning`() {
+    let configuration = SpeakSwiftly.Configuration()
+
+    #expect(configuration.speechBackend == .qwen3)
+    #expect(configuration.qwenConditioningStrategy == .preparedConditioning)
+}
+
 @Test func `public configuration round trips to disk`() throws {
     let rootURL = URL(fileURLWithPath: NSTemporaryDirectory())
         .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -52,6 +59,28 @@ import TextForSpeech
     #expect(throws: SpeakSwiftly.Configuration.LoadError.self) {
         try SpeakSwiftly.Configuration.load(from: missingURL)
     }
+}
+
+@Test func `public configuration normalizes the legacy qwen custom voice backend`() throws {
+    let rootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let persistenceURL = rootURL.appendingPathComponent("configuration.json")
+    let legacyConfigurationJSON = """
+    {
+      "qwenConditioningStrategy" : "legacy_raw",
+      "speechBackend" : "qwen3_custom_voice"
+    }
+    """
+
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    try Data(legacyConfigurationJSON.utf8).write(to: persistenceURL, options: .atomic)
+
+    let loaded = try SpeakSwiftly.Configuration.load(from: persistenceURL)
+
+    #expect(loaded.speechBackend == .qwen3)
+    #expect(loaded.qwenConditioningStrategy == .legacyRaw)
 }
 
 @Test func `public configuration can carry A text normalizer`() throws {

--- a/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
@@ -350,16 +350,18 @@ extension SpeakSwiftlyE2ETests {
                     let details = $0["details"] as? [String: Any],
                     let activeGenerationRequestIDs = details["active_generation_request_ids"] as? String,
                     let activeMarvisGenerationLanes = details["active_marvis_generation_lanes"] as? String,
+                    let queuedGenerationRequestIDs = details["queued_generation_request_ids"] as? String,
                     let parkedGenerationReasons = details["parked_generation_reasons"] as? String
                 else {
                     return false
                 }
 
                 return activeGenerationRequestIDs.contains(lanes[0].liveID)
-                    && activeGenerationRequestIDs.contains(lanes[1].liveID)
+                    && !activeGenerationRequestIDs.contains(lanes[1].liveID)
                     && activeMarvisGenerationLanes.contains("\(lanes[0].liveID):\(lanes[0].expectedVoice)")
-                    && activeMarvisGenerationLanes.contains("\(lanes[1].liveID):\(lanes[1].expectedVoice)")
-                    && parkedGenerationReasons.contains("\(lanes[2].liveID):waiting_for_marvis_generation_lane")
+                    && queuedGenerationRequestIDs.contains(lanes[1].liveID)
+                    && parkedGenerationReasons.contains("\(lanes[1].liveID):waiting_for_playback_stability")
+                    && queuedGenerationRequestIDs.contains(lanes[2].liveID)
             } != nil)
 
             for lane in lanes {

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import SpeakSwiftly
 import Testing
 
-private let qwenBenchmarkSchemaVersion = 2
+private let qwenBenchmarkSchemaVersion = 3
 
 // MARK: - SpeakSwiftlyE2ETests.QwenBenchmarkSuite
 
@@ -15,7 +15,7 @@ extension SpeakSwiftlyE2ETests {
         ),
     )
     struct QwenBenchmarkSuite {
-        @Test func `compare resident backends`() async throws {
+        @Test func `compare qwen conditioning strategies`() async throws {
             let sandbox = try E2ESandbox()
             defer { sandbox.cleanup() }
 
@@ -25,12 +25,12 @@ extension SpeakSwiftlyE2ETests {
             var samples = [QwenBenchmarkSample]()
             samples.reserveCapacity(iterations * 2)
 
-            for backend in [SpeakSwiftly.SpeechBackend.qwen3, .qwen3CustomVoice] {
+            for strategy in [SpeakSwiftly.QwenConditioningStrategy.legacyRaw, .preparedConditioning] {
                 for iteration in 1...iterations {
                     try await samples.append(
                         Self.runBenchmarkSample(
                             profileRootURL: sandbox.profileRootURL,
-                            backend: backend,
+                            strategy: strategy,
                             iteration: iteration,
                         ),
                     )
@@ -46,13 +46,13 @@ extension SpeakSwiftlyE2ETests {
                     benchmarkProfileName: Self.benchmarkProfileName,
                     playbackTextCharacterCount: SpeakSwiftlyE2ETests.testingPlaybackText.count,
                 ),
-                backends: QwenBackendBenchmarkReport.make(from: samples),
+                strategies: QwenConditioningStrategyBenchmarkReport.make(from: samples),
             )
             let summaryURL = try Self.writeBenchmarkSummary(summary)
 
             print("SpeakSwiftly qwen benchmark summary: \(summaryURL.path)")
-            for backend in summary.backends {
-                print(backend.prettyDescription)
+            for strategy in summary.strategies {
+                print(strategy.prettyDescription)
             }
         }
     }
@@ -62,7 +62,11 @@ private extension SpeakSwiftlyE2ETests.QwenBenchmarkSuite {
     static let benchmarkProfileName = "benchmark-profile"
 
     static func provisionBenchmarkProfile(in profileRootURL: URL) async throws {
-        try await withBenchmarkRuntime(profileRootURL: profileRootURL, backend: .qwen3) { runtime in
+        try await withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: .qwen3,
+            qwenConditioningStrategy: .preparedConditioning,
+        ) { runtime in
             _ = try await awaitResidentReady(on: runtime)
 
             let handle = await runtime.voices.create(
@@ -77,10 +81,14 @@ private extension SpeakSwiftlyE2ETests.QwenBenchmarkSuite {
 
     static func runBenchmarkSample(
         profileRootURL: URL,
-        backend: SpeakSwiftly.SpeechBackend,
+        strategy: SpeakSwiftly.QwenConditioningStrategy,
         iteration: Int,
     ) async throws -> QwenBenchmarkSample {
-        try await withBenchmarkRuntime(profileRootURL: profileRootURL, backend: backend) { runtime in
+        try await withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: .qwen3,
+            qwenConditioningStrategy: strategy,
+        ) { runtime in
             let preloadMS = try await awaitResidentReady(on: runtime)
             let generatedFile = try await runRequestBenchmark(
                 handle: runtime.generate.audio(
@@ -96,7 +104,7 @@ private extension SpeakSwiftlyE2ETests.QwenBenchmarkSuite {
             )
 
             return QwenBenchmarkSample(
-                backend: backend,
+                strategy: strategy,
                 iteration: iteration,
                 residentPreloadMS: preloadMS,
                 generatedFile: generatedFile,
@@ -108,11 +116,13 @@ private extension SpeakSwiftlyE2ETests.QwenBenchmarkSuite {
     static func withBenchmarkRuntime<T>(
         profileRootURL: URL,
         backend: SpeakSwiftly.SpeechBackend,
+        qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
         operation: @escaping @Sendable (SpeakSwiftly.Runtime) async throws -> T,
     ) async throws -> T {
         let runtime = try await makeBenchmarkRuntime(
             profileRootURL: profileRootURL,
             backend: backend,
+            qwenConditioningStrategy: qwenConditioningStrategy,
         )
 
         do {
@@ -128,6 +138,7 @@ private extension SpeakSwiftlyE2ETests.QwenBenchmarkSuite {
     static func makeBenchmarkRuntime(
         profileRootURL: URL,
         backend: SpeakSwiftly.SpeechBackend,
+        qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
     ) async throws -> SpeakSwiftly.Runtime {
         _ = try SpeakSwiftly.SupportResources.mlxBundleURL()
         _ = try SpeakSwiftly.SupportResources.defaultMetallibURL()
@@ -172,6 +183,7 @@ private extension SpeakSwiftlyE2ETests.QwenBenchmarkSuite {
         let runtime = SpeakSwiftly.Runtime(
             dependencies: dependencies,
             speechBackend: backend,
+            qwenConditioningStrategy: qwenConditioningStrategy,
             profileStore: profileStore,
             generatedFileStore: generatedFileStore,
             generationJobStore: generationJobStore,
@@ -396,7 +408,7 @@ private struct QwenBenchmarkSummary: Codable {
     let generatedAt: Date
     let host: QwenBenchmarkHost
     let settings: QwenBenchmarkSettings
-    let backends: [QwenBackendBenchmarkReport]
+    let strategies: [QwenConditioningStrategyBenchmarkReport]
 }
 
 // MARK: - QwenBenchmarkHost
@@ -438,7 +450,7 @@ private struct QwenBenchmarkSettings: Codable {
     let playbackTextCharacterCount: Int
     let timestampedSummaryPattern: String
     let latestSummaryFilename: String
-    let comparedBackends: [SpeakSwiftly.SpeechBackend]
+    let comparedStrategies: [SpeakSwiftly.QwenConditioningStrategy]
 
     static func current(
         iterations: Int,
@@ -451,15 +463,15 @@ private struct QwenBenchmarkSettings: Codable {
             playbackTextCharacterCount: playbackTextCharacterCount,
             timestampedSummaryPattern: "qwen-resident-benchmark-<ISO8601>.json",
             latestSummaryFilename: "qwen-resident-benchmark-latest.json",
-            comparedBackends: [.qwen3, .qwen3CustomVoice],
+            comparedStrategies: [.legacyRaw, .preparedConditioning],
         )
     }
 }
 
-// MARK: - QwenBackendBenchmarkReport
+// MARK: - QwenConditioningStrategyBenchmarkReport
 
-private struct QwenBackendBenchmarkReport: Codable {
-    let backend: SpeakSwiftly.SpeechBackend
+private struct QwenConditioningStrategyBenchmarkReport: Codable {
+    let strategy: SpeakSwiftly.QwenConditioningStrategy
     let sampleCount: Int
     let residentPreloadMS: QwenMetricSummary
     let generatedFile: QwenRequestBenchmarkAggregate
@@ -468,30 +480,30 @@ private struct QwenBackendBenchmarkReport: Codable {
 
     var prettyDescription: String {
         """
-        \(backend.rawValue): preload \(residentPreloadMS.prettyAverage) ms, file complete \(generatedFile.lifecycle.completedMS.prettyAverage) ms, file first audio \(generatedFile.generation.firstAudioChunkMS.prettyAverage) ms, live complete \(liveSpeech.lifecycle.completedMS.prettyAverage) ms, live first audio \(liveSpeech.generation.firstAudioChunkMS.prettyAverage) ms, live preroll \(liveSpeech.lifecycle.prerollReadyMS.prettyAverage) ms, tokens/s \(generatedFile.generation.tokensPerSecond.prettyAverage), peak memory \(generatedFile.generation.peakMemoryUsageGB.prettyAverage) GB
+        \(strategy.rawValue): preload \(residentPreloadMS.prettyAverage) ms, file complete \(generatedFile.lifecycle.completedMS.prettyAverage) ms, file first audio \(generatedFile.generation.firstAudioChunkMS.prettyAverage) ms, live complete \(liveSpeech.lifecycle.completedMS.prettyAverage) ms, live first audio \(liveSpeech.generation.firstAudioChunkMS.prettyAverage) ms, live preroll \(liveSpeech.lifecycle.prerollReadyMS.prettyAverage) ms, tokens/s \(generatedFile.generation.tokensPerSecond.prettyAverage), peak memory \(generatedFile.generation.peakMemoryUsageGB.prettyAverage) GB
         """
     }
 
     static func make(from samples: [QwenBenchmarkSample]) -> [Self] {
-        Dictionary(grouping: samples, by: \.backend)
-            .map { backend, backendSamples in
+        Dictionary(grouping: samples, by: \.strategy)
+            .map { strategy, strategySamples in
                 Self(
-                    backend: backend,
-                    sampleCount: backendSamples.count,
-                    residentPreloadMS: .make(from: backendSamples.map(\.residentPreloadMS)),
-                    generatedFile: .make(from: backendSamples.map(\.generatedFile)),
-                    liveSpeech: .make(from: backendSamples.map(\.liveSpeech)),
-                    samples: backendSamples.sorted { $0.iteration < $1.iteration },
+                    strategy: strategy,
+                    sampleCount: strategySamples.count,
+                    residentPreloadMS: .make(from: strategySamples.map(\.residentPreloadMS)),
+                    generatedFile: .make(from: strategySamples.map(\.generatedFile)),
+                    liveSpeech: .make(from: strategySamples.map(\.liveSpeech)),
+                    samples: strategySamples.sorted { $0.iteration < $1.iteration },
                 )
             }
-            .sorted { $0.backend.rawValue < $1.backend.rawValue }
+            .sorted { $0.strategy.rawValue < $1.strategy.rawValue }
     }
 }
 
 // MARK: - QwenBenchmarkSample
 
 private struct QwenBenchmarkSample: Codable {
-    let backend: SpeakSwiftly.SpeechBackend
+    let strategy: SpeakSwiftly.QwenConditioningStrategy
     let iteration: Int
     let residentPreloadMS: Double
     let generatedFile: QwenRequestBenchmark

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
@@ -729,7 +729,7 @@ final class WorkerProcess: @unchecked Sendable {
         }
 
         process.executableURL = executableURL
-        process.standardInput = stdinPipe
+        process.standardInput = stdinPipe.fileHandleForReading
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
         process.currentDirectoryURL = executableURL.deletingLastPathComponent()

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -325,6 +325,26 @@ import TextForSpeech
     #expect(firstRequestAdmission.concurrentGenerationTargetMS > firstRequestAdmission.startupBufferTargetMS)
 }
 
+@Test func `first drained live marvis adds a short fragile overlap hold above the ordinary target`() {
+    let configuration = PlaybackController.fragileOverlapWindowConfiguration(
+        tuningProfile: .firstDrainedLiveMarvis,
+        concurrentGenerationTargetMS: 2800,
+        lowWaterTargetMS: 1040,
+    )
+
+    #expect(configuration == PlaybackController.FragileOverlapWindowConfiguration(
+        holdBufferTargetMS: 3120,
+        requiredStableBufferEventCount: 2,
+    ))
+    #expect(
+        PlaybackController.fragileOverlapWindowConfiguration(
+            tuningProfile: .standard,
+            concurrentGenerationTargetMS: 2800,
+            lowWaterTargetMS: 1040,
+        ) == nil,
+    )
+}
+
 @Test func `concurrent generation stays closed below the claimed reserve target`() {
     #expect(
         PlaybackController.allowsConcurrentGeneration(
@@ -338,6 +358,46 @@ import TextForSpeech
             targetMS: 2700,
         ) == true,
     )
+}
+
+@Test func `fragile overlap window requires a brief healthy hold and re closes when reserve sags`() {
+    let progress = PlaybackController.FragileOverlapWindowProgress(
+        configuration: .init(
+            holdBufferTargetMS: 3120,
+            requiredStableBufferEventCount: 2,
+        ),
+        stableBufferEventCount: 0,
+        hasSatisfiedHold: false,
+    )
+
+    let firstHealthyEvent = PlaybackController.resolveConcurrentGenerationAdmission(
+        bufferedAudioMS: 3200,
+        concurrentGenerationTargetMS: 2800,
+        fragileOverlapWindowProgress: progress,
+    )
+    #expect(firstHealthyEvent.allowsConcurrentGeneration == false)
+    #expect(firstHealthyEvent.effectiveTargetMS == 3120)
+    #expect(firstHealthyEvent.fragileOverlapWindowProgress?.stableBufferEventCount == 1)
+    #expect(firstHealthyEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == false)
+
+    let secondHealthyEvent = PlaybackController.resolveConcurrentGenerationAdmission(
+        bufferedAudioMS: 3250,
+        concurrentGenerationTargetMS: 2800,
+        fragileOverlapWindowProgress: firstHealthyEvent.fragileOverlapWindowProgress,
+    )
+    #expect(secondHealthyEvent.allowsConcurrentGeneration == true)
+    #expect(secondHealthyEvent.effectiveTargetMS == 2800)
+    #expect(secondHealthyEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == true)
+
+    let collapsingReserveEvent = PlaybackController.resolveConcurrentGenerationAdmission(
+        bufferedAudioMS: 3000,
+        concurrentGenerationTargetMS: 2800,
+        fragileOverlapWindowProgress: secondHealthyEvent.fragileOverlapWindowProgress,
+    )
+    #expect(collapsingReserveEvent.allowsConcurrentGeneration == false)
+    #expect(collapsingReserveEvent.effectiveTargetMS == 3120)
+    #expect(collapsingReserveEvent.fragileOverlapWindowProgress?.stableBufferEventCount == 0)
+    #expect(collapsingReserveEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == false)
 }
 
 @Test func `adaptive playback thresholds leave warmup after stable chunk cadence`() {

--- a/Tests/SpeakSwiftlyTests/Generation/ProfileStoreTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ProfileStoreTests.swift
@@ -420,13 +420,13 @@ import Testing
 
     let stored = try store.storeQwenConditioningArtifact(
         named: "default-femme",
-        backend: .qwen3CustomVoice,
-        modelRepo: ModelFactory.residentModelRepo(for: .qwen3CustomVoice),
+        backend: .qwen3,
+        modelRepo: ModelFactory.residentModelRepo(for: .qwen3),
         conditioning: conditioning,
         createdAt: Date(timeIntervalSince1970: 1_712_800_000),
     )
 
-    let artifact = try #require(stored.qwenConditioningArtifact(for: .qwen3CustomVoice))
+    let artifact = try #require(stored.qwenConditioningArtifact(for: .qwen3))
     #expect(stored.manifest.qwenConditioningArtifacts.count == 1)
     #expect(fileManager.fileExists(atPath: artifact.artifactURL.path))
 
@@ -439,4 +439,63 @@ import Testing
     #expect(reloadedConditioning.referenceTextTokenIDs.asArray(Int32.self) == [101, 102, 103])
     #expect(reloadedConditioning.referenceTextTokenIDs.shape == [1, 3])
     #expect(reloadedConditioning.speakerEmbedding?.asArray(Float.self) == [0.25, 0.5])
+}
+
+@Test func `loads and normalizes legacy custom voice qwen artifact metadata`() throws {
+    let fileManager = FileManager.default
+    let tempRoot = makeTempDirectoryURL()
+    defer { try? fileManager.removeItem(at: tempRoot) }
+
+    let store = ProfileStore(rootURL: tempRoot, fileManager: fileManager)
+    let profileDirectory = store.profileDirectoryURL(for: "legacy-custom-voice")
+    try fileManager.createDirectory(at: profileDirectory, withIntermediateDirectories: true)
+    try Data([0x52, 0x49, 0x46, 0x46]).write(to: profileDirectory.appendingPathComponent(ProfileStore.audioFileName))
+    try Data("{}".utf8).write(
+        to: profileDirectory.appendingPathComponent("qwen-conditioning-\(SpeakSwiftly.SpeechBackend.legacyQwenCustomVoiceRawValue).json"),
+    )
+
+    let legacyManifestJSON = """
+    {
+      "backendMaterializations" : [
+        {
+          "backend" : "qwen3_custom_voice",
+          "createdAt" : "2026-04-16T00:00:00Z",
+          "modelRepo" : "\(ModelFactory.legacyQwenCustomVoiceResidentModelRepo)",
+          "referenceAudioFile" : "\(ProfileStore.audioFileName)",
+          "referenceText" : "Legacy custom voice transcript",
+          "sampleRate" : 24000
+        }
+      ],
+      "createdAt" : "2026-04-16T00:00:00Z",
+      "modelRepo" : "test-model",
+      "profileName" : "legacy-custom-voice",
+      "qwenConditioningArtifacts" : [
+        {
+          "artifactFile" : "qwen-conditioning-\(SpeakSwiftly.SpeechBackend.legacyQwenCustomVoiceRawValue).json",
+          "artifactVersion" : 1,
+          "backend" : "qwen3_custom_voice",
+          "createdAt" : "2026-04-16T00:00:00Z",
+          "modelRepo" : "\(ModelFactory.legacyQwenCustomVoiceResidentModelRepo)"
+        }
+      ],
+      "sampleRate" : 24000,
+      "sourceKind" : "generated",
+      "sourceText" : "Legacy custom voice transcript",
+      "version" : 5,
+      "vibe" : "femme",
+      "voiceDescription" : "Legacy custom voice profile."
+    }
+    """
+
+    try Data(legacyManifestJSON.utf8).write(to: store.manifestURL(for: profileDirectory))
+
+    let loaded = try store.loadProfile(named: "legacy-custom-voice")
+    let materialization = try loaded.qwenMaterialization(for: .qwen3)
+    let artifact = try #require(loaded.qwenConditioningArtifact(for: .qwen3))
+
+    #expect(materialization.manifest.backend == .qwen3)
+    #expect(materialization.manifest.modelRepo == ModelFactory.residentModelRepo(for: .qwen3))
+    #expect(artifact.manifest.backend == .qwen3)
+    #expect(artifact.manifest.modelRepo == ModelFactory.residentModelRepo(for: .qwen3))
+    #expect(artifact.artifactURL.lastPathComponent == "qwen-conditioning-\(SpeakSwiftly.SpeechBackend.legacyQwenCustomVoiceRawValue).json")
 }

--- a/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
@@ -571,7 +571,7 @@ func makeResidentModels(
     chunkCount: Int = 1,
 ) -> ResidentSpeechModels {
     switch backend {
-        case .qwen3, .qwen3CustomVoice:
+        case .qwen3:
             .qwen3(makeResidentModel(recorder: recorder, chunkCount: chunkCount))
         case .marvis:
             .marvis(
@@ -638,7 +638,7 @@ func makeRuntime(
     output: OutputRecorder,
     playback: PlaybackSpy,
     speechBackend: SpeakSwiftly.SpeechBackend = .qwen3,
-    qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .legacyRaw,
+    qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .preparedConditioning,
     audioLoadRecorder: ResidentModelRecorder? = nil,
     loadedAudioSamples: MLXArray? = nil,
     loadedCloneAudioSamples: [Float] = [],
@@ -667,7 +667,7 @@ func makeRuntime(
             }
             if let model = loaded as? AnySpeechModel {
                 switch backend {
-                    case .qwen3, .qwen3CustomVoice:
+                    case .qwen3:
                         return .qwen3(model)
                     case .marvis:
                         return .marvis(

--- a/docs/maintainers/marvis-overlap-profiling-runbook-2026-04-16.md
+++ b/docs/maintainers/marvis-overlap-profiling-runbook-2026-04-16.md
@@ -322,7 +322,6 @@ So a backend such as:
 would fit naturally beside:
 
 - `qwen3`
-- `qwen3_custom_voice`
 - `marvis`
 
 The near-term use case it unlocks is simple:

--- a/docs/maintainers/marvis-overlap-profiling-runbook-2026-04-16.md
+++ b/docs/maintainers/marvis-overlap-profiling-runbook-2026-04-16.md
@@ -98,7 +98,8 @@ xcodebuild build-for-testing -quiet \
 
 The `.xctestrun` file produced by `build-for-testing` does not carry the e2e
 gate and playback trace environment on its own. Patch it before each scenario
-session:
+session. On current Xcode manifests, the override lives under
+`TestConfigurations -> TestTargets -> EnvironmentVariables`:
 
 ```bash
 uv run python - <<'PY'
@@ -113,10 +114,11 @@ xctestrun_path = Path(
 with xctestrun_path.open("rb") as f:
     data = plistlib.load(f)
 
-for target in data.values():
-    env = target.setdefault("EnvironmentVariables", {})
-    env["SPEAKSWIFTLY_E2E"] = "1"
-    env["SPEAKSWIFTLY_PLAYBACK_TRACE"] = "1"
+for config in data.get("TestConfigurations", []):
+    for target in config.get("TestTargets", []):
+        env = target.setdefault("EnvironmentVariables", {})
+        env["SPEAKSWIFTLY_E2E"] = "1"
+        env["SPEAKSWIFTLY_PLAYBACK_TRACE"] = "1"
 
 with xctestrun_path.open("wb") as f:
     plistlib.dump(data, f)

--- a/docs/maintainers/qwen-base-default-migration-plan-2026-04-16.md
+++ b/docs/maintainers/qwen-base-default-migration-plan-2026-04-16.md
@@ -1,0 +1,81 @@
+## Qwen Base Default Migration Plan
+
+Date: 2026-04-16
+
+### Why this change exists
+
+This is a durable building-block cleanup, not a local stopgap.
+
+The near-term use case it unlocks is a cleaner and more accurate Qwen clone story in `SpeakSwiftly`: one resident Qwen backend built around the Base model's documented reference-conditioning path, with reusable prepared conditioning enabled by default for clone-style generation.
+
+The simpler path considered first was: leave `qwen3_custom_voice` in place, point callers toward `qwen3` informally, and slowly stop mentioning the custom-voice backend in docs. That path would leave a misleading runtime surface behind, keep benchmarks aimed at the wrong comparison, and make stored config and artifact semantics harder to reason about over time.
+
+### Documentation relied on
+
+- Apple `Decodable.init(from:)`: https://developer.apple.com/documentation/swift/decodable/init%28from%3A%29
+- Apple `RawRepresentable`: https://developer.apple.com/documentation/swift/rawrepresentable
+- Apple "Encoding and Decoding Custom Types": https://developer.apple.com/documentation/foundation/encoding-and-decoding-custom-types
+- Qwen3-TTS GitHub README: https://github.com/QwenLM/Qwen3-TTS
+- Qwen 0.6B Base model card: https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base
+
+The Swift rule this plan relies on is straightforward: `Decodable` permits custom `init(from:)` implementations, and raw-representable enums already decode through raw values. That means we can safely keep the public runtime config shape stable while explicitly mapping legacy serialized values such as `qwen3_custom_voice` to the surviving `.qwen3` case.
+
+### Current mismatch
+
+Today the package still treats `qwen3` and `qwen3_custom_voice` as separate resident backends even though the clone-focused runtime path is the Qwen prepared-conditioning flow, which already behaves like a reusable clone prompt.
+
+That creates three kinds of drift:
+
+- docs still describe resident backend switching across `qwen3`, `qwen3_custom_voice`, and `marvis`
+- runtime config and stored Qwen conditioning artifacts can persist `qwen3_custom_voice`
+- the opt-in benchmark suite compares two Qwen model repos instead of comparing the two Qwen conditioning strategies we actually care about
+
+### Decision
+
+Collapse the standalone `qwen3_custom_voice` backend into `qwen3`.
+
+After this change:
+
+- `.qwen3` is the only Qwen resident backend
+- the resident Qwen repo is the Base model repo
+- clone-oriented Qwen generation defaults to prepared conditioning
+- legacy serialized `qwen3_custom_voice` values continue to decode and are normalized onto `.qwen3`
+
+### Compatibility plan
+
+#### Runtime configuration
+
+- keep `SpeakSwiftly.Configuration` as the persisted shape
+- add explicit decode compatibility so old `speechBackend: "qwen3_custom_voice"` values load as `.qwen3`
+- always re-encode the normalized `.qwen3` value
+
+#### Stored profile materializations and conditioning artifacts
+
+- keep existing profile manifests readable when a materialization or conditioning artifact still says `qwen3_custom_voice`
+- normalize that legacy backend to `.qwen3` when loading manifests and artifacts
+- let later saves rewrite normalized manifests so the legacy backend tag gradually disappears from disk
+
+#### Environment surface
+
+- accept `SPEAKSWIFTLY_SPEECH_BACKEND=qwen3_custom_voice` as a legacy alias for `qwen3`
+- keep the operator-facing result normalized to `qwen3`
+
+### Implementation steps
+
+1. Remove the `qwen3CustomVoice` enum case from the public backend surface.
+2. Add explicit legacy alias decoding for config and environment parsing.
+3. Remove the custom-voice resident repo constant and route resident Qwen loading only through the Base model repo.
+4. Normalize stored backend materializations and stored Qwen conditioning artifacts onto `.qwen3` during load.
+5. Make `preparedConditioning` the default Qwen conditioning strategy.
+6. Rewrite docs and tests around one Qwen backend.
+7. Replace the Qwen benchmark comparison from backend-vs-backend to conditioning-strategy-vs-conditioning-strategy.
+
+### Validation target
+
+The intended validation lane for this pass is the fast SwiftPM lane first:
+
+- `swift test --filter ProfileStoreTests`
+- `swift test --filter LibrarySurfaceTests`
+- `swift test --filter QwenBenchmarkSuite` only if the benchmark suite still compiles after the comparison rewrite
+
+If the known vendored parser snag blocks the SwiftPM lane, fall back to the documented Xcode-backed lane afterward.


### PR DESCRIPTION
## Summary
- add the Marvis fragile-first-playback overlap guard and keep the second lane parked until playback stability recovers
- collapse Qwen runtime backend handling onto base Qwen with prepared conditioning as the default path
- bump `mlx-audio-swift` to `v69.1.5` and fix the Marvis e2e harness expectations and stdin shutdown behavior

## Why
This patch train is meant to leave the Marvis and Qwen runtime surfaces in a release-ready state. It includes the upstream Marvis strict-verification fix, the local playback-policy improvement, and the final e2e harness cleanup needed to make the release-grade Xcode validation lane trustworthy.

## Verification
- `xcodebuild build-for-testing -quiet -scheme SpeakSwiftly-Package -destination 'platform=macOS' -derivedDataPath .local/xcode/derived-data/Instruments-MarvisProfile -clonedSourcePackagesDirPath .local/xcode/source-packages`
- `xcodebuild test-without-building -quiet -xctestrun .local/xcode/derived-data/Instruments-MarvisProfile/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/SpeakSwiftlyE2ETests/MarvisWorkflowSuite/\`prequeued jobs drain in order\`()' -resultBundlePath .local/xcode/results/Instruments-MarvisProfile-fragile-window-v69_1_5-clean2.xcresult`
- `xcodebuild test-without-building -quiet -xctestrun .local/xcode/derived-data/Instruments-MarvisProfile/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests'`
- `xcodebuild test-without-building -quiet -xctestrun .local/xcode/derived-data/Instruments-MarvisProfile/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/ProfileStoreTests'`
- `xcodebuild test-without-building -quiet -xctestrun .local/xcode/derived-data/Instruments-MarvisProfile/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/ModelClientsTests'`
- `xcodebuild test-without-building -quiet -xctestrun .local/xcode/derived-data/Instruments-MarvisProfile/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/WorkerRuntimeQueueingTests'`
