### PR TITLE
build: fix release formatting blockers

### DIFF
--- a/Sources/SpeakSwiftly/Playback/PlaybackThresholdController.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackThresholdController.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 // MARK: - PlaybackComplexityClass
 
 enum PlaybackComplexityClass: String {

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
@@ -993,8 +993,6 @@ import TextForSpeech
                 && $0["op"] as? String == "list_voice_profiles"
         }
     })
-
     let startedOps = output.startedEvents()
     #expect(startedOps == ["req-1:create_voice_profile_from_description", "req-2:generate_speech", "req-3:list_voice_profiles"])
 }
-


### PR DESCRIPTION
## Summary
- add the missing blank line after the new playback threshold imports
- remove the extra blank line in the runtime control-surface tests
- unblock the `v3.0.8` release flow after the repo-maintenance formatter gate

## Verification
- `sh scripts/repo-maintenance/release.sh --mode standard --version v3.0.8` (stopped at protected-branch push after validation, runtime publish, and local tag creation)
- `sh scripts/repo-maintenance/validate-all.sh`