### PR TITLE
build: add iOS simulator smoke lane

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -107,7 +107,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          simulator_id="$(xcrun simctl list devices available | awk -F '[()]' '/^[[:space:]]*iPhone/ { print $2; exit }')"
+          simulator_id="$(
+            xcrun simctl list devices available \
+              | sed -nE '/^[[:space:]]*iPhone/ s/.*\(([0-9A-F-]{36})\)[[:space:]]+\([^)]*\)[[:space:]]*$/\1/p' \
+              | head -n 1
+          )"
           if [[ -z "$simulator_id" ]]; then
             printf 'SpeakSwiftly CI could not find an available iPhone simulator destination on this runner.\n' >&2
             xcrun simctl list devices available >&2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -84,6 +84,74 @@ jobs:
             -destination 'platform=macOS' \
             -only-testing:'SpeakSwiftlyTests/ModelClientsTests'
 
+  ios-compile-and-smoke:
+    name: iOS compile and smoke on macOS 15
+    runs-on: macos-15
+    env:
+      SPEAKSWIFTLY_IOS_CI_DERIVED_DATA: .local/xcode/derived-data/ios-ci
+      SPEAKSWIFTLY_IOS_CI_SOURCE_PACKAGES: .local/xcode/source-packages
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Resolve available iOS simulator destination
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          simulator_id="$(xcrun simctl list devices available | awk -F '[()]' '/^[[:space:]]*iPhone/ { print $2; exit }')"
+          if [[ -z "$simulator_id" ]]; then
+            printf 'SpeakSwiftly CI could not find an available iPhone simulator destination on this runner.\n' >&2
+            xcrun simctl list devices available >&2
+            exit 1
+          fi
+
+          printf 'SPEAKSWIFTLY_IOS_SIMULATOR_ID=%s\n' "$simulator_id" >>"$GITHUB_ENV"
+
+      - name: Build package tests for iOS Simulator
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          xcodebuild build-for-testing -quiet \
+            -scheme SpeakSwiftly-Package \
+            -destination "platform=iOS Simulator,id=$SPEAKSWIFTLY_IOS_SIMULATOR_ID" \
+            -derivedDataPath "$SPEAKSWIFTLY_IOS_CI_DERIVED_DATA" \
+            -clonedSourcePackagesDirPath "$SPEAKSWIFTLY_IOS_CI_SOURCE_PACKAGES"
+
+      - name: Resolve iOS Xcode-backed test manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          xctestrun_path="$(find "$SPEAKSWIFTLY_IOS_CI_DERIVED_DATA/Build/Products" -maxdepth 1 -name '*.xctestrun' | head -n 1)"
+          if [[ -z "$xctestrun_path" ]]; then
+            printf 'SpeakSwiftly CI could not find the iOS .xctestrun manifest produced by build-for-testing under %s.\n' "$SPEAKSWIFTLY_IOS_CI_DERIVED_DATA/Build/Products" >&2
+            exit 1
+          fi
+
+          printf 'SPEAKSWIFTLY_IOS_CI_XCTESTRUN=%s\n' "$xctestrun_path" >>"$GITHUB_ENV"
+
+      - name: Run iOS simulator smoke tests
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          xcodebuild test-without-building -quiet \
+            -xctestrun "$SPEAKSWIFTLY_IOS_CI_XCTESTRUN" \
+            -destination "platform=iOS Simulator,id=$SPEAKSWIFTLY_IOS_SIMULATOR_ID" \
+            -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests' \
+            -only-testing:'SpeakSwiftlyTests/SupportResourcesTests' \
+            -only-testing:'SpeakSwiftlyTests/ProfileStoreTests'
+
   tagged-runtime-publication:
     name: Tagged Runtime Publication (${{ matrix.configuration }})
     if: startsWith(github.ref, 'refs/tags/')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -654,6 +654,21 @@ tests. Keep `swift package dump-package` as the manifest sanity check, but use
 the repo-root Xcode-backed package lane for CI build-and-test coverage until
 the vendored parser failure is gone.
 
+The current CI split is:
+
+- macOS Xcode-backed package validation:
+  - `SpeakSwiftlyTests/WorkerRuntimePlaybackTests`
+  - `SpeakSwiftlyTests/LibrarySurfaceTests`
+  - `SpeakSwiftlyTests/ModelClientsTests`
+- iOS Simulator compile-and-smoke validation:
+  - `SpeakSwiftlyTests/LibrarySurfaceTests`
+  - `SpeakSwiftlyTests/SupportResourcesTests`
+  - `SpeakSwiftlyTests/ProfileStoreTests`
+
+Keep the iOS lane library-first. The worker-driven e2e harness under
+`Tests/SpeakSwiftlyTests/E2E/` is macOS-only because it launches the published
+CLI worker process and does not model an app-hosted iOS runtime.
+
 Long deep-trace playback probe:
 
 ```bash

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "937daf0373b0c74f5eb6b0ece9b9389868a6d3626b19797d572c822ce95ee85d",
+  "originHash" : "d9da914100c4212825fd5b8b5aff0b3a0168d43c3aea65d868d60f6d034a39a1",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "556646677a3403771123fc498c9d6e2b6ce4b823",
-        "version" : "0.17.1"
+        "revision" : "8dfe72e9f870532f0f25027b6cf1bec17793bea3",
+        "version" : "0.17.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/gaelic-ghost/TextForSpeech.git",
-            .upToNextMajor(from: "0.17.1"),
+            .upToNextMajor(from: "0.17.2"),
         ),
         .package(
             url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "SpeakSwiftly",
     platforms: [
         .macOS(.v15),
+        .iOS(.v17),
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -302,6 +302,26 @@ use the Xcode-backed validation fallback documented in
 [CONTRIBUTING.md](CONTRIBUTING.md) and
 [docs/maintainers/validation-lanes.md](docs/maintainers/validation-lanes.md).
 
+The current Xcode-backed simulator smoke lane for iOS is:
+
+```bash
+xcodebuild build-for-testing \
+  -scheme SpeakSwiftly-Package \
+  -destination 'platform=iOS Simulator,id=<simulator-udid>' \
+  -derivedDataPath .local/xcode/derived-data/ios-smoke \
+  -clonedSourcePackagesDirPath .local/xcode/source-packages
+
+xcodebuild test-without-building \
+  -xctestrun "$(find .local/xcode/derived-data/ios-smoke/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" \
+  -destination 'platform=iOS Simulator,id=<simulator-udid>' \
+  -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests' \
+  -only-testing:'SpeakSwiftlyTests/SupportResourcesTests' \
+  -only-testing:'SpeakSwiftlyTests/ProfileStoreTests'
+```
+
+That lane is intentionally library-first. The published worker executable and
+real-model end-to-end coverage are still macOS-first validation surfaces.
+
 Real MLX-backed runtime verification starts by publishing the Xcode-backed runtime:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ SpeakSwiftly is a standard Swift package with two direct dependencies:
 - [`TextForSpeech`](https://github.com/gaelic-ghost/TextForSpeech)
 - [`mlx-audio-swift`](https://github.com/gaelic-ghost/mlx-audio-swift)
 
+The package manifest currently declares:
+
+- `macOS 15+`
+- `iOS 17+`
+
+That platform widening is library-first. The typed `SpeakSwiftly` library now
+enters the package graph for both platforms, while the long-lived worker and the
+release-grade MLX verification flow are still maintained as macOS-first
+surfaces.
+
 Library consumers can add the package from GitHub:
 
 ```swift

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,6 +126,7 @@ Tickets:
 - [ ] Audit the `SpeakSwiftly` public API for the minimum supported downstream surface before advertising broader package distribution.
 - [ ] Document SwiftPM dependency examples for both the library product and the executable product in the README.
 - [ ] Add a package-consumer verification path that exercises dependency resolution from a clean external package instead of relying only on sibling-checkout integration.
+- [ ] Land the playback-platform seam described in `docs/maintainers/ios-portability-plan-2026-04-17.md` before widening supported platforms beyond macOS.
 - [ ] Decide whether package-registry publication is in scope or whether Git-based SwiftPM distribution is the intended first supported path.
 - [ ] Tighten release notes and release-checklist language so package consumers can tell when a change is semver-safe versus when migration work is required.
 - [ ] Document any remaining Xcode-built runtime caveats clearly so distributed package consumers understand where SwiftPM alone is sufficient and where it is not.

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift
@@ -98,6 +98,7 @@ extension AudioPlaybackDriver {
         }
 
         guard shouldResume != false else { return }
+
         beginPlaybackRecovery(reason: .audioSessionInterruption)
     }
 

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift
@@ -81,6 +81,26 @@ extension AudioPlaybackDriver {
         emitEnvironmentEvent(.sessionActivityChanged(isActive: isActive))
     }
 
+    func handleInterruptionStateChange(isInterrupted: Bool, shouldResume: Bool?) {
+        markEnvironmentInstability()
+        emitEnvironmentEvent(
+            .interruptionStateChanged(
+                isInterrupted: isInterrupted,
+                shouldResume: shouldResume,
+            ),
+        )
+
+        guard activeRequestState != nil else { return }
+
+        if isInterrupted {
+            playerNode?.pause()
+            return
+        }
+
+        guard shouldResume != false else { return }
+        beginPlaybackRecovery(reason: .audioSessionInterruption)
+    }
+
     func emitEnvironmentEvent(_ event: PlaybackEnvironmentEvent) {
         guard let environmentEventSink else { return }
 
@@ -186,7 +206,7 @@ extension AudioPlaybackDriver {
         interruptActivePlayback(
             with: WorkerError(
                 code: .audioPlaybackFailed,
-                message: "Live playback could not recover after macOS reported a \(reason.rawValue) event. SpeakSwiftly attempted to rebuild the audio engine \(AudioPlaybackConfiguration.recoveryMaximumAttempts) times, but the output route never stabilized enough to resume the active request.",
+                message: "Live playback could not recover after the playback environment reported a \(reason.rawValue) event. SpeakSwiftly attempted to rebuild the audio engine \(AudioPlaybackConfiguration.recoveryMaximumAttempts) times, but the active route never stabilized enough to resume the request.",
             ),
         )
     }

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift
@@ -97,7 +97,15 @@ extension AudioPlaybackDriver {
             return
         }
 
-        guard shouldResume != false else { return }
+        guard shouldResume != false else {
+            interruptActivePlayback(
+                with: WorkerError(
+                    code: .audioPlaybackFailed,
+                    message: "Live playback was interrupted and the active audio session reported that this request must not resume automatically.",
+                ),
+            )
+            return
+        }
 
         beginPlaybackRecovery(reason: .audioSessionInterruption)
     }

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift
@@ -1,6 +1,4 @@
-@preconcurrency import AppKit
 @preconcurrency import AVFoundation
-import CoreAudio
 import Foundation
 import TextForSpeech
 
@@ -30,95 +28,8 @@ extension AudioPlaybackDriver {
         }
     }
 
-    func installWorkspaceObservers() {
-        let workspaceNotificationCenter = NSWorkspace.shared.notificationCenter
-
-        workspaceObservers.append(
-            workspaceNotificationCenter.addObserver(
-                forName: NSWorkspace.willSleepNotification,
-                object: nil,
-                queue: nil,
-            ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.handleSystemSleepStateChange(isSleeping: true)
-                }
-            },
-        )
-        workspaceObservers.append(
-            workspaceNotificationCenter.addObserver(
-                forName: NSWorkspace.didWakeNotification,
-                object: nil,
-                queue: nil,
-            ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.handleSystemSleepStateChange(isSleeping: false)
-                }
-            },
-        )
-        workspaceObservers.append(
-            workspaceNotificationCenter.addObserver(
-                forName: NSWorkspace.screensDidSleepNotification,
-                object: nil,
-                queue: nil,
-            ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.handleScreenSleepStateChange(isSleeping: true)
-                }
-            },
-        )
-        workspaceObservers.append(
-            workspaceNotificationCenter.addObserver(
-                forName: NSWorkspace.screensDidWakeNotification,
-                object: nil,
-                queue: nil,
-            ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.handleScreenSleepStateChange(isSleeping: false)
-                }
-            },
-        )
-        workspaceObservers.append(
-            workspaceNotificationCenter.addObserver(
-                forName: NSWorkspace.sessionDidResignActiveNotification,
-                object: nil,
-                queue: nil,
-            ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.handleSessionActivityChange(isActive: false)
-                }
-            },
-        )
-        workspaceObservers.append(
-            workspaceNotificationCenter.addObserver(
-                forName: NSWorkspace.sessionDidBecomeActiveNotification,
-                object: nil,
-                queue: nil,
-            ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.handleSessionActivityChange(isActive: true)
-                }
-            },
-        )
-    }
-
-    func installDefaultOutputDeviceObserver() {
-        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            Task { @MainActor [weak self] in
-                self?.handleDefaultOutputDeviceChange()
-            }
-        }
-        defaultOutputDeviceListener = listener
-        AudioObjectAddPropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &defaultOutputDeviceAddress,
-            DispatchQueue.main,
-            listener,
-        )
-    }
-
-    func handleDefaultOutputDeviceChange() {
+    func handleObservedOutputDeviceChange(currentDevice: String?) {
         let previousDevice = lastObservedOutputDeviceDescription
-        let currentDevice = currentDefaultAudioPlaybackDeviceDescription()
         guard previousDevice != currentDevice else { return }
 
         lastObservedOutputDeviceDescription = currentDevice

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+PlaybackLifecycle.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+PlaybackLifecycle.swift
@@ -102,8 +102,8 @@ extension AudioPlaybackDriver {
     }
 
     func rebuildEngine(sampleRate: Double) async throws {
-        tearDownPlaybackHardware(leavingArbitration: true)
-        try await beginRoutingArbitration()
+        tearDownPlaybackHardware(leavingPlaybackEnvironment: true)
+        try await playbackEnvironment.prepareForPlaybackStart()
 
         let engine = AVAudioEngine()
         let node = AVAudioPlayerNode()
@@ -136,32 +136,15 @@ extension AudioPlaybackDriver {
         playerNode?.reset()
     }
 
-    func tearDownPlaybackHardware(leavingArbitration: Bool) {
+    func tearDownPlaybackHardware(leavingPlaybackEnvironment: Bool) {
         playerNode?.stop()
         audioEngine?.stop()
         playerNode = nil
         audioEngine = nil
         streamingFormat = nil
         engineSampleRate = nil
-        if leavingArbitration {
-            routingArbitration.leave()
-        }
-    }
-
-    func beginRoutingArbitration() async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            routingArbitration.begin(category: .playback) { _, error in
-                if let error {
-                    continuation.resume(
-                        throwing: WorkerError(
-                            code: .audioPlaybackFailed,
-                            message: "SpeakSwiftly could not begin macOS audio routing arbitration before starting local playback. \(error.localizedDescription)",
-                        ),
-                    )
-                } else {
-                    continuation.resume(returning: ())
-                }
-            }
+        if leavingPlaybackEnvironment {
+            playbackEnvironment.finishPlayback()
         }
     }
 

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift
@@ -1,6 +1,4 @@
-@preconcurrency import AppKit
 @preconcurrency import AVFoundation
-import CoreAudio
 import Foundation
 import TextForSpeech
 
@@ -13,13 +11,6 @@ final class AudioPlaybackDriver {
     var streamingFormat: AVAudioFormat?
     var engineSampleRate: Double?
     var engineConfigurationObserver: NSObjectProtocol?
-    var workspaceObservers = [NSObjectProtocol]()
-    var defaultOutputDeviceAddress = AudioObjectPropertyAddress(
-        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
-        mScope: kAudioObjectPropertyScopeGlobal,
-        mElement: kAudioObjectPropertyElementMain,
-    )
-    var defaultOutputDeviceListener: AudioObjectPropertyListenerBlock?
     var lastEnvironmentInstabilityAt: Date?
     var recoveryTask: Task<Void, Never>?
     var isSystemSleeping = false
@@ -27,7 +18,6 @@ final class AudioPlaybackDriver {
     var isSessionActive = true
     var playbackRecoveryReason: AudioPlaybackRecoveryReason?
     var playbackRecoveryAttempt = 0
-    var routingArbitration = AVAudioRoutingArbiter.shared
     var activeRequestState: AudioPlaybackRequestState?
     var activeEventSink: (@Sendable (PlaybackEvent) async -> Void)?
     var activeRuntimeFailure: WorkerError?
@@ -38,6 +28,7 @@ final class AudioPlaybackDriver {
 
     private var nextRequestID: UInt64 = 0
     private let traceEnabled: Bool
+    let playbackEnvironment: PlaybackEnvironmentCoordinator
     private var playbackState: PlaybackState = .idle
 
     var shouldSuppressDrainProgressTimeout: Bool {
@@ -54,12 +45,35 @@ final class AudioPlaybackDriver {
         playbackRecoveryReason != nil || isSystemSleeping
     }
 
-    init(traceEnabled: Bool = false) {
+    init(
+        traceEnabled: Bool = false,
+        playbackEnvironment: PlaybackEnvironmentCoordinator = MacOSPlaybackEnvironmentCoordinator(),
+    ) {
         self.traceEnabled = traceEnabled
-        lastObservedOutputDeviceDescription = currentDefaultAudioPlaybackDeviceDescription()
+        self.playbackEnvironment = playbackEnvironment
+        lastObservedOutputDeviceDescription = playbackEnvironment.currentOutputDeviceDescription
         installEngineConfigurationObserver()
-        installWorkspaceObservers()
-        installDefaultOutputDeviceObserver()
+        playbackEnvironment.installObservers(
+            onSystemSleepStateChange: { [weak self] isSleeping in
+                self?.handleSystemSleepStateChange(isSleeping: isSleeping)
+            },
+            onScreenSleepStateChange: { [weak self] isSleeping in
+                self?.handleScreenSleepStateChange(isSleeping: isSleeping)
+            },
+            onSessionActivityChange: { [weak self] isActive in
+                self?.handleSessionActivityChange(isActive: isActive)
+            },
+            onOutputDeviceChange: { [weak self] currentDevice in
+                self?.handleObservedOutputDeviceChange(currentDevice: currentDevice)
+            },
+        )
+    }
+
+    deinit {
+        let playbackEnvironment = playbackEnvironment
+        Task { @MainActor in
+            playbackEnvironment.invalidate()
+        }
     }
 
     func setEnvironmentEventSink(
@@ -547,14 +561,13 @@ final class AudioPlaybackDriver {
     func stop() {
         recoveryTask?.cancel()
         recoveryTask = nil
-        tearDownPlaybackHardware(leavingArbitration: true)
+        tearDownPlaybackHardware(leavingPlaybackEnvironment: true)
         playbackRecoveryReason = nil
         playbackRecoveryAttempt = 0
         lastEnvironmentInstabilityAt = nil
         playbackState = .idle
         isPlaybackPausedManually = false
         shouldPlayInterJobBoop = false
-        routingArbitration.leave()
     }
 
     func pause() -> PlaybackState {

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift
@@ -26,9 +26,10 @@ final class AudioPlaybackDriver {
     var environmentEventSink: (@Sendable (PlaybackEnvironmentEvent) async -> Void)?
     var shouldPlayInterJobBoop = false
 
+    let playbackEnvironment: PlaybackEnvironmentCoordinator
+
     private var nextRequestID: UInt64 = 0
     private let traceEnabled: Bool
-    let playbackEnvironment: PlaybackEnvironmentCoordinator
     private var playbackState: PlaybackState = .idle
 
     var shouldSuppressDrainProgressTimeout: Bool {

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift
@@ -47,9 +47,10 @@ final class AudioPlaybackDriver {
 
     init(
         traceEnabled: Bool = false,
-        playbackEnvironment: PlaybackEnvironmentCoordinator = MacOSPlaybackEnvironmentCoordinator(),
+        playbackEnvironment: PlaybackEnvironmentCoordinator? = nil,
     ) {
         self.traceEnabled = traceEnabled
+        let playbackEnvironment = playbackEnvironment ?? makeDefaultPlaybackEnvironmentCoordinator()
         self.playbackEnvironment = playbackEnvironment
         lastObservedOutputDeviceDescription = playbackEnvironment.currentOutputDeviceDescription
         installEngineConfigurationObserver()
@@ -65,6 +66,12 @@ final class AudioPlaybackDriver {
             },
             onOutputDeviceChange: { [weak self] currentDevice in
                 self?.handleObservedOutputDeviceChange(currentDevice: currentDevice)
+            },
+            onInterruptionStateChange: { [weak self] isInterrupted, shouldResume in
+                self?.handleInterruptionStateChange(
+                    isInterrupted: isInterrupted,
+                    shouldResume: shouldResume,
+                )
             },
         )
     }

--- a/Sources/SpeakSwiftly/Playback/IOSPlaybackEnvironmentCoordinator.swift
+++ b/Sources/SpeakSwiftly/Playback/IOSPlaybackEnvironmentCoordinator.swift
@@ -14,6 +14,38 @@ final class IOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator {
         Self.currentOutputRouteDescription(audioSession.currentRoute)
     }
 
+    private static func parseInterruption(_ notification: Notification) -> (Bool, Bool?) {
+        guard
+            let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: typeValue)
+        else {
+            return (true, nil)
+        }
+
+        switch type {
+            case .began:
+                return (true, nil)
+            case .ended:
+                guard let optionsValue = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt else {
+                    return (false, nil)
+                }
+
+                let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+                return (false, options.contains(.shouldResume))
+            @unknown default:
+                return (false, nil)
+        }
+    }
+
+    private static func currentOutputRouteDescription(_ route: AVAudioSessionRouteDescription) -> String? {
+        let outputs = route.outputs.map { output in
+            "\(output.portName) [\(output.portType.rawValue)]"
+        }
+        guard !outputs.isEmpty else { return nil }
+
+        return outputs.joined(separator: ", ")
+    }
+
     func installObservers(
         onSystemSleepStateChange: @escaping @MainActor (Bool) -> Void,
         onScreenSleepStateChange: @escaping @MainActor (Bool) -> Void,
@@ -22,6 +54,7 @@ final class IOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator {
         onInterruptionStateChange: @escaping @MainActor (_ isInterrupted: Bool, _ shouldResume: Bool?) -> Void,
     ) {
         guard !observersInstalled else { return }
+
         observersInstalled = true
 
         observerTasks.append(
@@ -76,37 +109,6 @@ final class IOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator {
         observerTasks.removeAll()
         observersInstalled = false
         finishPlayback()
-    }
-
-    private static func parseInterruption(_ notification: Notification) -> (Bool, Bool?) {
-        guard
-            let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
-            let type = AVAudioSession.InterruptionType(rawValue: typeValue)
-        else {
-            return (true, nil)
-        }
-
-        switch type {
-            case .began:
-                return (true, nil)
-            case .ended:
-                guard let optionsValue = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt else {
-                    return (false, nil)
-                }
-                let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
-                return (false, options.contains(.shouldResume))
-            @unknown default:
-                return (false, nil)
-        }
-    }
-
-    private static func currentOutputRouteDescription(_ route: AVAudioSessionRouteDescription) -> String? {
-        let outputs = route.outputs.map { output in
-            "\(output.portName) [\(output.portType.rawValue)]"
-        }
-        guard !outputs.isEmpty else { return nil }
-
-        return outputs.joined(separator: ", ")
     }
 }
 #endif

--- a/Sources/SpeakSwiftly/Playback/IOSPlaybackEnvironmentCoordinator.swift
+++ b/Sources/SpeakSwiftly/Playback/IOSPlaybackEnvironmentCoordinator.swift
@@ -1,0 +1,112 @@
+#if os(iOS)
+@preconcurrency import AVFoundation
+import Foundation
+
+// MARK: - IOSPlaybackEnvironmentCoordinator
+
+@MainActor
+final class IOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator {
+    private let audioSession = AVAudioSession.sharedInstance()
+    private var observerTasks = [Task<Void, Never>]()
+    private var observersInstalled = false
+
+    var currentOutputDeviceDescription: String? {
+        Self.currentOutputRouteDescription(audioSession.currentRoute)
+    }
+
+    func installObservers(
+        onSystemSleepStateChange: @escaping @MainActor (Bool) -> Void,
+        onScreenSleepStateChange: @escaping @MainActor (Bool) -> Void,
+        onSessionActivityChange: @escaping @MainActor (Bool) -> Void,
+        onOutputDeviceChange: @escaping @MainActor (String?) -> Void,
+        onInterruptionStateChange: @escaping @MainActor (_ isInterrupted: Bool, _ shouldResume: Bool?) -> Void,
+    ) {
+        guard !observersInstalled else { return }
+        observersInstalled = true
+
+        observerTasks.append(
+            Task { @MainActor [audioSession] in
+                for await _ in NotificationCenter.default.notifications(
+                    named: AVAudioSession.routeChangeNotification,
+                    object: audioSession,
+                ) {
+                    onOutputDeviceChange(Self.currentOutputRouteDescription(audioSession.currentRoute))
+                }
+            },
+        )
+
+        observerTasks.append(
+            Task { @MainActor [audioSession] in
+                for await notification in NotificationCenter.default.notifications(
+                    named: AVAudioSession.interruptionNotification,
+                    object: audioSession,
+                ) {
+                    let (isInterrupted, shouldResume) = Self.parseInterruption(notification)
+                    onInterruptionStateChange(isInterrupted, shouldResume)
+                    onSessionActivityChange(!isInterrupted)
+                }
+            },
+        )
+    }
+
+    func prepareForPlaybackStart() async throws {
+        do {
+            try audioSession.setCategory(.playback)
+            try audioSession.setActive(true)
+        } catch {
+            throw WorkerError(
+                code: .audioPlaybackFailed,
+                message: "SpeakSwiftly could not activate the iOS audio session before starting local playback. \(error.localizedDescription)",
+            )
+        }
+    }
+
+    func finishPlayback() {
+        do {
+            try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            // Keep teardown best-effort so playback shutdown does not mask the real request result.
+        }
+    }
+
+    func invalidate() {
+        for observerTask in observerTasks {
+            observerTask.cancel()
+        }
+        observerTasks.removeAll()
+        observersInstalled = false
+        finishPlayback()
+    }
+
+    private static func parseInterruption(_ notification: Notification) -> (Bool, Bool?) {
+        guard
+            let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: typeValue)
+        else {
+            return (true, nil)
+        }
+
+        switch type {
+            case .began:
+                return (true, nil)
+            case .ended:
+                guard let optionsValue = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt else {
+                    return (false, nil)
+                }
+                let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+                return (false, options.contains(.shouldResume))
+            @unknown default:
+                return (false, nil)
+        }
+    }
+
+    private static func currentOutputRouteDescription(_ route: AVAudioSessionRouteDescription) -> String? {
+        let outputs = route.outputs.map { output in
+            "\(output.portName) [\(output.portType.rawValue)]"
+        }
+        guard !outputs.isEmpty else { return nil }
+
+        return outputs.joined(separator: ", ")
+    }
+}
+#endif

--- a/Sources/SpeakSwiftly/Playback/MacOSPlaybackEnvironmentCoordinator.swift
+++ b/Sources/SpeakSwiftly/Playback/MacOSPlaybackEnvironmentCoordinator.swift
@@ -22,6 +22,55 @@ final class MacOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator 
         Self.currentDefaultAudioPlaybackDeviceDescription()
     }
 
+    private static func currentDefaultAudioPlaybackDeviceDescription() -> String? {
+        var deviceID = AudioObjectID(kAudioObjectUnknown)
+        var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
+        var deviceAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        let deviceStatus = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &deviceAddress,
+            0,
+            nil,
+            &dataSize,
+            &deviceID,
+        )
+
+        guard deviceStatus == noErr, deviceID != AudioObjectID(kAudioObjectUnknown) else {
+            return nil
+        }
+
+        var deviceName: CFString = "" as CFString
+        var nameSize = UInt32(MemoryLayout<CFString>.stride)
+        var nameAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceNameCFString,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        let nameStatus = withUnsafeMutablePointer(to: &deviceName) { pointer in
+            AudioObjectGetPropertyData(
+                deviceID,
+                &nameAddress,
+                0,
+                nil,
+                &nameSize,
+                UnsafeMutableRawPointer(pointer),
+            )
+        }
+
+        if nameStatus == noErr {
+            let name = "\(deviceName)"
+            if !name.isEmpty {
+                return "\(name) [\(deviceID)]"
+            }
+        }
+
+        return "AudioObjectID \(deviceID)"
+    }
+
     func installObservers(
         onSystemSleepStateChange: @escaping @MainActor (Bool) -> Void,
         onScreenSleepStateChange: @escaping @MainActor (Bool) -> Void,
@@ -30,6 +79,7 @@ final class MacOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator 
         onInterruptionStateChange: @escaping @MainActor (_ isInterrupted: Bool, _ shouldResume: Bool?) -> Void,
     ) {
         guard !observersInstalled else { return }
+
         observersInstalled = true
 
         let workspaceNotificationCenter = NSWorkspace.shared.notificationCenter
@@ -155,55 +205,6 @@ final class MacOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator 
 
         routingArbitration.leave()
         observersInstalled = false
-    }
-
-    private static func currentDefaultAudioPlaybackDeviceDescription() -> String? {
-        var deviceID = AudioObjectID(kAudioObjectUnknown)
-        var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
-        var deviceAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain,
-        )
-        let deviceStatus = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &deviceAddress,
-            0,
-            nil,
-            &dataSize,
-            &deviceID,
-        )
-
-        guard deviceStatus == noErr, deviceID != AudioObjectID(kAudioObjectUnknown) else {
-            return nil
-        }
-
-        var deviceName: CFString = "" as CFString
-        var nameSize = UInt32(MemoryLayout<CFString>.stride)
-        var nameAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyDeviceNameCFString,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain,
-        )
-        let nameStatus = withUnsafeMutablePointer(to: &deviceName) { pointer in
-            AudioObjectGetPropertyData(
-                deviceID,
-                &nameAddress,
-                0,
-                nil,
-                &nameSize,
-                UnsafeMutableRawPointer(pointer),
-            )
-        }
-
-        if nameStatus == noErr {
-            let name = "\(deviceName)"
-            if !name.isEmpty {
-                return "\(name) [\(deviceID)]"
-            }
-        }
-
-        return "AudioObjectID \(deviceID)"
     }
 }
 #endif

--- a/Sources/SpeakSwiftly/Playback/MacOSPlaybackEnvironmentCoordinator.swift
+++ b/Sources/SpeakSwiftly/Playback/MacOSPlaybackEnvironmentCoordinator.swift
@@ -1,0 +1,206 @@
+@preconcurrency import AppKit
+@preconcurrency import AVFoundation
+import CoreAudio
+import Foundation
+
+// MARK: - MacOSPlaybackEnvironmentCoordinator
+
+@MainActor
+final class MacOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator {
+    private var workspaceObservers = [NSObjectProtocol]()
+    private var defaultOutputDeviceAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain,
+    )
+    private var defaultOutputDeviceListener: AudioObjectPropertyListenerBlock?
+    private var routingArbitration = AVAudioRoutingArbiter.shared
+    private var observersInstalled = false
+
+    var currentOutputDeviceDescription: String? {
+        Self.currentDefaultAudioPlaybackDeviceDescription()
+    }
+
+    func installObservers(
+        onSystemSleepStateChange: @escaping @MainActor (Bool) -> Void,
+        onScreenSleepStateChange: @escaping @MainActor (Bool) -> Void,
+        onSessionActivityChange: @escaping @MainActor (Bool) -> Void,
+        onOutputDeviceChange: @escaping @MainActor (String?) -> Void,
+    ) {
+        guard !observersInstalled else { return }
+        observersInstalled = true
+
+        let workspaceNotificationCenter = NSWorkspace.shared.notificationCenter
+
+        workspaceObservers.append(
+            workspaceNotificationCenter.addObserver(
+                forName: NSWorkspace.willSleepNotification,
+                object: nil,
+                queue: nil,
+            ) { _ in
+                Task { @MainActor in
+                    onSystemSleepStateChange(true)
+                }
+            },
+        )
+        workspaceObservers.append(
+            workspaceNotificationCenter.addObserver(
+                forName: NSWorkspace.didWakeNotification,
+                object: nil,
+                queue: nil,
+            ) { _ in
+                Task { @MainActor in
+                    onSystemSleepStateChange(false)
+                }
+            },
+        )
+        workspaceObservers.append(
+            workspaceNotificationCenter.addObserver(
+                forName: NSWorkspace.screensDidSleepNotification,
+                object: nil,
+                queue: nil,
+            ) { _ in
+                Task { @MainActor in
+                    onScreenSleepStateChange(true)
+                }
+            },
+        )
+        workspaceObservers.append(
+            workspaceNotificationCenter.addObserver(
+                forName: NSWorkspace.screensDidWakeNotification,
+                object: nil,
+                queue: nil,
+            ) { _ in
+                Task { @MainActor in
+                    onScreenSleepStateChange(false)
+                }
+            },
+        )
+        workspaceObservers.append(
+            workspaceNotificationCenter.addObserver(
+                forName: NSWorkspace.sessionDidResignActiveNotification,
+                object: nil,
+                queue: nil,
+            ) { _ in
+                Task { @MainActor in
+                    onSessionActivityChange(false)
+                }
+            },
+        )
+        workspaceObservers.append(
+            workspaceNotificationCenter.addObserver(
+                forName: NSWorkspace.sessionDidBecomeActiveNotification,
+                object: nil,
+                queue: nil,
+            ) { _ in
+                Task { @MainActor in
+                    onSessionActivityChange(true)
+                }
+            },
+        )
+
+        let listener: AudioObjectPropertyListenerBlock = { _, _ in
+            Task { @MainActor in
+                onOutputDeviceChange(Self.currentDefaultAudioPlaybackDeviceDescription())
+            }
+        }
+        defaultOutputDeviceListener = listener
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &defaultOutputDeviceAddress,
+            DispatchQueue.main,
+            listener,
+        )
+    }
+
+    func prepareForPlaybackStart() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            routingArbitration.begin(category: .playback) { _, error in
+                if let error {
+                    continuation.resume(
+                        throwing: WorkerError(
+                            code: .audioPlaybackFailed,
+                            message: "SpeakSwiftly could not begin macOS audio routing arbitration before starting local playback. \(error.localizedDescription)",
+                        ),
+                    )
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    func finishPlayback() {
+        routingArbitration.leave()
+    }
+
+    func invalidate() {
+        let workspaceNotificationCenter = NSWorkspace.shared.notificationCenter
+        for observer in workspaceObservers {
+            workspaceNotificationCenter.removeObserver(observer)
+        }
+        workspaceObservers.removeAll()
+
+        if let defaultOutputDeviceListener {
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &defaultOutputDeviceAddress,
+                DispatchQueue.main,
+                defaultOutputDeviceListener,
+            )
+            self.defaultOutputDeviceListener = nil
+        }
+
+        routingArbitration.leave()
+        observersInstalled = false
+    }
+
+    private static func currentDefaultAudioPlaybackDeviceDescription() -> String? {
+        var deviceID = AudioObjectID(kAudioObjectUnknown)
+        var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
+        var deviceAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        let deviceStatus = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &deviceAddress,
+            0,
+            nil,
+            &dataSize,
+            &deviceID,
+        )
+
+        guard deviceStatus == noErr, deviceID != AudioObjectID(kAudioObjectUnknown) else {
+            return nil
+        }
+
+        var deviceName: CFString = "" as CFString
+        var nameSize = UInt32(MemoryLayout<CFString>.stride)
+        var nameAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceNameCFString,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        )
+        let nameStatus = withUnsafeMutablePointer(to: &deviceName) { pointer in
+            AudioObjectGetPropertyData(
+                deviceID,
+                &nameAddress,
+                0,
+                nil,
+                &nameSize,
+                UnsafeMutableRawPointer(pointer),
+            )
+        }
+
+        if nameStatus == noErr {
+            let name = "\(deviceName)"
+            if !name.isEmpty {
+                return "\(name) [\(deviceID)]"
+            }
+        }
+
+        return "AudioObjectID \(deviceID)"
+    }
+}

--- a/Sources/SpeakSwiftly/Playback/MacOSPlaybackEnvironmentCoordinator.swift
+++ b/Sources/SpeakSwiftly/Playback/MacOSPlaybackEnvironmentCoordinator.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 @preconcurrency import AppKit
 @preconcurrency import AVFoundation
 import CoreAudio
@@ -26,6 +27,7 @@ final class MacOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator 
         onScreenSleepStateChange: @escaping @MainActor (Bool) -> Void,
         onSessionActivityChange: @escaping @MainActor (Bool) -> Void,
         onOutputDeviceChange: @escaping @MainActor (String?) -> Void,
+        onInterruptionStateChange: @escaping @MainActor (_ isInterrupted: Bool, _ shouldResume: Bool?) -> Void,
     ) {
         guard !observersInstalled else { return }
         observersInstalled = true
@@ -204,3 +206,4 @@ final class MacOSPlaybackEnvironmentCoordinator: PlaybackEnvironmentCoordinator 
         return "AudioObjectID \(deviceID)"
     }
 }
+#endif

--- a/Sources/SpeakSwiftly/Playback/PlaybackConfiguration.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackConfiguration.swift
@@ -1,5 +1,4 @@
 @preconcurrency import AVFoundation
-import CoreAudio
 import Foundation
 
 // MARK: - AudioPlaybackConfiguration
@@ -24,55 +23,4 @@ enum AudioPlaybackConfiguration {
         let paddedQueuedAudioMS = queuedAudioMS + drainTimeoutPaddingMS
         return max(minimumDrainTimeout, .milliseconds(paddedQueuedAudioMS))
     }
-}
-
-// MARK: - Playback Device Inspection
-
-func currentDefaultAudioPlaybackDeviceDescription() -> String? {
-    var deviceID = AudioObjectID(kAudioObjectUnknown)
-    var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
-    var deviceAddress = AudioObjectPropertyAddress(
-        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
-        mScope: kAudioObjectPropertyScopeGlobal,
-        mElement: kAudioObjectPropertyElementMain,
-    )
-    let deviceStatus = AudioObjectGetPropertyData(
-        AudioObjectID(kAudioObjectSystemObject),
-        &deviceAddress,
-        0,
-        nil,
-        &dataSize,
-        &deviceID,
-    )
-
-    guard deviceStatus == noErr, deviceID != AudioObjectID(kAudioObjectUnknown) else {
-        return nil
-    }
-
-    var deviceName: CFString = "" as CFString
-    var nameSize = UInt32(MemoryLayout<CFString>.stride)
-    var nameAddress = AudioObjectPropertyAddress(
-        mSelector: kAudioDevicePropertyDeviceNameCFString,
-        mScope: kAudioObjectPropertyScopeGlobal,
-        mElement: kAudioObjectPropertyElementMain,
-    )
-    let nameStatus = withUnsafeMutablePointer(to: &deviceName) { pointer in
-        AudioObjectGetPropertyData(
-            deviceID,
-            &nameAddress,
-            0,
-            nil,
-            &nameSize,
-            UnsafeMutableRawPointer(pointer),
-        )
-    }
-
-    if nameStatus == noErr {
-        let name = "\(deviceName)"
-        if !name.isEmpty {
-            return "\(name) [\(deviceID)]"
-        }
-    }
-
-    return "AudioObjectID \(deviceID)"
 }

--- a/Sources/SpeakSwiftly/Playback/PlaybackEnvironmentCoordinator.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackEnvironmentCoordinator.swift
@@ -11,9 +11,23 @@ protocol PlaybackEnvironmentCoordinator: AnyObject, Sendable {
         onScreenSleepStateChange: @escaping @MainActor (Bool) -> Void,
         onSessionActivityChange: @escaping @MainActor (Bool) -> Void,
         onOutputDeviceChange: @escaping @MainActor (String?) -> Void,
+        onInterruptionStateChange: @escaping @MainActor (_ isInterrupted: Bool, _ shouldResume: Bool?) -> Void,
     )
 
     func prepareForPlaybackStart() async throws
     func finishPlayback()
     func invalidate()
+}
+
+// MARK: - Playback Environment Factory
+
+@MainActor
+func makeDefaultPlaybackEnvironmentCoordinator() -> PlaybackEnvironmentCoordinator {
+    #if os(macOS)
+        MacOSPlaybackEnvironmentCoordinator()
+    #elseif os(iOS)
+        IOSPlaybackEnvironmentCoordinator()
+    #else
+        fatalError("SpeakSwiftly does not support local playback environment coordination on this platform.")
+    #endif
 }

--- a/Sources/SpeakSwiftly/Playback/PlaybackEnvironmentCoordinator.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackEnvironmentCoordinator.swift
@@ -23,11 +23,11 @@ protocol PlaybackEnvironmentCoordinator: AnyObject, Sendable {
 
 @MainActor
 func makeDefaultPlaybackEnvironmentCoordinator() -> PlaybackEnvironmentCoordinator {
-    #if os(macOS)
-        MacOSPlaybackEnvironmentCoordinator()
-    #elseif os(iOS)
-        IOSPlaybackEnvironmentCoordinator()
-    #else
-        fatalError("SpeakSwiftly does not support local playback environment coordination on this platform.")
-    #endif
+#if os(macOS)
+    MacOSPlaybackEnvironmentCoordinator()
+#elseif os(iOS)
+    IOSPlaybackEnvironmentCoordinator()
+#else
+    fatalError("SpeakSwiftly does not support local playback environment coordination on this platform.")
+#endif
 }

--- a/Sources/SpeakSwiftly/Playback/PlaybackEnvironmentCoordinator.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackEnvironmentCoordinator.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+// MARK: - PlaybackEnvironmentCoordinator
+
+@MainActor
+protocol PlaybackEnvironmentCoordinator: AnyObject, Sendable {
+    var currentOutputDeviceDescription: String? { get }
+
+    func installObservers(
+        onSystemSleepStateChange: @escaping @MainActor (Bool) -> Void,
+        onScreenSleepStateChange: @escaping @MainActor (Bool) -> Void,
+        onSessionActivityChange: @escaping @MainActor (Bool) -> Void,
+        onOutputDeviceChange: @escaping @MainActor (String?) -> Void,
+    )
+
+    func prepareForPlaybackStart() async throws
+    func finishPlayback()
+    func invalidate()
+}

--- a/Sources/SpeakSwiftly/Playback/PlaybackEvents.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackEvents.swift
@@ -29,6 +29,7 @@ enum PlaybackEnvironmentEvent {
     case outputDeviceObserved(currentDevice: String?)
     case outputDeviceChanged(previousDevice: String?, currentDevice: String?)
     case engineConfigurationChanged(engineIsRunning: Bool)
+    case interruptionStateChanged(isInterrupted: Bool, shouldResume: Bool?)
     case systemSleepStateChanged(isSleeping: Bool)
     case screenSleepStateChanged(isSleeping: Bool)
     case sessionActivityChanged(isActive: Bool)

--- a/Sources/SpeakSwiftly/Playback/PlaybackOperations+Events.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackOperations+Events.swift
@@ -213,6 +213,21 @@ extension SpeakSwiftly.Runtime {
                         "had_active_request": .bool(activeRequest != nil),
                     ],
                 )
+            case let .interruptionStateChanged(isInterrupted, shouldResume):
+                var details: [String: LogValue] = [
+                    "is_interrupted": .bool(isInterrupted),
+                    "had_active_request": .bool(activeRequest != nil),
+                ]
+                if let shouldResume {
+                    details["should_resume"] = .bool(shouldResume)
+                }
+                await logEvent(
+                    isInterrupted ? "playback_interruption_began" : "playback_interruption_ended",
+                    requestID: requestID,
+                    op: op,
+                    profileName: profileName,
+                    details: details,
+                )
             case let .systemSleepStateChanged(isSleeping):
                 await logEvent(
                     isSleeping ? "playback_system_sleep_started" : "playback_system_woke",

--- a/Sources/SpeakSwiftly/Playback/PlaybackSupportModels.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackSupportModels.swift
@@ -57,4 +57,5 @@ enum AudioPlaybackRecoveryReason: String {
     case systemWake = "system_wake"
     case outputDeviceChange = "output_device_change"
     case engineConfigurationChange = "engine_configuration_change"
+    case audioSessionInterruption = "audio_session_interruption"
 }

--- a/Sources/SpeakSwiftly/Runtime/WorkerDependencies.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerDependencies.swift
@@ -133,6 +133,9 @@ private func loadFloatAudioSamples(from url: URL, sampleRate: Int) throws -> [Fl
 }
 
 private func currentRuntimeMemorySnapshot() -> RuntimeMemorySnapshot? {
+    let snapshot = Memory.snapshot()
+
+#if os(macOS)
     var usage = rusage_info_current()
     let usageResult = withUnsafeMutablePointer(to: &usage) { pointer in
         pointer.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { rebound in
@@ -140,12 +143,22 @@ private func currentRuntimeMemorySnapshot() -> RuntimeMemorySnapshot? {
         }
     }
 
-    let snapshot = Memory.snapshot()
+    let processResidentBytes = usageResult == 0 ? Int(usage.ri_resident_size) : nil
+    let processPhysFootprintBytes = usageResult == 0 ? Int(usage.ri_phys_footprint) : nil
+    let processUserCPUTimeNS = usageResult == 0 ? Int(usage.ri_user_time) : nil
+    let processSystemCPUTimeNS = usageResult == 0 ? Int(usage.ri_system_time) : nil
+#else
+    let processResidentBytes: Int? = nil
+    let processPhysFootprintBytes: Int? = nil
+    let processUserCPUTimeNS: Int? = nil
+    let processSystemCPUTimeNS: Int? = nil
+#endif
+
     return RuntimeMemorySnapshot(
-        processResidentBytes: usageResult == 0 ? Int(usage.ri_resident_size) : nil,
-        processPhysFootprintBytes: usageResult == 0 ? Int(usage.ri_phys_footprint) : nil,
-        processUserCPUTimeNS: usageResult == 0 ? Int(usage.ri_user_time) : nil,
-        processSystemCPUTimeNS: usageResult == 0 ? Int(usage.ri_system_time) : nil,
+        processResidentBytes: processResidentBytes,
+        processPhysFootprintBytes: processPhysFootprintBytes,
+        processUserCPUTimeNS: processUserCPUTimeNS,
+        processSystemCPUTimeNS: processSystemCPUTimeNS,
         mlxActiveMemoryBytes: snapshot.activeMemory,
         mlxCacheMemoryBytes: snapshot.cacheMemory,
         mlxPeakMemoryBytes: snapshot.peakMemory,

--- a/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedBatchE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedBatchE2ETests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 @testable import SpeakSwiftly
 import Testing
@@ -110,3 +111,4 @@ extension SpeakSwiftlyE2ETests {
         }
     }
 }
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 @testable import SpeakSwiftly
 import Testing
@@ -87,3 +88,4 @@ extension SpeakSwiftlyE2ETests {
         }
     }
 }
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Chatterbox/ChatterboxWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Chatterbox/ChatterboxWorkflowE2ETests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 @testable import SpeakSwiftly
 import Testing
@@ -166,3 +167,4 @@ extension SpeakSwiftlyE2ETests {
         }
     }
 }
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/DeepTrace/DeepTraceE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/DeepTrace/DeepTraceE2ETests.swift
@@ -1,12 +1,18 @@
+#if os(macOS)
 import Foundation
 @testable import SpeakSwiftly
 import Testing
 
 extension SpeakSwiftlyE2ETests {
+    @Suite(
+        .enabled(
+            if: SpeakSwiftlyE2ETests.isDeepTraceE2EEnabled,
+            "This deep-trace suite is opt-in and requires SPEAKSWIFTLY_DEEP_TRACE_E2E=1.",
+        ),
+    )
     struct DeepTraceSuite {
         @Test func `long code heavy`() async throws {
             #expect(SpeakSwiftlyE2ETests.isE2EEnabled)
-            #expect(SpeakSwiftlyE2ETests.isDeepTraceE2EEnabled)
 
             let sandbox = try E2ESandbox()
             defer { sandbox.cleanup() }
@@ -79,7 +85,6 @@ extension SpeakSwiftlyE2ETests {
 
         @Test func `segmented weird text`() async throws {
             #expect(SpeakSwiftlyE2ETests.isE2EEnabled)
-            #expect(SpeakSwiftlyE2ETests.isDeepTraceE2EEnabled)
 
             let sandbox = try E2ESandbox()
             defer { sandbox.cleanup() }
@@ -162,7 +167,6 @@ extension SpeakSwiftlyE2ETests {
 
         @Test func `reversed segmented weird text`() async throws {
             #expect(SpeakSwiftlyE2ETests.isE2EEnabled)
-            #expect(SpeakSwiftlyE2ETests.isDeepTraceE2EEnabled)
 
             let sandbox = try E2ESandbox()
             defer { sandbox.cleanup() }
@@ -245,7 +249,6 @@ extension SpeakSwiftlyE2ETests {
 
         @Test func `segmented conversational prose`() async throws {
             #expect(SpeakSwiftlyE2ETests.isE2EEnabled)
-            #expect(SpeakSwiftlyE2ETests.isDeepTraceE2EEnabled)
 
             let sandbox = try E2ESandbox()
             defer { sandbox.cleanup() }
@@ -327,7 +330,6 @@ extension SpeakSwiftlyE2ETests {
 
         @Test func `reversed segmented conversational prose`() async throws {
             #expect(SpeakSwiftlyE2ETests.isE2EEnabled)
-            #expect(SpeakSwiftlyE2ETests.isDeepTraceE2EEnabled)
 
             let sandbox = try E2ESandbox()
             defer { sandbox.cleanup() }
@@ -408,3 +410,4 @@ extension SpeakSwiftlyE2ETests {
         }
     }
 }
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 @testable import SpeakSwiftly
 import Testing
@@ -381,3 +382,4 @@ extension SpeakSwiftlyE2ETests {
         }
     }
 }
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 @testable import SpeakSwiftly
 import Testing
@@ -660,3 +661,4 @@ private struct BenchmarkError: Error, CustomStringConvertible {
         self.description = description
     }
 }
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenWorkflowE2ETests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 @testable import SpeakSwiftly
 import Testing
@@ -283,3 +284,4 @@ extension SpeakSwiftlyE2ETests {
         }
     }
 }
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/SpeakSwiftlyE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/SpeakSwiftlyE2ETests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Testing
 
 @Suite(
@@ -8,3 +9,4 @@ import Testing
     ),
 )
 enum SpeakSwiftlyE2ETests {}
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 @testable import SpeakSwiftly
 import Testing
@@ -1369,3 +1370,4 @@ extension String {
         return String(encoded.dropFirst(2).dropLast(2))
     }
 }
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Trace/TraceCaptureE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Trace/TraceCaptureE2ETests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 @testable import SpeakSwiftly
 import Testing
@@ -61,3 +62,4 @@ extension SpeakSwiftlyE2ETests {
         }
     }
 }
+#endif

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -5,6 +5,10 @@ import MLXAudioTTS
 import Testing
 import TextForSpeech
 
+private let longPlaybackPlannerFixtureText = """
+Hello from the real resident SpeakSwiftly playback path. This end to end test now uses a longer utterance so we can observe startup buffering, queue floor recovery, drain timing, and steady streaming behavior with enough generated audio to make the diagnostics useful instead of noisy.
+"""
+
 // MARK: - Adaptive Playback Thresholds
 
 @Test func `resident backend repos include chatterbox turbo 8bit`() {
@@ -1308,7 +1312,7 @@ import TextForSpeech
 }
 
 @Test func `live speech chunk planner splits oversized single sentences at clause boundaries`() {
-    let text = SpeakSwiftlyE2ETests.testingPlaybackText
+    let text = longPlaybackPlannerFixtureText
 
     let chunks = LiveSpeechChunkPlanner.chunks(for: text)
 

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimePlaybackTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimePlaybackTests.swift
@@ -369,6 +369,42 @@ private actor EnvironmentEventRecorder {
     #expect(await recorder.events().isEmpty)
 }
 
+@MainActor
+@Test func `non resumable interruption immediately fails the active playback request`() async throws {
+    let driver = AudioPlaybackDriver()
+    let state = AudioPlaybackRequestState(
+        requestID: 7,
+        text: "interruption test",
+        tuningProfile: .standard,
+    )
+    state.queuedSampleCount = 2400
+    driver.activeRequestState = state
+
+    let waitTask = Task {
+        try await driver.awaitPlaybackDrainSignal(
+            state: state,
+            sampleRate: 24000,
+        )
+    }
+
+    await Task.yield()
+    #expect(state.drainContinuation != nil)
+
+    driver.handleInterruptionStateChange(
+        isInterrupted: false,
+        shouldResume: false,
+    )
+
+    await #expect(throws: WorkerError.self) {
+        try await waitTask.value
+    }
+
+    let failure = try #require(driver.activeRuntimeFailure)
+    #expect(failure.code == .audioPlaybackFailed)
+    #expect(failure.message == "Live playback was interrupted and the active audio session reported that this request must not resume automatically.")
+    #expect(driver.playbackRecoveryReason == nil)
+}
+
 @Test func `playback environment events are logged for power session and recovery changes`() async throws {
     let output = OutputRecorder()
     let storeRoot = makeTempDirectoryURL()

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimePlaybackTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimePlaybackTests.swift
@@ -395,6 +395,8 @@ private actor EnvironmentEventRecorder {
                 .screenSleepStateChanged(isSleeping: false),
                 .sessionActivityChanged(isActive: false),
                 .sessionActivityChanged(isActive: true),
+                .interruptionStateChanged(isInterrupted: true, shouldResume: nil),
+                .interruptionStateChanged(isInterrupted: false, shouldResume: true),
                 .recoveryStateChanged(
                     reason: "output_device_change",
                     stage: "recovered",
@@ -431,6 +433,23 @@ private actor EnvironmentEventRecorder {
     #expect(await waitUntil {
         output.containsStderrJSONObject {
             $0["event"] as? String == "playback_session_resigned_active"
+        }
+    })
+    #expect(await waitUntil {
+        output.containsStderrJSONObject {
+            $0["event"] as? String == "playback_interruption_began"
+        }
+    })
+    #expect(await waitUntil {
+        output.containsStderrJSONObject {
+            guard
+                $0["event"] as? String == "playback_interruption_ended",
+                let details = $0["details"] as? [String: Any]
+            else {
+                return false
+            }
+
+            return details["should_resume"] as? Bool == true
         }
     })
     #expect(await waitUntil {

--- a/docs/maintainers/ios-portability-plan-2026-04-17.md
+++ b/docs/maintainers/ios-portability-plan-2026-04-17.md
@@ -9,8 +9,24 @@ implementation order for making `SpeakSwiftly` a realistic iOS-capable Swift
 package.
 
 This is a portability plan, not a claim that the package is already close to
-shipping on iOS. The package is still explicitly macOS-only today, and the main
-reason is the playback runtime.
+shipping on iOS. The package now resolves for both macOS and iOS, but the
+remaining work is still concentrated in playback behavior, platform-aware
+validation, and honest operator guidance around which surfaces are library-first
+versus macOS worker-first.
+
+## Progress Update
+
+As of 2026-04-17, the first portability passes are now in place:
+
+- the playback runtime uses an explicit platform environment seam
+- macOS environment ownership lives in a dedicated adapter
+- the package now includes an initial iOS `AVAudioSession`-based environment
+  adapter
+- `Package.swift` now declares both `.macOS(.v15)` and `.iOS(.v17)`
+
+That means the plan has moved past "make the package graph admit iOS at all" and
+into "prove the iOS path honestly and keep the worker-facing macOS story
+explicit."
 
 ## Documented Apple Constraints
 
@@ -47,66 +63,53 @@ organization and playback-environment modeling, not in package-selection churn.
 
 ## Hard Blockers In The Current Source Tree
 
-### 1. The package manifest is macOS-only
+### 1. The package manifest was macOS-only
 
-`Package.swift` currently declares only:
+This blocker is now resolved. `Package.swift` declares:
 
 - `.macOS(.v15)`
+- `.iOS(.v17)`
 
-That is the first hard stop. iOS cannot enter the package graph until the
-manifest is widened.
+The remaining question is not whether SwiftPM can admit iOS consumers, but
+whether the iOS playback path is honest enough to keep that manifest widening
+accurate.
 
-### 2. Playback imports AppKit directly
+### 2. Playback used to import AppKit directly
 
-These files currently import AppKit:
+This blocker is also resolved. Shared playback files no longer import AppKit
+directly. AppKit and CoreAudio ownership now live in
+`Sources/SpeakSwiftly/Playback/MacOSPlaybackEnvironmentCoordinator.swift`.
 
-- `Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift`
-- `Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift`
+### 3. macOS recovery is modeled around `NSWorkspace`
 
-That means the playback target as written cannot compile for iOS.
+That is still true, but it is no longer a shared-target blocker. The
+`NSWorkspace` observer model now sits behind the macOS-specific playback
+environment adapter instead of leaking into the platform-neutral playback core.
 
-### 3. Playback recovery is modeled around `NSWorkspace`
+### 4. macOS output-device tracking is modeled around CoreAudio system objects
 
-`AudioPlaybackDriver+EnvironmentRecovery.swift` currently listens for:
+That is still the macOS story, and it is the right place for it. CoreAudio
+output-device inspection no longer lives in the shared playback files; it now
+belongs to the macOS playback-environment adapter.
 
-- system sleep and wake
-- screen sleep and wake
-- session resign-active and become-active
+### 5. Playback startup used to assume macOS routing arbitration
 
-Those are all driven through `NSWorkspace.shared.notificationCenter`, which is a
-desktop environment model. iOS does not offer the same lifecycle surface.
+That is now isolated as well. The shared playback lifecycle no longer owns
+`AVAudioRoutingArbiter` directly; the macOS adapter handles it, while the iOS
+adapter activates an `AVAudioSession` instead.
 
-### 4. Output-device tracking is modeled around macOS CoreAudio system objects
+### 6. The iOS audio-session model is now deliberately minimal
 
-These files use `AudioObject*` APIs and the default output-device system object:
+The package now contains an initial iOS playback environment adapter based on
+`AVAudioSession`, including:
 
-- `Sources/SpeakSwiftly/Playback/PlaybackConfiguration.swift`
-- `Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift`
-- `Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift`
+- playback-category activation
+- route-change observation
+- interruption observation
+- interruption-driven playback recovery hints
 
-That device-inspection model is tied to macOS output-device ownership. It is
-not the iOS route and interruption model.
-
-### 5. Playback startup explicitly assumes macOS routing arbitration
-
-`AudioPlaybackDriver+PlaybackLifecycle.swift` currently begins playback through
-`AVAudioRoutingArbiter` and even emits a user-facing error that says:
-
-- `macOS audio routing arbitration`
-
-That path is not the right primitive for iOS playback startup.
-
-### 6. There is no iOS audio-session model in the package yet
-
-The current `Sources/SpeakSwiftly` tree does not contain:
-
-- `AVAudioSession`
-- route-change handling
-- interruption handling
-- iOS-style audio-session activation or category management
-
-So even after removing macOS-only imports, the package would still be missing
-the native playback-environment behavior iOS expects.
+That is enough to make the playback seam honest, but it is still an early iOS
+path rather than a claim of polished feature parity with the macOS worker flow.
 
 ## What Already Looks Portable
 

--- a/docs/maintainers/ios-portability-plan-2026-04-17.md
+++ b/docs/maintainers/ios-portability-plan-2026-04-17.md
@@ -1,0 +1,272 @@
+# iOS Portability Plan
+
+Date: 2026-04-17
+
+## Purpose
+
+This note records the current source-level blockers and the recommended
+implementation order for making `SpeakSwiftly` a realistic iOS-capable Swift
+package.
+
+This is a portability plan, not a claim that the package is already close to
+shipping on iOS. The package is still explicitly macOS-only today, and the main
+reason is the playback runtime.
+
+## Documented Apple Constraints
+
+These Apple platform rules are the architectural guardrails for the plan:
+
+- `NSWorkspace` is an AppKit type and a macOS environment surface, not an iOS
+  API:
+  - <https://developer.apple.com/documentation/appkit/nsworkspace>
+- `AVAudioRoutingArbiter` exists so macOS apps can participate in AirPods
+  Automatic Switching, while iOS apps already participate automatically:
+  - <https://developer.apple.com/documentation/avfaudio/avaudioroutingarbiter>
+- On iOS, playback apps should configure and activate an `AVAudioSession`
+  instead of relying on desktop-style output-device arbitration and workspace
+  notifications:
+  - <https://developer.apple.com/documentation/avfoundation/configuring-your-app-for-media-playback#Configure-the-audio-session>
+
+Those three rules mean the current macOS playback-environment handling cannot be
+made portable by sprinkling `#if os(iOS)` around the existing code. The package
+needs a narrow platform boundary around playback environment ownership.
+
+## Good News First
+
+The upstream dependency story is not the blocker right now:
+
+- `TextForSpeech` `0.17.2` declares:
+  - `.iOS(.v17)`
+  - `.macOS(.v14)`
+- `mlx-audio-swift` `69.1.5` declares:
+  - `.macOS(.v14)`
+  - `.iOS(.v17)`
+
+That means the immediate portability pressure is in `SpeakSwiftly` source
+organization and playback-environment modeling, not in package-selection churn.
+
+## Hard Blockers In The Current Source Tree
+
+### 1. The package manifest is macOS-only
+
+`Package.swift` currently declares only:
+
+- `.macOS(.v15)`
+
+That is the first hard stop. iOS cannot enter the package graph until the
+manifest is widened.
+
+### 2. Playback imports AppKit directly
+
+These files currently import AppKit:
+
+- `Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift`
+- `Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift`
+
+That means the playback target as written cannot compile for iOS.
+
+### 3. Playback recovery is modeled around `NSWorkspace`
+
+`AudioPlaybackDriver+EnvironmentRecovery.swift` currently listens for:
+
+- system sleep and wake
+- screen sleep and wake
+- session resign-active and become-active
+
+Those are all driven through `NSWorkspace.shared.notificationCenter`, which is a
+desktop environment model. iOS does not offer the same lifecycle surface.
+
+### 4. Output-device tracking is modeled around macOS CoreAudio system objects
+
+These files use `AudioObject*` APIs and the default output-device system object:
+
+- `Sources/SpeakSwiftly/Playback/PlaybackConfiguration.swift`
+- `Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift`
+- `Sources/SpeakSwiftly/Playback/AudioPlaybackDriver+EnvironmentRecovery.swift`
+
+That device-inspection model is tied to macOS output-device ownership. It is
+not the iOS route and interruption model.
+
+### 5. Playback startup explicitly assumes macOS routing arbitration
+
+`AudioPlaybackDriver+PlaybackLifecycle.swift` currently begins playback through
+`AVAudioRoutingArbiter` and even emits a user-facing error that says:
+
+- `macOS audio routing arbitration`
+
+That path is not the right primitive for iOS playback startup.
+
+### 6. There is no iOS audio-session model in the package yet
+
+The current `Sources/SpeakSwiftly` tree does not contain:
+
+- `AVAudioSession`
+- route-change handling
+- interruption handling
+- iOS-style audio-session activation or category management
+
+So even after removing macOS-only imports, the package would still be missing
+the native playback-environment behavior iOS expects.
+
+## What Already Looks Portable
+
+These areas are not the main problem:
+
+- `Storage/ProfileStore.swift` uses
+  `FileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)`,
+  which is a reasonable sandbox-friendly default for both platforms.
+- Normalization, generation, runtime queueing, request observation, and most of
+  the typed API surface do not appear to be inherently desktop-only.
+- The newest `TextForSpeech` and current `mlx-audio-swift` baselines already
+  advertise iOS support, which lowers the risk of starting this work now.
+
+## Recommended Architectural Split
+
+The durable shape is:
+
+1. Keep one platform-neutral playback core.
+2. Move platform environment monitoring into a narrow playback-environment
+   boundary.
+3. Implement one macOS environment adapter and one iOS environment adapter.
+
+In concrete repo terms, that means:
+
+- keep audio buffering, queue draining, chunk scheduling, and playback summary
+  logic in the shared playback driver path
+- move desktop lifecycle observation out of the main driver type
+- stop letting the core playback type own raw `NSWorkspace` and CoreAudio device
+  listeners directly
+- introduce a narrow protocol or helper boundary for:
+  - route preparation
+  - route or environment observation
+  - interruption or recovery triggers
+  - optional platform diagnostics
+
+This should stay a small building-block change, not a new subsystem. The goal
+is one explicit platform seam inside playback, not a new manager or coordinator
+stack.
+
+## Proposed File-Level Reshape
+
+### Shared files that should remain platform-neutral
+
+- `PlaybackOperations.swift`
+- `PlaybackOperations+Events.swift`
+- `PlaybackExecutionState.swift`
+- `PlaybackSupportModels.swift`
+- `PlaybackEvents.swift`
+- the queue-drain and scheduling parts of `AudioPlaybackDriver`
+
+### macOS-specific code that should be isolated
+
+- `NSWorkspace` observers
+- CoreAudio default-output-device inspection
+- CoreAudio output-device change listeners
+- `AVAudioRoutingArbiter`
+
+### iOS-specific code that will need to be added
+
+- `AVAudioSession` category selection and activation
+- interruption handling
+- route-change handling
+- any iOS-only app-state coordination that is genuinely required for playback
+  recovery
+
+## Concrete Work Order
+
+### Phase 1: Create the playback platform seam
+
+- Extract desktop-only environment observation out of
+  `AudioPlaybackDriver.swift` and
+  `AudioPlaybackDriver+EnvironmentRecovery.swift`.
+- Define the smallest shared boundary that the playback core needs.
+- Keep the shared playback driver responsible for playback itself, not for
+  learning platform lifecycle semantics.
+
+Exit goal:
+
+- shared playback code compiles without importing AppKit directly
+- desktop-specific code lives behind one explicit playback-environment boundary
+
+### Phase 2: Preserve macOS behavior behind the new boundary
+
+- Re-home the existing `NSWorkspace`, CoreAudio output-device, and routing
+  arbitration logic into a macOS-specific implementation.
+- Keep current macOS recovery behavior working before adding iOS.
+
+Exit goal:
+
+- macOS behavior remains functionally equivalent after the split
+- the macOS path proves the seam is real instead of speculative
+
+### Phase 3: Add an iOS playback-environment implementation
+
+- Add an iOS-specific playback environment owner based on `AVAudioSession`.
+- Model:
+  - audio-session configuration
+  - activation
+  - interruption handling
+  - route-change handling
+- Keep the initial iOS path deliberately minimal and honest. It does not need
+  to chase macOS feature parity on day one if the underlying lifecycle model is
+  different.
+
+Exit goal:
+
+- the library target can compile for iOS
+- playback startup and recovery use iOS-native audio-session semantics instead
+  of desktop emulation
+
+### Phase 4: Widen the package manifest
+
+- Change `Package.swift` from macOS-only to:
+  - `.macOS(.v15)`
+  - `.iOS(.v17)`
+- Re-check whether `SpeakSwiftlyTool` should remain part of the same package
+  surface unchanged or whether it needs an explicit macOS-only posture in docs
+  and validation.
+
+Exit goal:
+
+- SwiftPM can resolve the library for iOS consumers without lying about
+  supported platforms
+
+### Phase 5: Add platform-aware validation lanes
+
+- Keep the current macOS Xcode-backed lane for release-grade MLX coverage.
+- Add an iOS compile-and-smoke lane focused on:
+  - package resolution
+  - iOS target compilation
+  - playback-environment compile coverage
+- Do not block early iOS architecture work on full real-model simulator or
+  device automation until the playback seam is in place.
+
+Exit goal:
+
+- maintainers can tell whether a regression is:
+  - shared playback logic
+  - macOS environment glue
+  - iOS environment glue
+
+## What Not To Do
+
+- Do not try to make `NSWorkspace` or CoreAudio output-device code
+  conditionally portable with scattered `#if os(iOS)` checks.
+- Do not bury platform differences inside `AudioPlaybackDriver` until it becomes
+  a giant platform switchboard.
+- Do not start by adding a new cross-cutting playback manager or coordinator.
+- Do not widen the package manifest to iOS before the playback seam exists,
+  because that will turn the package into a compile-failure magnet.
+
+## Suggested First Slice
+
+The best first implementation slice is:
+
+1. isolate `NSWorkspace`, CoreAudio device inspection, and routing arbitration
+   from `AudioPlaybackDriver`
+2. keep current macOS behavior intact behind that seam
+3. only then add the first iOS `AVAudioSession` implementation
+
+That slice earns its complexity immediately because it removes the real source
+blockers without forcing the package into an iOS-ready claim before the playback
+runtime can actually support it.

--- a/docs/maintainers/ios-portability-plan-2026-04-17.md
+++ b/docs/maintainers/ios-portability-plan-2026-04-17.md
@@ -23,6 +23,10 @@ As of 2026-04-17, the first portability passes are now in place:
 - the package now includes an initial iOS `AVAudioSession`-based environment
   adapter
 - `Package.swift` now declares both `.macOS(.v15)` and `.iOS(.v17)`
+- the Xcode-backed package lane now builds for iOS Simulator and runs a small
+  library-first smoke suite
+- the worker-driven e2e sources are now fenced as macOS-only so the shared test
+  target can compile honestly for iOS
 
 That means the plan has moved past "make the package graph admit iOS at all" and
 into "prove the iOS path honestly and keep the worker-facing macOS story
@@ -243,6 +247,21 @@ Exit goal:
   - playback-environment compile coverage
 - Do not block early iOS architecture work on full real-model simulator or
   device automation until the playback seam is in place.
+
+Current status:
+
+- this lane now exists in local validation and CI as an iOS Simulator
+  build-for-testing pass plus a targeted smoke subset:
+  - `SpeakSwiftlyTests/LibrarySurfaceTests`
+  - `SpeakSwiftlyTests/SupportResourcesTests`
+  - `SpeakSwiftlyTests/ProfileStoreTests`
+- the lane is intentionally library-first rather than worker-first, because the
+  current e2e harness launches the published CLI worker process and therefore
+  remains a macOS concern
+- one source-level portability cleanup was needed for this lane:
+  `WorkerDependencies.currentRuntimeMemorySnapshot()` now treats
+  `proc_pid_rusage` as macOS-only instead of pretending that process-rusage API
+  exists on iOS
 
 Exit goal:
 

--- a/docs/maintainers/validation-lanes.md
+++ b/docs/maintainers/validation-lanes.md
@@ -69,11 +69,45 @@ swift package dump-package
 
 Then use the same Xcode-backed package lane for build-and-test coverage instead
 of plain `swift build` / `swift test` until the vendored parser snag is gone.
-The current CI target set is:
+The current macOS CI target set is:
 
 - `SpeakSwiftlyTests/WorkerRuntimePlaybackTests`
 - `SpeakSwiftlyTests/LibrarySurfaceTests`
 - `SpeakSwiftlyTests/ModelClientsTests`
+
+## iOS Compile-And-Smoke Lane
+
+The iOS lane is intentionally smaller than the macOS package lane. Its job is
+to prove that:
+
+- the package resolves for iOS
+- the shared library and playback-environment code compile for iOS Simulator
+- a small library-first smoke slice still runs under Simulator
+
+Build once:
+
+```bash
+xcodebuild build-for-testing -quiet \
+  -scheme SpeakSwiftly-Package \
+  -destination 'platform=iOS Simulator,id=<simulator-udid>' \
+  -derivedDataPath .local/xcode/derived-data/ios-smoke \
+  -clonedSourcePackagesDirPath .local/xcode/source-packages
+```
+
+Then run the current smoke slice:
+
+```bash
+xcodebuild test-without-building -quiet \
+  -xctestrun "$(find .local/xcode/derived-data/ios-smoke/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" \
+  -destination 'platform=iOS Simulator,id=<simulator-udid>' \
+  -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests' \
+  -only-testing:'SpeakSwiftlyTests/SupportResourcesTests' \
+  -only-testing:'SpeakSwiftlyTests/ProfileStoreTests'
+```
+
+Keep this lane library-first. The worker-driven e2e harness is macOS-only and
+should stay out of the iOS simulator smoke path unless we deliberately create an
+app-hosted iOS e2e story later.
 
 ## E2E and Real-Model Notes
 

--- a/docs/releases/v3-0-9-release-notes.md
+++ b/docs/releases/v3-0-9-release-notes.md
@@ -1,0 +1,69 @@
+# v3.0.9 Release Notes
+
+## What changed
+
+- added an iOS Simulator compile-and-smoke validation lane to CI
+- fenced the worker-driven e2e harness as macOS-only so the shared package test
+  target compiles honestly for iOS
+- fixed runtime memory snapshot portability by treating `proc_pid_rusage` as a
+  macOS-only API
+- documented the new iOS validation lane across README, CONTRIBUTING, and
+  maintainer notes
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- this is a patch release focused on portability and validation hardening
+- the iOS validation lane is intentionally library-first and simulator-based; it
+  does not yet imply a full app-hosted or real-device iOS end-to-end workflow
+- macOS worker e2e coverage remains macOS-only because the current harness
+  launches the published CLI worker process
+
+## Verification performed
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```
+
+```bash
+xcodebuild build-for-testing \
+  -scheme SpeakSwiftly-Package \
+  -destination 'platform=macOS' \
+  -derivedDataPath .local/xcode/derived-data/release-v3-0-9-macos \
+  -clonedSourcePackagesDirPath .local/xcode/source-packages
+```
+
+```bash
+xcodebuild test-without-building \
+  -xctestrun .local/xcode/derived-data/release-v3-0-9-macos/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/WorkerRuntimePlaybackTests' \
+  -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests'
+```
+
+```bash
+xcodebuild test-without-building \
+  -xctestrun .local/xcode/derived-data/release-v3-0-9-macos/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/ModelClientsTests'
+```
+
+```bash
+xcodebuild build-for-testing \
+  -scheme SpeakSwiftly-Package \
+  -destination 'platform=iOS Simulator,id=4343A7EF-1074-44EB-8FD6-7972330DD08E' \
+  -derivedDataPath .local/xcode/derived-data/ios-smoke \
+  -clonedSourcePackagesDirPath .local/xcode/source-packages
+```
+
+```bash
+xcodebuild test-without-building \
+  -xctestrun .local/xcode/derived-data/ios-smoke/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_iphonesimulator26.4-arm64.xctestrun \
+  -destination 'platform=iOS Simulator,id=4343A7EF-1074-44EB-8FD6-7972330DD08E' \
+  -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests' \
+  -only-testing:'SpeakSwiftlyTests/SupportResourcesTests' \
+  -only-testing:'SpeakSwiftlyTests/ProfileStoreTests'
+```

--- a/docs/releases/v3-0-9-release-prep.md
+++ b/docs/releases/v3-0-9-release-prep.md
@@ -1,0 +1,99 @@
+# v3.0.9 Release Prep
+
+Date: 2026-04-17
+
+This note captures the intended scope and validation story for the `v3.0.9`
+patch release.
+
+## Intended Scope
+
+The release should be framed as:
+
+- an iOS portability and validation hardening pass
+- a package-test cleanup that keeps macOS worker e2e coverage out of the iOS
+  simulator smoke lane
+- a small runtime portability fix for process-rusage inspection on non-macOS
+  platforms
+
+Included work on the current branch:
+
+- add an iOS Simulator compile-and-smoke CI lane to `.github/workflows/swift.yml`
+- document the iOS lane in maintainer notes, README, and CONTRIBUTING guidance
+- fence `Tests/SpeakSwiftlyTests/E2E/` as macOS-only so the shared test target
+  compiles honestly for iOS
+- move the long chunk-planner fixture in `ModelClientsTests` out of the macOS
+  e2e harness
+- make `WorkerDependencies.currentRuntimeMemorySnapshot()` treat
+  `proc_pid_rusage` as macOS-only and return `nil` process-rusage fields on iOS
+
+Not included:
+
+- a new public API surface
+- a new app-hosted iOS end-to-end harness
+- a change to the macOS-first worker-runtime ownership model
+
+## SemVer Framing
+
+- this should ship as a patch release
+- the work widens supported validation and compile coverage, but it does not
+  add a new consumer-facing feature flag or break an existing public contract
+
+## Validation Performed
+
+Shared guidance and formatting gate:
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```
+
+macOS Xcode-backed package validation:
+
+```bash
+xcodebuild build-for-testing \
+  -scheme SpeakSwiftly-Package \
+  -destination 'platform=macOS' \
+  -derivedDataPath .local/xcode/derived-data/release-v3-0-9-macos \
+  -clonedSourcePackagesDirPath .local/xcode/source-packages
+```
+
+```bash
+xcodebuild test-without-building \
+  -xctestrun .local/xcode/derived-data/release-v3-0-9-macos/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/WorkerRuntimePlaybackTests' \
+  -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests'
+```
+
+```bash
+xcodebuild test-without-building \
+  -xctestrun .local/xcode/derived-data/release-v3-0-9-macos/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/ModelClientsTests'
+```
+
+iOS Simulator compile-and-smoke validation:
+
+```bash
+xcodebuild build-for-testing \
+  -scheme SpeakSwiftly-Package \
+  -destination 'platform=iOS Simulator,id=4343A7EF-1074-44EB-8FD6-7972330DD08E' \
+  -derivedDataPath .local/xcode/derived-data/ios-smoke \
+  -clonedSourcePackagesDirPath .local/xcode/source-packages
+```
+
+```bash
+xcodebuild test-without-building \
+  -xctestrun .local/xcode/derived-data/ios-smoke/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_iphonesimulator26.4-arm64.xctestrun \
+  -destination 'platform=iOS Simulator,id=4343A7EF-1074-44EB-8FD6-7972330DD08E' \
+  -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests' \
+  -only-testing:'SpeakSwiftlyTests/SupportResourcesTests' \
+  -only-testing:'SpeakSwiftlyTests/ProfileStoreTests'
+```
+
+## Release Checklist
+
+- keep the release notes focused on portability and validation hardening, not as
+  a new app-facing feature release
+- call out that the iOS lane is still a library-first simulator smoke lane, not
+  a full app-hosted or real-device end-to-end harness
+- mention that macOS worker e2e coverage remains macOS-only by design


### PR DESCRIPTION
## Summary

- add an iOS Simulator compile-and-smoke lane to CI
- keep the shared package test target compiling on iOS by fencing the worker-driven E2E harness as macOS-only
- document the new portability and validation story across README, CONTRIBUTING, maintainer notes, and v3.0.9 release notes

## Verification

- `sh scripts/repo-maintenance/validate-all.sh`
- `xcodebuild build-for-testing -quiet -scheme SpeakSwiftly-Package -destination 'platform=macOS' -derivedDataPath .local/xcode/derived-data/release-v3-0-9-macos -clonedSourcePackagesDirPath .local/xcode/source-packages`
- `xcodebuild test-without-building -quiet -xctestrun .local/xcode/derived-data/release-v3-0-9-macos/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/WorkerRuntimePlaybackTests' -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests'
- `xcodebuild test-without-building -quiet -xctestrun .local/xcode/derived-data/release-v3-0-9-macos/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/ModelClientsTests'
- `xcodebuild build-for-testing -quiet -scheme SpeakSwiftly-Package -destination 'platform=iOS Simulator,id=4343A7EF-1074-44EB-8FD6-7972330DD08E' -derivedDataPath .local/xcode/derived-data/ios-smoke -clonedSourcePackagesDirPath .local/xcode/source-packages`
- `xcodebuild test-without-building -quiet -xctestrun .local/xcode/derived-data/ios-smoke/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_iphonesimulator26.4-arm64.xctestrun -destination 'platform=iOS Simulator,id=4343A7EF-1074-44EB-8FD6-7972330DD08E' -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests' -only-testing:'SpeakSwiftlyTests/SupportResourcesTests' -only-testing:'SpeakSwiftlyTests/ProfileStoreTests'
