### PR TITLE
tests: format e2e suite sources for validation

### DIFF
--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -139,7 +139,7 @@ import Darwin
     #expect(await normalizer.persistence.url() == expectedURL)
 }
 
-@Test func `liftoff normalizer persistence matches the default text profile path`() async throws {
+@Test func `liftoff normalizer persistence matches the default text profile path`() async {
     let overrideRoot = makeTempDirectoryURL()
     defer { try? FileManager.default.removeItem(at: overrideRoot) }
 

--- a/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedBatchE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedBatchE2ETests.swift
@@ -4,7 +4,6 @@ import Foundation
 import Testing
 
 @Suite(
-    "Generated Batch E2E",
     .serialized,
     .tags(.e2e, .artifacts, .quick),
     .enabled(

--- a/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
@@ -4,7 +4,6 @@ import Foundation
 import Testing
 
 @Suite(
-    "Generated File E2E",
     .serialized,
     .tags(.e2e, .artifacts, .quick),
     .enabled(

--- a/Tests/SpeakSwiftlyTests/E2E/Chatterbox/ChatterboxWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Chatterbox/ChatterboxWorkflowE2ETests.swift
@@ -4,7 +4,6 @@ import Foundation
 import Testing
 
 @Suite(
-    "Chatterbox E2E",
     .serialized,
     .tags(.e2e, .chatterbox),
     .enabled(

--- a/Tests/SpeakSwiftlyTests/E2E/DeepTrace/DeepTraceE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/DeepTrace/DeepTraceE2ETests.swift
@@ -4,7 +4,6 @@ import Foundation
 import Testing
 
 @Suite(
-    "Deep Trace E2E",
     .serialized,
     .tags(.e2e, .deepTrace, .trace),
     .enabled(
@@ -17,392 +16,392 @@ import Testing
     ),
 )
 struct DeepTraceE2ETests {
-        @Test func `long code heavy`() async throws {
-            let sandbox = try E2ESandbox()
-            defer { sandbox.cleanup() }
+    @Test func `long code heavy`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
 
-            let worker = try WorkerProcess(
-                profileRootURL: sandbox.profileRootURL,
-                silentPlayback: false,
-                playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
-            )
-            defer { Task { await worker.stop() } }
+        let worker = try WorkerProcess(
+            profileRootURL: sandbox.profileRootURL,
+            silentPlayback: false,
+            playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
+        )
+        defer { Task { await worker.stop() } }
 
-            try await E2EHarness.awaitWorkerReady(worker)
-            try await E2EHarness.createVoiceDesignProfile(
-                on: worker,
-                id: "req-create-deep-trace",
-                profileName: E2EHarness.testingProfileName,
-                text: E2EHarness.testingProfileText,
-                vibe: .masc,
-                voiceDescription: E2EHarness.testingProfileVoiceDescription,
-            )
+        try await E2EHarness.awaitWorkerReady(worker)
+        try await E2EHarness.createVoiceDesignProfile(
+            on: worker,
+            id: "req-create-deep-trace",
+            profileName: E2EHarness.testingProfileName,
+            text: E2EHarness.testingProfileText,
+            vibe: .masc,
+            voiceDescription: E2EHarness.testingProfileVoiceDescription,
+        )
 
-            try worker.sendJSON(
-                """
-                {"id":"req-live-deep-trace","op":"generate_speech","text":"\(E2EHarness.deepTracePlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
-                """,
-            )
+        try worker.sendJSON(
+            """
+            {"id":"req-live-deep-trace","op":"generate_speech","text":"\(E2EHarness.deepTracePlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            """,
+        )
 
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-deep-trace"
-                    && $0["event"] as? String == "progress"
-                    && $0["stage"] as? String == "buffering_audio"
-            } != nil)
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-deep-trace"
-                    && $0["event"] as? String == "progress"
-                    && $0["stage"] as? String == "preroll_ready"
-            } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-deep-trace"
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "buffering_audio"
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-deep-trace"
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "preroll_ready"
+        } != nil)
 
-            let playbackFinished = try #require(
-                try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
-                    guard
-                        $0["event"] as? String == "playback_finished",
-                        $0["request_id"] as? String == "req-live-deep-trace",
-                        let details = $0["details"] as? [String: Any]
-                    else {
-                        return false
-                    }
-
-                    return details["chunk_count"] as? Int != nil
-                        && details["sample_count"] as? Int != nil
-                        && details["time_to_first_chunk_ms"] as? Int != nil
-                        && details["time_to_preroll_ready_ms"] as? Int != nil
-                        && details["schedule_callback_count"] as? Int != nil
-                        && details["played_back_callback_count"] as? Int != nil
-                },
-            )
-
-            let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
-            #expect((playbackDetails["chunk_count"] as? Int ?? 0) > 1)
-            #expect((playbackDetails["sample_count"] as? Int ?? 0) > 0)
-
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-deep-trace"
-                    && $0["ok"] as? Bool == true
-            } != nil)
-
-            try worker.closeInput()
-            try await worker.waitForExit(timeout: .seconds(30))
-        }
-
-        @Test func `segmented weird text`() async throws {
-            let sandbox = try E2ESandbox()
-            defer { sandbox.cleanup() }
-
-            let worker = try WorkerProcess(
-                profileRootURL: sandbox.profileRootURL,
-                silentPlayback: false,
-                playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
-            )
-            defer { Task { await worker.stop() } }
-
-            try await E2EHarness.awaitWorkerReady(worker)
-            try await E2EHarness.createVoiceDesignProfile(
-                on: worker,
-                id: "req-create-segmented",
-                profileName: E2EHarness.testingProfileName,
-                text: E2EHarness.testingProfileText,
-                vibe: .masc,
-                voiceDescription: E2EHarness.testingProfileVoiceDescription,
-            )
-
-            try worker.sendJSON(
-                """
-                {"id":"req-live-segmented","op":"generate_speech","text":"\(E2EHarness.segmentedDeepTracePlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
-                """,
-            )
-
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-segmented"
-                    && $0["event"] as? String == "progress"
-                    && $0["stage"] as? String == "preroll_ready"
-            } != nil)
-
-            let playbackFinished = try #require(
-                try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
-                    guard
-                        $0["event"] as? String == "playback_finished",
-                        $0["request_id"] as? String == "req-live-segmented",
-                        let details = $0["details"] as? [String: Any]
-                    else {
-                        return false
-                    }
-
-                    return (details["markdown_header_count"] as? Int ?? 0) >= 5
-                        && (details["url_count"] as? Int ?? 0) >= 1
-                        && (details["file_path_count"] as? Int ?? 0) >= 1
-                        && (details["dotted_identifier_count"] as? Int ?? 0) >= 2
-                        && (details["camel_case_token_count"] as? Int ?? 0) >= 1
-                        && (details["snake_case_token_count"] as? Int ?? 0) >= 1
-                        && (details["objc_symbol_count"] as? Int ?? 0) >= 1
-                        && (details["repeated_letter_run_count"] as? Int ?? 0) >= 2
-                },
-            )
-
-            let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
-            #expect((playbackDetails["rebuffer_event_count"] as? Int ?? 0) >= 0)
-            #expect((playbackDetails["normalized_character_count"] as? Int ?? 0) > 0)
-            #expect((playbackDetails["section_count"] as? Int ?? 0) >= 5)
-            #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+        let playbackFinished = try #require(
+            try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
                 guard
-                    $0["event"] as? String == "playback_section_window",
+                    $0["event"] as? String == "playback_finished",
+                    $0["request_id"] as? String == "req-live-deep-trace",
+                    let details = $0["details"] as? [String: Any]
+                else {
+                    return false
+                }
+
+                return details["chunk_count"] as? Int != nil
+                    && details["sample_count"] as? Int != nil
+                    && details["time_to_first_chunk_ms"] as? Int != nil
+                    && details["time_to_preroll_ready_ms"] as? Int != nil
+                    && details["schedule_callback_count"] as? Int != nil
+                    && details["played_back_callback_count"] as? Int != nil
+            },
+        )
+
+        let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
+        #expect((playbackDetails["chunk_count"] as? Int ?? 0) > 1)
+        #expect((playbackDetails["sample_count"] as? Int ?? 0) > 0)
+
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-deep-trace"
+                && $0["ok"] as? Bool == true
+        } != nil)
+
+        try worker.closeInput()
+        try await worker.waitForExit(timeout: .seconds(30))
+    }
+
+    @Test func `segmented weird text`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        let worker = try WorkerProcess(
+            profileRootURL: sandbox.profileRootURL,
+            silentPlayback: false,
+            playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
+        )
+        defer { Task { await worker.stop() } }
+
+        try await E2EHarness.awaitWorkerReady(worker)
+        try await E2EHarness.createVoiceDesignProfile(
+            on: worker,
+            id: "req-create-segmented",
+            profileName: E2EHarness.testingProfileName,
+            text: E2EHarness.testingProfileText,
+            vibe: .masc,
+            voiceDescription: E2EHarness.testingProfileVoiceDescription,
+        )
+
+        try worker.sendJSON(
+            """
+            {"id":"req-live-segmented","op":"generate_speech","text":"\(E2EHarness.segmentedDeepTracePlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            """,
+        )
+
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-segmented"
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "preroll_ready"
+        } != nil)
+
+        let playbackFinished = try #require(
+            try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+                guard
+                    $0["event"] as? String == "playback_finished",
                     $0["request_id"] as? String == "req-live-segmented",
                     let details = $0["details"] as? [String: Any]
                 else {
                     return false
                 }
 
-                return details["section_title"] as? String == "Section Two"
-                    && (details["estimated_end_ms"] as? Int ?? 0) > (details["estimated_start_ms"] as? Int ?? 0)
-                    && (details["estimated_end_chunk"] as? Int ?? 0) > (details["estimated_start_chunk"] as? Int ?? 0)
-            } != nil)
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-segmented"
-                    && $0["ok"] as? Bool == true
-            } != nil)
+                return (details["markdown_header_count"] as? Int ?? 0) >= 5
+                    && (details["url_count"] as? Int ?? 0) >= 1
+                    && (details["file_path_count"] as? Int ?? 0) >= 1
+                    && (details["dotted_identifier_count"] as? Int ?? 0) >= 2
+                    && (details["camel_case_token_count"] as? Int ?? 0) >= 1
+                    && (details["snake_case_token_count"] as? Int ?? 0) >= 1
+                    && (details["objc_symbol_count"] as? Int ?? 0) >= 1
+                    && (details["repeated_letter_run_count"] as? Int ?? 0) >= 2
+            },
+        )
 
-            try worker.closeInput()
-            try await worker.waitForExit(timeout: .seconds(30))
-        }
+        let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
+        #expect((playbackDetails["rebuffer_event_count"] as? Int ?? 0) >= 0)
+        #expect((playbackDetails["normalized_character_count"] as? Int ?? 0) > 0)
+        #expect((playbackDetails["section_count"] as? Int ?? 0) >= 5)
+        #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+            guard
+                $0["event"] as? String == "playback_section_window",
+                $0["request_id"] as? String == "req-live-segmented",
+                let details = $0["details"] as? [String: Any]
+            else {
+                return false
+            }
 
-        @Test func `reversed segmented weird text`() async throws {
-            let sandbox = try E2ESandbox()
-            defer { sandbox.cleanup() }
+            return details["section_title"] as? String == "Section Two"
+                && (details["estimated_end_ms"] as? Int ?? 0) > (details["estimated_start_ms"] as? Int ?? 0)
+                && (details["estimated_end_chunk"] as? Int ?? 0) > (details["estimated_start_chunk"] as? Int ?? 0)
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-segmented"
+                && $0["ok"] as? Bool == true
+        } != nil)
 
-            let worker = try WorkerProcess(
-                profileRootURL: sandbox.profileRootURL,
-                silentPlayback: false,
-                playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
-            )
-            defer { Task { await worker.stop() } }
+        try worker.closeInput()
+        try await worker.waitForExit(timeout: .seconds(30))
+    }
 
-            try await E2EHarness.awaitWorkerReady(worker)
-            try await E2EHarness.createVoiceDesignProfile(
-                on: worker,
-                id: "req-create-reversed-segmented",
-                profileName: E2EHarness.testingProfileName,
-                text: E2EHarness.testingProfileText,
-                vibe: .masc,
-                voiceDescription: E2EHarness.testingProfileVoiceDescription,
-            )
+    @Test func `reversed segmented weird text`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
 
-            try worker.sendJSON(
-                """
-                {"id":"req-live-reversed-segmented","op":"generate_speech","text":"\(E2EHarness.reversedSegmentedDeepTracePlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
-                """,
-            )
+        let worker = try WorkerProcess(
+            profileRootURL: sandbox.profileRootURL,
+            silentPlayback: false,
+            playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
+        )
+        defer { Task { await worker.stop() } }
 
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-reversed-segmented"
-                    && $0["event"] as? String == "progress"
-                    && $0["stage"] as? String == "preroll_ready"
-            } != nil)
+        try await E2EHarness.awaitWorkerReady(worker)
+        try await E2EHarness.createVoiceDesignProfile(
+            on: worker,
+            id: "req-create-reversed-segmented",
+            profileName: E2EHarness.testingProfileName,
+            text: E2EHarness.testingProfileText,
+            vibe: .masc,
+            voiceDescription: E2EHarness.testingProfileVoiceDescription,
+        )
 
-            let playbackFinished = try #require(
-                try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
-                    guard
-                        $0["event"] as? String == "playback_finished",
-                        $0["request_id"] as? String == "req-live-reversed-segmented",
-                        let details = $0["details"] as? [String: Any]
-                    else {
-                        return false
-                    }
+        try worker.sendJSON(
+            """
+            {"id":"req-live-reversed-segmented","op":"generate_speech","text":"\(E2EHarness.reversedSegmentedDeepTracePlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            """,
+        )
 
-                    return (details["markdown_header_count"] as? Int ?? 0) >= 5
-                        && (details["url_count"] as? Int ?? 0) >= 1
-                        && (details["file_path_count"] as? Int ?? 0) >= 1
-                        && (details["dotted_identifier_count"] as? Int ?? 0) >= 2
-                        && (details["camel_case_token_count"] as? Int ?? 0) >= 1
-                        && (details["snake_case_token_count"] as? Int ?? 0) >= 1
-                        && (details["objc_symbol_count"] as? Int ?? 0) >= 1
-                        && (details["repeated_letter_run_count"] as? Int ?? 0) >= 2
-                },
-            )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-reversed-segmented"
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "preroll_ready"
+        } != nil)
 
-            let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
-            #expect((playbackDetails["rebuffer_event_count"] as? Int ?? 0) >= 0)
-            #expect((playbackDetails["normalized_character_count"] as? Int ?? 0) > 0)
-            #expect((playbackDetails["section_count"] as? Int ?? 0) >= 5)
-            #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+        let playbackFinished = try #require(
+            try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
                 guard
-                    $0["event"] as? String == "playback_section_window",
+                    $0["event"] as? String == "playback_finished",
                     $0["request_id"] as? String == "req-live-reversed-segmented",
                     let details = $0["details"] as? [String: Any]
                 else {
                     return false
                 }
 
-                return details["section_title"] as? String == "Footer"
-                    && (details["estimated_end_ms"] as? Int ?? 0) > (details["estimated_start_ms"] as? Int ?? 0)
-                    && (details["estimated_end_chunk"] as? Int ?? 0) > (details["estimated_start_chunk"] as? Int ?? 0)
-            } != nil)
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-reversed-segmented"
-                    && $0["ok"] as? Bool == true
-            } != nil)
+                return (details["markdown_header_count"] as? Int ?? 0) >= 5
+                    && (details["url_count"] as? Int ?? 0) >= 1
+                    && (details["file_path_count"] as? Int ?? 0) >= 1
+                    && (details["dotted_identifier_count"] as? Int ?? 0) >= 2
+                    && (details["camel_case_token_count"] as? Int ?? 0) >= 1
+                    && (details["snake_case_token_count"] as? Int ?? 0) >= 1
+                    && (details["objc_symbol_count"] as? Int ?? 0) >= 1
+                    && (details["repeated_letter_run_count"] as? Int ?? 0) >= 2
+            },
+        )
 
-            try worker.closeInput()
-            try await worker.waitForExit(timeout: .seconds(30))
-        }
+        let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
+        #expect((playbackDetails["rebuffer_event_count"] as? Int ?? 0) >= 0)
+        #expect((playbackDetails["normalized_character_count"] as? Int ?? 0) > 0)
+        #expect((playbackDetails["section_count"] as? Int ?? 0) >= 5)
+        #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+            guard
+                $0["event"] as? String == "playback_section_window",
+                $0["request_id"] as? String == "req-live-reversed-segmented",
+                let details = $0["details"] as? [String: Any]
+            else {
+                return false
+            }
 
-        @Test func `segmented conversational prose`() async throws {
-            let sandbox = try E2ESandbox()
-            defer { sandbox.cleanup() }
+            return details["section_title"] as? String == "Footer"
+                && (details["estimated_end_ms"] as? Int ?? 0) > (details["estimated_start_ms"] as? Int ?? 0)
+                && (details["estimated_end_chunk"] as? Int ?? 0) > (details["estimated_start_chunk"] as? Int ?? 0)
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-reversed-segmented"
+                && $0["ok"] as? Bool == true
+        } != nil)
 
-            let worker = try WorkerProcess(
-                profileRootURL: sandbox.profileRootURL,
-                silentPlayback: false,
-                playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
-            )
-            defer { Task { await worker.stop() } }
+        try worker.closeInput()
+        try await worker.waitForExit(timeout: .seconds(30))
+    }
 
-            try await E2EHarness.awaitWorkerReady(worker)
-            try await E2EHarness.createVoiceDesignProfile(
-                on: worker,
-                id: "req-create-conversational",
-                profileName: E2EHarness.testingProfileName,
-                text: E2EHarness.testingProfileText,
-                vibe: .masc,
-                voiceDescription: E2EHarness.testingProfileVoiceDescription,
-            )
+    @Test func `segmented conversational prose`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
 
-            try worker.sendJSON(
-                """
-                {"id":"req-live-conversational","op":"generate_speech","text":"\(E2EHarness.segmentedConversationalPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
-                """,
-            )
+        let worker = try WorkerProcess(
+            profileRootURL: sandbox.profileRootURL,
+            silentPlayback: false,
+            playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
+        )
+        defer { Task { await worker.stop() } }
 
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-conversational"
-                    && $0["event"] as? String == "progress"
-                    && $0["stage"] as? String == "preroll_ready"
-            } != nil)
+        try await E2EHarness.awaitWorkerReady(worker)
+        try await E2EHarness.createVoiceDesignProfile(
+            on: worker,
+            id: "req-create-conversational",
+            profileName: E2EHarness.testingProfileName,
+            text: E2EHarness.testingProfileText,
+            vibe: .masc,
+            voiceDescription: E2EHarness.testingProfileVoiceDescription,
+        )
 
-            let playbackFinished = try #require(
-                try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
-                    guard
-                        $0["event"] as? String == "playback_finished",
-                        $0["request_id"] as? String == "req-live-conversational",
-                        let details = $0["details"] as? [String: Any]
-                    else {
-                        return false
-                    }
+        try worker.sendJSON(
+            """
+            {"id":"req-live-conversational","op":"generate_speech","text":"\(E2EHarness.segmentedConversationalPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            """,
+        )
 
-                    return (details["markdown_header_count"] as? Int ?? 0) >= 5
-                        && (details["file_path_count"] as? Int ?? 0) == 0
-                        && (details["dotted_identifier_count"] as? Int ?? 0) == 0
-                        && (details["camel_case_token_count"] as? Int ?? 0) == 0
-                        && (details["snake_case_token_count"] as? Int ?? 0) == 0
-                        && (details["objc_symbol_count"] as? Int ?? 0) == 0
-                        && (details["repeated_letter_run_count"] as? Int ?? 0) == 0
-                },
-            )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-conversational"
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "preroll_ready"
+        } != nil)
 
-            let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
-            #expect((playbackDetails["rebuffer_event_count"] as? Int ?? 0) >= 0)
-            #expect((playbackDetails["normalized_character_count"] as? Int ?? 0) > 0)
-            #expect((playbackDetails["section_count"] as? Int ?? 0) >= 5)
-            #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+        let playbackFinished = try #require(
+            try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
                 guard
-                    $0["event"] as? String == "playback_section_window",
+                    $0["event"] as? String == "playback_finished",
                     $0["request_id"] as? String == "req-live-conversational",
                     let details = $0["details"] as? [String: Any]
                 else {
                     return false
                 }
 
-                return details["section_title"] as? String == "Section Two"
-                    && (details["estimated_end_ms"] as? Int ?? 0) > (details["estimated_start_ms"] as? Int ?? 0)
-                    && (details["estimated_end_chunk"] as? Int ?? 0) > (details["estimated_start_chunk"] as? Int ?? 0)
-            } != nil)
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-conversational"
-                    && $0["ok"] as? Bool == true
-            } != nil)
+                return (details["markdown_header_count"] as? Int ?? 0) >= 5
+                    && (details["file_path_count"] as? Int ?? 0) == 0
+                    && (details["dotted_identifier_count"] as? Int ?? 0) == 0
+                    && (details["camel_case_token_count"] as? Int ?? 0) == 0
+                    && (details["snake_case_token_count"] as? Int ?? 0) == 0
+                    && (details["objc_symbol_count"] as? Int ?? 0) == 0
+                    && (details["repeated_letter_run_count"] as? Int ?? 0) == 0
+            },
+        )
 
-            try worker.closeInput()
-            try await worker.waitForExit(timeout: .seconds(30))
-        }
+        let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
+        #expect((playbackDetails["rebuffer_event_count"] as? Int ?? 0) >= 0)
+        #expect((playbackDetails["normalized_character_count"] as? Int ?? 0) > 0)
+        #expect((playbackDetails["section_count"] as? Int ?? 0) >= 5)
+        #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+            guard
+                $0["event"] as? String == "playback_section_window",
+                $0["request_id"] as? String == "req-live-conversational",
+                let details = $0["details"] as? [String: Any]
+            else {
+                return false
+            }
 
-        @Test func `reversed segmented conversational prose`() async throws {
-            let sandbox = try E2ESandbox()
-            defer { sandbox.cleanup() }
+            return details["section_title"] as? String == "Section Two"
+                && (details["estimated_end_ms"] as? Int ?? 0) > (details["estimated_start_ms"] as? Int ?? 0)
+                && (details["estimated_end_chunk"] as? Int ?? 0) > (details["estimated_start_chunk"] as? Int ?? 0)
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-conversational"
+                && $0["ok"] as? Bool == true
+        } != nil)
 
-            let worker = try WorkerProcess(
-                profileRootURL: sandbox.profileRootURL,
-                silentPlayback: false,
-                playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
-            )
-            defer { Task { await worker.stop() } }
+        try worker.closeInput()
+        try await worker.waitForExit(timeout: .seconds(30))
+    }
 
-            try await E2EHarness.awaitWorkerReady(worker)
-            try await E2EHarness.createVoiceDesignProfile(
-                on: worker,
-                id: "req-create-reversed-conversational",
-                profileName: E2EHarness.testingProfileName,
-                text: E2EHarness.testingProfileText,
-                vibe: .masc,
-                voiceDescription: E2EHarness.testingProfileVoiceDescription,
-            )
+    @Test func `reversed segmented conversational prose`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
 
-            try worker.sendJSON(
-                """
-                {"id":"req-live-reversed-conversational","op":"generate_speech","text":"\(E2EHarness.reversedSegmentedConversationalPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
-                """,
-            )
+        let worker = try WorkerProcess(
+            profileRootURL: sandbox.profileRootURL,
+            silentPlayback: false,
+            playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
+        )
+        defer { Task { await worker.stop() } }
 
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-reversed-conversational"
-                    && $0["event"] as? String == "progress"
-                    && $0["stage"] as? String == "preroll_ready"
-            } != nil)
+        try await E2EHarness.awaitWorkerReady(worker)
+        try await E2EHarness.createVoiceDesignProfile(
+            on: worker,
+            id: "req-create-reversed-conversational",
+            profileName: E2EHarness.testingProfileName,
+            text: E2EHarness.testingProfileText,
+            vibe: .masc,
+            voiceDescription: E2EHarness.testingProfileVoiceDescription,
+        )
 
-            let playbackFinished = try #require(
-                try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
-                    guard
-                        $0["event"] as? String == "playback_finished",
-                        $0["request_id"] as? String == "req-live-reversed-conversational",
-                        let details = $0["details"] as? [String: Any]
-                    else {
-                        return false
-                    }
+        try worker.sendJSON(
+            """
+            {"id":"req-live-reversed-conversational","op":"generate_speech","text":"\(E2EHarness.reversedSegmentedConversationalPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            """,
+        )
 
-                    return (details["markdown_header_count"] as? Int ?? 0) >= 5
-                        && (details["file_path_count"] as? Int ?? 0) == 0
-                        && (details["dotted_identifier_count"] as? Int ?? 0) == 0
-                        && (details["camel_case_token_count"] as? Int ?? 0) == 0
-                        && (details["snake_case_token_count"] as? Int ?? 0) == 0
-                        && (details["objc_symbol_count"] as? Int ?? 0) == 0
-                        && (details["repeated_letter_run_count"] as? Int ?? 0) == 0
-                },
-            )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-reversed-conversational"
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "preroll_ready"
+        } != nil)
 
-            let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
-            #expect((playbackDetails["rebuffer_event_count"] as? Int ?? 0) >= 0)
-            #expect((playbackDetails["normalized_character_count"] as? Int ?? 0) > 0)
-            #expect((playbackDetails["section_count"] as? Int ?? 0) >= 5)
-            #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+        let playbackFinished = try #require(
+            try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
                 guard
-                    $0["event"] as? String == "playback_section_window",
+                    $0["event"] as? String == "playback_finished",
                     $0["request_id"] as? String == "req-live-reversed-conversational",
                     let details = $0["details"] as? [String: Any]
                 else {
                     return false
                 }
 
-                return details["section_title"] as? String == "Footer"
-                    && (details["estimated_end_ms"] as? Int ?? 0) > (details["estimated_start_ms"] as? Int ?? 0)
-                    && (details["estimated_end_chunk"] as? Int ?? 0) > (details["estimated_start_chunk"] as? Int ?? 0)
-            } != nil)
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-reversed-conversational"
-                    && $0["ok"] as? Bool == true
-            } != nil)
+                return (details["markdown_header_count"] as? Int ?? 0) >= 5
+                    && (details["file_path_count"] as? Int ?? 0) == 0
+                    && (details["dotted_identifier_count"] as? Int ?? 0) == 0
+                    && (details["camel_case_token_count"] as? Int ?? 0) == 0
+                    && (details["snake_case_token_count"] as? Int ?? 0) == 0
+                    && (details["objc_symbol_count"] as? Int ?? 0) == 0
+                    && (details["repeated_letter_run_count"] as? Int ?? 0) == 0
+            },
+        )
 
-            try worker.closeInput()
-            try await worker.waitForExit(timeout: .seconds(30))
-        }
+        let playbackDetails = try #require(playbackFinished["details"] as? [String: Any])
+        #expect((playbackDetails["rebuffer_event_count"] as? Int ?? 0) >= 0)
+        #expect((playbackDetails["normalized_character_count"] as? Int ?? 0) > 0)
+        #expect((playbackDetails["section_count"] as? Int ?? 0) >= 5)
+        #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+            guard
+                $0["event"] as? String == "playback_section_window",
+                $0["request_id"] as? String == "req-live-reversed-conversational",
+                let details = $0["details"] as? [String: Any]
+            else {
+                return false
+            }
+
+            return details["section_title"] as? String == "Footer"
+                && (details["estimated_end_ms"] as? Int ?? 0) > (details["estimated_start_ms"] as? Int ?? 0)
+                && (details["estimated_end_chunk"] as? Int ?? 0) > (details["estimated_start_chunk"] as? Int ?? 0)
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-reversed-conversational"
+                && $0["ok"] as? Bool == true
+        } != nil)
+
+        try worker.closeInput()
+        try await worker.waitForExit(timeout: .seconds(30))
+    }
 }
 #endif

--- a/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import SpeakSwiftly
 import Testing
 
-enum MarvisRouteCase: String, CaseIterable, Sendable {
+enum MarvisRouteCase: String, CaseIterable {
     case femme
     case mascClone
     case androgenous
@@ -77,7 +77,7 @@ enum MarvisRouteCase: String, CaseIterable, Sendable {
     }
 }
 
-private struct MarvisProfileLane: Sendable {
+private struct MarvisProfileLane {
     let createID: String
     let liveID: String
     let profileName: String
@@ -114,7 +114,6 @@ private struct MarvisProfileLane: Sendable {
 }
 
 @Suite(
-    "Marvis E2E",
     .serialized,
     .tags(.e2e, .marvis),
     .enabled(
@@ -123,8 +122,8 @@ private struct MarvisProfileLane: Sendable {
     ),
 )
 struct MarvisE2ETests {
-    @Test("routes expected conversational voice", arguments: MarvisRouteCase.allCases)
-    func routesExpectedConversationalVoice(testCase: MarvisRouteCase) async throws {
+    @Test(arguments: MarvisRouteCase.allCases)
+    func `routes expected conversational voice`(testCase: MarvisRouteCase) async throws {
         let sandbox = try E2ESandbox()
         defer { sandbox.cleanup() }
 

--- a/Tests/SpeakSwiftlyTests/E2E/QuickTest/QuickE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/QuickTest/QuickE2ETests.swift
@@ -4,7 +4,6 @@ import Foundation
 import Testing
 
 @Suite(
-    "Quick E2E",
     .serialized,
     .tags(.e2e, .quick),
     .enabled(

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
@@ -6,7 +6,6 @@ import Testing
 private let qwenBenchmarkSchemaVersion = 3
 
 @Suite(
-    "Qwen Benchmark E2E",
     .serialized,
     .tags(.e2e, .qwen, .benchmark),
     .enabled(

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenWorkflowE2ETests.swift
@@ -4,7 +4,6 @@ import Foundation
 import Testing
 
 @Suite(
-    "Qwen E2E",
     .serialized,
     .tags(.e2e, .qwen),
     .enabled(

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
@@ -118,6 +118,10 @@ enum E2EHarness {
     Please read this opening section in a steady, friendly tone. We are checking how the worker sounds over a longer stretch of ordinary conversational prose, with enough breathing room and variety to make the trace useful instead of tiny and noisy.
     """
 
+    static var e2eTimeout: Duration {
+        .seconds(1200)
+    }
+
     static func awaitWorkerReady(
         _ worker: WorkerProcess,
     ) async throws {
@@ -236,38 +240,38 @@ enum E2EHarness {
         }
     }
 
-	static func runSilentSpeech(
-		on worker: WorkerProcess,
-		id: String,
-		text: String,
-		profileName: String,
-	) async throws {
-		try worker.sendJSON(
-			"""
-			{"id":"\(id)","op":"generate_speech","text":"\(text.jsonEscaped)","profile_name":"\(profileName)"}
-			""",
-		)
+    static func runSilentSpeech(
+        on worker: WorkerProcess,
+        id: String,
+        text: String,
+        profileName: String,
+    ) async throws {
+        try worker.sendJSON(
+            """
+            {"id":"\(id)","op":"generate_speech","text":"\(text.jsonEscaped)","profile_name":"\(profileName)"}
+            """,
+        )
 
-		#expect(try await worker.waitForJSONObject(timeout: e2eTimeout) {
-			$0["id"] as? String == id
-			&& $0["event"] as? String == "started"
-			&& $0["op"] as? String == "generate_speech"
-		} != nil)
-		#expect(try await worker.waitForJSONObject(timeout: e2eTimeout) {
-			$0["id"] as? String == id
-			&& $0["event"] as? String == "progress"
-			&& $0["stage"] as? String == "buffering_audio"
-		} != nil)
-		#expect(try await worker.waitForJSONObject(timeout: e2eTimeout) {
-			$0["id"] as? String == id
-			&& $0["event"] as? String == "progress"
-			&& $0["stage"] as? String == "playback_finished"
-		} != nil)
-		#expect(try await worker.waitForJSONObject(timeout: e2eTimeout) {
-			$0["id"] as? String == id
-			&& $0["ok"] as? Bool == true
-		} != nil)
-	}
+        #expect(try await worker.waitForJSONObject(timeout: e2eTimeout) {
+            $0["id"] as? String == id
+                && $0["event"] as? String == "started"
+                && $0["op"] as? String == "generate_speech"
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: e2eTimeout) {
+            $0["id"] as? String == id
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "buffering_audio"
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: e2eTimeout) {
+            $0["id"] as? String == id
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "playback_finished"
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: e2eTimeout) {
+            $0["id"] as? String == id
+                && $0["ok"] as? Bool == true
+        } != nil)
+    }
 
     static func runAudibleSpeech(
         on worker: WorkerProcess,
@@ -552,10 +556,6 @@ enum E2EHarness {
                 .filter { !$0.isEmpty },
         )
     }
-
-    static var e2eTimeout: Duration {
-        .seconds(1200)
-    }
 }
 
 // MARK: - E2ESandbox
@@ -768,6 +768,12 @@ final class WorkerProcess: @unchecked Sendable {
         artifacts.recordProcessID(process.processIdentifier)
     }
 
+    deinit {
+        closeCapturedOutputs()
+        stdoutTask.cancel()
+        stderrTask.cancel()
+    }
+
     private static func workerProfileRootOverrideURL(for profileRootURL: URL) -> URL {
         guard profileRootURL.lastPathComponent == ProfileStore.profilesDirectoryName else {
             return profileRootURL
@@ -778,12 +784,6 @@ final class WorkerProcess: @unchecked Sendable {
         // so it can derive profiles/, configuration.json, and text-profiles.json
         // consistently without nesting profiles/profiles/.
         return profileRootURL.deletingLastPathComponent()
-    }
-
-    deinit {
-        closeCapturedOutputs()
-        stdoutTask.cancel()
-        stderrTask.cancel()
     }
 
     private static func captureLines(

--- a/Tests/SpeakSwiftlyTests/E2E/Trace/TraceCaptureE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Trace/TraceCaptureE2ETests.swift
@@ -4,7 +4,6 @@ import Foundation
 import Testing
 
 @Suite(
-    "Trace Capture E2E",
     .serialized,
     .tags(.e2e, .trace),
     .enabled(
@@ -17,52 +16,52 @@ import Testing
     ),
 )
 struct TraceCaptureE2ETests {
-        @Test func `capture on demand`() async throws {
-            let sandbox = try E2ESandbox()
-            defer { sandbox.cleanup() }
+    @Test func `capture on demand`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
 
-            let worker = try WorkerProcess(
-                profileRootURL: sandbox.profileRootURL,
-                silentPlayback: false,
-                playbackTrace: true,
-            )
-            defer { Task { await worker.stop() } }
+        let worker = try WorkerProcess(
+            profileRootURL: sandbox.profileRootURL,
+            silentPlayback: false,
+            playbackTrace: true,
+        )
+        defer { Task { await worker.stop() } }
 
-            try await E2EHarness.awaitWorkerReady(worker)
-            try await E2EHarness.createVoiceDesignProfile(
-                on: worker,
-                id: "req-create-trace",
-                profileName: E2EHarness.testingProfileName,
-                text: E2EHarness.testingProfileText,
-                vibe: .masc,
-                voiceDescription: E2EHarness.testingProfileVoiceDescription,
-            )
+        try await E2EHarness.awaitWorkerReady(worker)
+        try await E2EHarness.createVoiceDesignProfile(
+            on: worker,
+            id: "req-create-trace",
+            profileName: E2EHarness.testingProfileName,
+            text: E2EHarness.testingProfileText,
+            vibe: .masc,
+            voiceDescription: E2EHarness.testingProfileVoiceDescription,
+        )
 
-            try worker.sendJSON(
-                """
-                {"id":"req-live-trace","op":"generate_speech","text":"\(E2EHarness.testingPlaybackText)","profile_name":"\(E2EHarness.testingProfileName)"}
-                """,
-            )
+        try worker.sendJSON(
+            """
+            {"id":"req-live-trace","op":"generate_speech","text":"\(E2EHarness.testingPlaybackText)","profile_name":"\(E2EHarness.testingProfileName)"}
+            """,
+        )
 
-            #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["event"] as? String == "playback_trace_chunk_received"
-                    && $0["request_id"] as? String == "req-live-trace"
-            } != nil)
-            #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["event"] as? String == "playback_trace_buffer_scheduled"
-                    && $0["request_id"] as? String == "req-live-trace"
-            } != nil)
-            #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["event"] as? String == "playback_trace_buffer_played_back"
-                    && $0["request_id"] as? String == "req-live-trace"
-            } != nil)
-            #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
-                $0["id"] as? String == "req-live-trace"
-                    && $0["ok"] as? Bool == true
-            } != nil)
+        #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["event"] as? String == "playback_trace_chunk_received"
+                && $0["request_id"] as? String == "req-live-trace"
+        } != nil)
+        #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["event"] as? String == "playback_trace_buffer_scheduled"
+                && $0["request_id"] as? String == "req-live-trace"
+        } != nil)
+        #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["event"] as? String == "playback_trace_buffer_played_back"
+                && $0["request_id"] as? String == "req-live-trace"
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-live-trace"
+                && $0["ok"] as? Bool == true
+        } != nil)
 
-            try worker.closeInput()
-            try await worker.waitForExit(timeout: .seconds(30))
-        }
+        try worker.closeInput()
+        try await worker.waitForExit(timeout: .seconds(30))
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- apply the checked-in SwiftFormat rules across the E2E suite files touched by the recent refactor
- keep the branch green against `scripts/repo-maintenance/validate-all.sh` after the merged profile-root override follow-up
- carry forward the `v3.1.0` release tag on the current passing head

## Testing
- `bash scripts/repo-maintenance/validate-all.sh`
- `sh scripts/repo-maintenance/run-e2e-full.sh`
