### PR TITLE
playback: fix swiftformat brace placement

### DIFF
--- a/Sources/SpeakSwiftly/Playback/PlaybackController.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackController.swift
@@ -506,8 +506,7 @@ actor PlaybackController {
                         trace.name == "buffer_scheduled",
                         !activePlaybackIsRebuffering,
                         let queuedAudioAfterMS = trace.queuedAudioAfterMS,
-                        let concurrentGenerationTargetMS = activePlaybackConcurrentGenerationTargetMS
-                    {
+                        let concurrentGenerationTargetMS = activePlaybackConcurrentGenerationTargetMS {
                         applyConcurrentGenerationAdmission(
                             bufferedAudioMS: queuedAudioAfterMS,
                             concurrentGenerationTargetMS: concurrentGenerationTargetMS,


### PR DESCRIPTION
## Summary
- fix the one brace-placement miss in `PlaybackController` that caused the repo-maintenance formatter check to fail on `main`

## Why
PR #9 merged cleanly but the post-merge `Validate Repo Maintenance` workflow failed on a single SwiftFormat rule. This follow-up is intentionally formatting-only so `main` can return to green without mixing in any behavioral changes.

## Verification
- `bash scripts/repo-maintenance/validate-all.sh`
