### PR TITLE
build: align mlx-swift pinning and add qwen decay probes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -723,7 +723,7 @@ SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_DEEP_TRACE_E2E=1 swift test --filter DeepTraceE2
 Opt-in qwen resident benchmark comparison:
 
 ```bash
-sh scripts/repo-maintenance/run-e2e.sh --suite qwen-benchmark --benchmark
+sh scripts/repo-maintenance/run-benchmark.sh --qwen
 SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1 swift test --filter QwenBenchmarkE2ETests
 ```
 
@@ -732,11 +732,24 @@ Without `SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1`, the benchmark suite is skipped duri
 Run multiple comparison samples per Qwen conditioning strategy:
 
 ```bash
-sh scripts/repo-maintenance/run-e2e.sh --suite qwen-benchmark --benchmark --benchmark-iterations 3
+sh scripts/repo-maintenance/run-benchmark.sh --qwen --iterations 3
 SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1 SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS=3 swift test --filter QwenBenchmarkE2ETests
 ```
 
 Each benchmark run persists a timestamped JSON summary under `.local/benchmarks` and refreshes `.local/benchmarks/qwen-resident-benchmark-latest.json` for quick inspection.
+
+Opt-in backend-wide queued live benchmark comparison:
+
+```bash
+sh scripts/repo-maintenance/run-benchmark.sh
+sh scripts/repo-maintenance/run-benchmark.sh --audible --iterations 3
+SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1 swift test --filter BackendBenchmarkE2ETests
+```
+
+The backend-wide suite runs the same two-request live benchmark scenario across
+`qwen3`, `chatterbox_turbo`, and `marvis`. The second request is expected to
+queue behind the first one; if it does not, the suite now fails so the queued
+benchmark contract cannot silently drift into a non-queued workload.
 
 Section-aware weird-text deep-trace probes:
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9280ae85fbc587bef76543d4c9cbb5b3ff2334ec634b6103e392baca2fb329c2",
+  "originHash" : "45b1192a75535e522b815a08dcce27584621c12e8c3b55fc0441236b57595aa3",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/mlx-audio-swift.git",
       "state" : {
-        "revision" : "a40ac9fb1ce8f4ead5f8d913ef1f15fb80e69847",
-        "version" : "69.2.0"
+        "revision" : "dfb55adee9437e973b98b9dbd00caa30d48b3809",
+        "version" : "0.7.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "0a1e5adca30cfe520171419218372506cd70115a",
-        "version" : "0.18.0"
+        "revision" : "810ad9e60650d8d9617aa61060f461dfcfe43839",
+        "version" : "0.18.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,11 +26,15 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/gaelic-ghost/TextForSpeech.git",
-            .upToNextMajor(from: "0.18.0"),
+            .upToNextMajor(from: "0.18.2"),
         ),
         .package(
             url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",
-            from: "69.2.0",
+            exact: "0.7.0",
+        ),
+        .package(
+            url: "https://github.com/ml-explore/mlx-swift.git",
+            .upToNextMajor(from: "0.30.6"),
         ),
     ],
     targets: [
@@ -63,7 +67,12 @@ let package = Package(
         ),
         .executableTarget(
             name: "SpeakSwiftlyTesting",
-            dependencies: ["SpeakSwiftly"],
+            dependencies: [
+                "SpeakSwiftly",
+                .product(name: "MLXAudioTTS", package: "mlx-audio-swift"),
+                .product(name: "MLXAudioCore", package: "mlx-audio-swift"),
+                .product(name: "MLX", package: "mlx-swift"),
+            ],
         ),
     ],
     swiftLanguageModes: [

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ swift build
 swift test
 ```
 
-The current `mlx-audio-swift` `69.2.0` fork pin restores the ordinary SwiftPM
+The current `mlx-audio-swift` `0.7.0` fork pin restores the ordinary SwiftPM
 build and test path. If a future toolchain regression brings back the old
 `EnglishG2P.swift` parser failure, use the documented fallback lane in
 [CONTRIBUTING.md](CONTRIBUTING.md) instead of repeatedly retrying the same
@@ -182,9 +182,12 @@ The package also ships a small executable consumer harness, `SpeakSwiftlyTesting
 swift run SpeakSwiftlyTesting resources
 swift run SpeakSwiftlyTesting status
 swift run SpeakSwiftlyTesting smoke
+swift run SpeakSwiftlyTesting create-design-profile --profile probe-fresh-a --voice "A steady, intimate, softly spoken feminine voice with even projection."
+swift run SpeakSwiftlyTesting volume-probe --profile default-femme --profile-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16
+swift run SpeakSwiftlyTesting compare-volume --profile default-femme --profile-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16
 ```
 
-`resources` prints the packaged bundle and metallib paths, `status` constructs the typed runtime and prints the first terminal status payload it sees, and `smoke` runs both checks in sequence.
+`resources` prints the packaged bundle and metallib paths, `status` constructs the typed runtime and prints the first terminal status payload it sees, `smoke` runs both checks in sequence, `create-design-profile` creates and stores a fresh voice-design profile through the typed runtime, `volume-probe` generates a retained file then prints per-window RMS and peak measurements so long-form loudness drift can be inspected against a real stored profile, and `compare-volume` runs that retained-file path against a direct non-stream Qwen decode using the same stored profile conditioning so the drift can be compared side by side.
 
 ## API Notes
 

--- a/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
+++ b/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
@@ -1,12 +1,123 @@
 import Foundation
+@preconcurrency import MLX
+import MLXAudioCore
+import MLXAudioTTS
 import SpeakSwiftly
 
 @main
 struct SpeakSwiftlyTestingMain {
+    static let profileRootOverrideEnvironmentVariable = "SPEAKSWIFTLY_PROFILE_ROOT"
+
     enum Command: String {
         case resources
         case status
         case smoke
+        case createDesignProfile = "create-design-profile"
+        case volumeProbe = "volume-probe"
+        case compareVolume = "compare-volume"
+    }
+
+    struct CreateDesignProfileOptions {
+        var profileName: String
+        var sourceText = "Hello there from SpeakSwiftly end-to-end coverage."
+        var vibe = "femme"
+        var voiceDescription: String
+        var profileRoot: String?
+    }
+
+    struct VolumeProbeOptions {
+        var profileName = "default-femme"
+        var profileRoot: String?
+        var textFile: String?
+        var repeatCount = 10
+        var windowSeconds = 2.0
+    }
+
+    struct VolumeWindow {
+        let index: Int
+        let startSeconds: Double
+        let durationSeconds: Double
+        let rms: Double
+        let peak: Double
+    }
+
+    struct VolumeSummary {
+        let firstRMS: Double
+        let lastRMS: Double
+        let rmsDropPercent: Double
+        let slopePerWindow: Double
+        let firstPeak: Double
+        let lastPeak: Double
+    }
+
+    struct ProbeAnalysis {
+        let sampleRate: Int
+        let windows: [VolumeWindow]
+        let summary: VolumeSummary?
+    }
+
+    struct CompareRun {
+        let generatedFilePath: String
+        let analysis: ProbeAnalysis
+    }
+
+    struct ComparisonResult {
+        let streamed: CompareRun
+        let direct: CompareRun
+    }
+
+    struct ProbeProfileManifest: Decodable {
+        let backendMaterializations: [ProbeMaterializationManifest]
+        let qwenConditioningArtifacts: [ProbeConditioningArtifactManifest]
+    }
+
+    struct ProbeMaterializationManifest: Decodable {
+        let backend: String
+        let modelRepo: String
+        let referenceAudioFile: String
+        let referenceText: String
+        let sampleRate: Int
+    }
+
+    struct ProbeConditioningArtifactManifest: Decodable {
+        let backend: String
+        let artifactFile: String
+    }
+
+    struct ProbePersistedQwenConditioningArtifact: Decodable {
+        let speakerEmbedding: ProbeFloatTensor?
+        let referenceSpeechCodes: ProbeInt32Tensor
+        let referenceTextTokenIDs: ProbeInt32Tensor
+        let resolvedLanguage: String
+        let codecLanguageID: Int?
+
+        func makeConditioning() -> Qwen3TTSModel.Qwen3TTSReferenceConditioning {
+            Qwen3TTSModel.Qwen3TTSReferenceConditioning(
+                speakerEmbedding: speakerEmbedding?.makeArray(),
+                referenceSpeechCodes: referenceSpeechCodes.makeArray(),
+                referenceTextTokenIDs: referenceTextTokenIDs.makeArray(),
+                resolvedLanguage: resolvedLanguage,
+                codecLanguageID: codecLanguageID,
+            )
+        }
+    }
+
+    struct ProbeFloatTensor: Decodable {
+        let values: [Float]
+        let shape: [Int]
+
+        func makeArray() -> MLXArray {
+            MLXArray(values).reshaped(shape)
+        }
+    }
+
+    struct ProbeInt32Tensor: Decodable {
+        let values: [Int32]
+        let shape: [Int]
+
+        func makeArray() -> MLXArray {
+            MLXArray(values).reshaped(shape)
+        }
     }
 
     static func main() async {
@@ -19,7 +130,8 @@ struct SpeakSwiftlyTestingMain {
     }
 
     static func run() async throws {
-        let command = try parseCommand()
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        let command = try parseCommand(arguments: arguments)
 
         switch command {
             case .resources:
@@ -29,22 +141,130 @@ struct SpeakSwiftlyTestingMain {
             case .smoke:
                 try printResources()
                 try await printStatus()
+            case .createDesignProfile:
+                let options = try parseCreateDesignProfileOptions(arguments: arguments)
+                try await runCreateDesignProfile(options: options)
+            case .volumeProbe:
+                let options = try parseVolumeProbeOptions(arguments: arguments)
+                try await runVolumeProbe(options: options)
+            case .compareVolume:
+                let options = try parseVolumeProbeOptions(arguments: arguments)
+                try await runCompareVolume(options: options)
         }
     }
 
-    static func parseCommand() throws -> Command {
-        let arguments = Array(CommandLine.arguments.dropFirst())
+    static func parseCommand(arguments: [String]) throws -> Command {
         guard let rawCommand = arguments.first else {
             throw UsageError.missingCommand
         }
         guard let command = Command(rawValue: rawCommand) else {
             throw UsageError.unknownCommand(rawCommand)
         }
-        guard arguments.count == 1 else {
+        if command != .volumeProbe,
+           command != .compareVolume,
+           command != .createDesignProfile,
+           arguments.count != 1
+        {
             throw UsageError.unexpectedArguments(arguments.dropFirst().joined(separator: " "))
         }
 
         return command
+    }
+
+    static func parseCreateDesignProfileOptions(arguments: [String]) throws -> CreateDesignProfileOptions {
+        var profileName: String?
+        var voiceDescription: String?
+        var options = CreateDesignProfileOptions(
+            profileName: "",
+            voiceDescription: "",
+        )
+        var index = 1
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+                case "--profile":
+                    index += 1
+                    profileName = try requireOptionValue(arguments, index: index, for: argument)
+                case "--voice":
+                    index += 1
+                    voiceDescription = try requireOptionValue(arguments, index: index, for: argument)
+                case "--text":
+                    index += 1
+                    options.sourceText = try requireOptionValue(arguments, index: index, for: argument)
+                case "--vibe":
+                    index += 1
+                    options.vibe = try requireOptionValue(arguments, index: index, for: argument)
+                case "--profile-root":
+                    index += 1
+                    options.profileRoot = try requireOptionValue(arguments, index: index, for: argument)
+                default:
+                    throw UsageError.unknownCommand(argument)
+            }
+            index += 1
+        }
+
+        guard let profileName, !profileName.isEmpty else {
+            throw UsageError.missingRequiredOption("--profile")
+        }
+        guard let voiceDescription, !voiceDescription.isEmpty else {
+            throw UsageError.missingRequiredOption("--voice")
+        }
+
+        options.profileName = profileName
+        options.voiceDescription = voiceDescription
+        return options
+    }
+
+    static func parseVolumeProbeOptions(arguments: [String]) throws -> VolumeProbeOptions {
+        var options = VolumeProbeOptions()
+        var index = 1
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+                case "--profile":
+                    index += 1
+                    options.profileName = try requireOptionValue(arguments, index: index, for: argument)
+                case "--profile-root":
+                    index += 1
+                    options.profileRoot = try requireOptionValue(arguments, index: index, for: argument)
+                case "--text-file":
+                    index += 1
+                    options.textFile = try requireOptionValue(arguments, index: index, for: argument)
+                case "--repeat":
+                    index += 1
+                    let value = try requireOptionValue(arguments, index: index, for: argument)
+                    guard let repeatCount = Int(value), repeatCount > 0 else {
+                        throw UsageError.invalidOptionValue(argument, value)
+                    }
+                    options.repeatCount = repeatCount
+                case "--window-seconds":
+                    index += 1
+                    let value = try requireOptionValue(arguments, index: index, for: argument)
+                    guard let windowSeconds = Double(value), windowSeconds > 0 else {
+                        throw UsageError.invalidOptionValue(argument, value)
+                    }
+                    options.windowSeconds = windowSeconds
+                default:
+                    throw UsageError.unknownCommand(argument)
+            }
+            index += 1
+        }
+
+        return options
+    }
+
+    static func requireOptionValue(
+        _ arguments: [String],
+        index: Int,
+        for option: String,
+    ) throws -> String {
+        guard index < arguments.count else {
+            throw UsageError.missingOptionValue(option)
+        }
+
+        return arguments[index]
     }
 
     static func printResources() throws {
@@ -85,6 +305,583 @@ struct SpeakSwiftlyTestingMain {
         throw UsageError.statusStreamEndedWithoutTerminalEvent
     }
 
+    static func runVolumeProbe(options: VolumeProbeOptions) async throws {
+        if let profileRoot = options.profileRoot {
+            setenv(profileRootOverrideEnvironmentVariable, profileRoot, 1)
+        }
+
+        let text = try loadVolumeProbeText(options: options)
+        let result = try await runStreamedProbe(
+            profileName: options.profileName,
+            text: text,
+            windowSeconds: options.windowSeconds,
+        )
+
+        print("profile_name: \(options.profileName)")
+        if let profileRoot = options.profileRoot {
+            print("profile_root: \(profileRoot)")
+        }
+        print("text_characters: \(text.count)")
+        print("text_words: \(text.split(whereSeparator: \.isWhitespace).count)")
+        print("generated_file: \(result.generatedFilePath)")
+        print("sample_rate: \(result.analysis.sampleRate)")
+        print("window_seconds: \(options.windowSeconds)")
+
+        printAnalysis(result.analysis, prefix: "window", summaryLabel: "summary")
+    }
+
+    static func runCreateDesignProfile(options: CreateDesignProfileOptions) async throws {
+        if let profileRoot = options.profileRoot {
+            setenv(profileRootOverrideEnvironmentVariable, profileRoot, 1)
+        }
+
+        let vibe = try parseVibe(options.vibe)
+        let runtime = await SpeakSwiftly.liftoff()
+        await runtime.start()
+        let handle = await runtime.voices.create(
+            design: options.profileName,
+            from: options.sourceText,
+            vibe: vibe,
+            voice: options.voiceDescription,
+        )
+        let created = try await awaitCreatedProfile(from: handle)
+
+        print("profile_name: \(created.profileName)")
+        print("profile_path: \(created.profilePath)")
+        print("source_text: \(options.sourceText)")
+        print("voice_description: \(options.voiceDescription)")
+        print("vibe: \(vibe.rawValue)")
+        if let profileRoot = options.profileRoot {
+            print("profile_root: \(profileRoot)")
+        }
+    }
+
+    static func runCompareVolume(options: VolumeProbeOptions) async throws {
+        if let profileRoot = options.profileRoot {
+            setenv(profileRootOverrideEnvironmentVariable, profileRoot, 1)
+        }
+
+        let text = try loadVolumeProbeText(options: options)
+        let comparison = try await compareVolume(options: options, text: text)
+
+        print("profile_name: \(options.profileName)")
+        if let profileRoot = options.profileRoot {
+            print("profile_root: \(profileRoot)")
+        }
+        print("text_characters: \(text.count)")
+        print("text_words: \(text.split(whereSeparator: \.isWhitespace).count)")
+        print("window_seconds: \(options.windowSeconds)")
+        print("streamed_generated_file: \(comparison.streamed.generatedFilePath)")
+        print("streamed_sample_rate: \(comparison.streamed.analysis.sampleRate)")
+        print("direct_generated_file: \(comparison.direct.generatedFilePath)")
+        print("direct_sample_rate: \(comparison.direct.analysis.sampleRate)")
+
+        printAnalysis(
+            comparison.streamed.analysis,
+            prefix: "streamed_window",
+            summaryLabel: "streamed_summary",
+        )
+        printAnalysis(
+            comparison.direct.analysis,
+            prefix: "direct_window",
+            summaryLabel: "direct_summary",
+        )
+
+        if let streamedSummary = comparison.streamed.analysis.summary,
+           let directSummary = comparison.direct.analysis.summary {
+            print(
+                String(
+                    format: "comparison: streamed_last_rms=%.5f direct_last_rms=%.5f streamed_drop_pct=%.2f direct_drop_pct=%.2f drop_delta_pct=%.2f streamed_slope=%.6f direct_slope=%.6f",
+                    streamedSummary.lastRMS,
+                    directSummary.lastRMS,
+                    streamedSummary.rmsDropPercent,
+                    directSummary.rmsDropPercent,
+                    streamedSummary.rmsDropPercent - directSummary.rmsDropPercent,
+                    streamedSummary.slopePerWindow,
+                    directSummary.slopePerWindow,
+                ),
+            )
+        }
+    }
+
+    static func loadVolumeProbeText(options: VolumeProbeOptions) throws -> String {
+        if let textFile = options.textFile {
+            let text = try String(contentsOfFile: textFile, encoding: .utf8)
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw UsageError.emptyProbeText
+            }
+            return trimmed
+        }
+
+        let paragraph = """
+        This is a long-form loudness probe for SpeakSwiftly. Please keep the voice steady, natural, and evenly projected from beginning to end. We are intentionally using a much longer passage so we can inspect whether the waveform stays consistent over time or gradually loses energy. The content itself is not important. What matters is that the generated speech remains stable, full, and equally audible throughout the entire passage, even after many seconds of continuous synthesis.
+        """
+
+        return Array(repeating: paragraph, count: options.repeatCount).joined(separator: "\n\n")
+    }
+
+    static func awaitGeneratedFile(
+        from handle: SpeakSwiftly.RequestHandle,
+    ) async throws -> SpeakSwiftly.GeneratedFile {
+        for try await event in handle.events {
+            switch event {
+                case .queued, .started, .progress:
+                    continue
+                case let .acknowledged(success), let .completed(success):
+                    if let generatedFile = success.generatedFile {
+                        return generatedFile
+                    }
+            }
+        }
+
+        throw UsageError.volumeProbeEndedWithoutGeneratedFile
+    }
+
+    static func awaitCreatedProfile(
+        from handle: SpeakSwiftly.RequestHandle,
+    ) async throws -> (profileName: String, profilePath: String) {
+        for try await event in handle.events {
+            switch event {
+                case .queued, .started, .progress:
+                    continue
+                case let .acknowledged(success), let .completed(success):
+                    if let profileName = success.profileName, let profilePath = success.profilePath {
+                        return (profileName, profilePath)
+                    }
+            }
+        }
+
+        throw UsageError.createProfileEndedWithoutProfilePayload
+    }
+
+    static func parseVibe(_ rawValue: String) throws -> SpeakSwiftly.Vibe {
+        guard let vibe = SpeakSwiftly.Vibe(rawValue: rawValue) else {
+            throw UsageError.invalidOptionValue("--vibe", rawValue)
+        }
+        return vibe
+    }
+
+    static func runStreamedProbe(
+        profileName: String,
+        text: String,
+        windowSeconds: Double,
+    ) async throws -> CompareRun {
+        let runtime = await SpeakSwiftly.liftoff()
+        await runtime.start()
+
+        let handle = await runtime.generate.audio(
+            text: text,
+            with: profileName,
+        )
+
+        let generatedFile = try await awaitGeneratedFile(from: handle)
+        let analysis = try analyzeVolume(
+            at: generatedFile.filePath,
+            sampleRate: generatedFile.sampleRate,
+            windowSeconds: windowSeconds,
+        )
+
+        return CompareRun(
+            generatedFilePath: generatedFile.filePath,
+            analysis: analysis,
+        )
+    }
+
+    static func compareVolume(
+        options: VolumeProbeOptions,
+        text: String,
+    ) async throws -> ComparisonResult {
+        let streamed = try await runStreamedProbe(
+            profileName: options.profileName,
+            text: text,
+            windowSeconds: options.windowSeconds,
+        )
+        let profileRootURL = profileRootURL(options: options)
+        let profileDirectoryURL = profileRootURL
+            .appendingPathComponent("profiles", isDirectory: true)
+            .appendingPathComponent(options.profileName, isDirectory: true)
+        let manifest = try loadProfileManifest(from: profileDirectoryURL)
+        let direct = try await runDirectProbe(
+            text: text,
+            manifest: manifest,
+            profileDirectoryURL: profileDirectoryURL,
+            windowSeconds: options.windowSeconds,
+        )
+        return ComparisonResult(streamed: streamed, direct: direct)
+    }
+
+    static func runDirectProbe(
+        text: String,
+        manifest: ProbeProfileManifest,
+        profileDirectoryURL: URL,
+        windowSeconds: Double,
+    ) async throws -> CompareRun {
+        guard let materialization = manifest.backendMaterializations.first(where: { $0.backend == "qwen3" }) else {
+            throw UsageError.profileMissingQwenMaterialization(profileDirectoryURL.path)
+        }
+
+        let loadedModel = try await TTS.loadModel(modelRepo: materialization.modelRepo)
+        guard let qwenModel = loadedModel as? Qwen3TTSModel else {
+            throw UsageError.profileModelIsNotQwen(materialization.modelRepo)
+        }
+
+        var generationParameters = qwenModel.defaultGenerationParameters
+        let wordCount = max(text.split(whereSeparator: \.isWhitespace).count, 1)
+        generationParameters.maxTokens = min(2048, max(56, wordCount * 8))
+        generationParameters.temperature = 0.9
+        generationParameters.topP = 1.0
+        generationParameters.repetitionPenalty = 1.05
+        let directSamples: [Float]
+
+        if let conditioningArtifact = try loadStoredConditioning(manifest: manifest, profileDirectoryURL: profileDirectoryURL) {
+            directSamples = try await qwenModel.generate(
+                text: text,
+                conditioning: conditioningArtifact,
+                generationParameters: generationParameters,
+            ).asArray(Float.self)
+        } else {
+            let referenceAudioURL = profileDirectoryURL.appendingPathComponent(
+                materialization.referenceAudioFile,
+                isDirectory: false,
+            )
+            let refAudio = try loadReferenceAudio(at: referenceAudioURL, sampleRate: qwenModel.sampleRate)
+            directSamples = try await qwenModel.generate(
+                text: text,
+                voice: nil,
+                refAudio: refAudio,
+                refText: materialization.referenceText,
+                language: "English",
+                generationParameters: generationParameters,
+            ).asArray(Float.self)
+        }
+
+        let directOutputURL = try writeProbeWAV(
+            samples: directSamples,
+            sampleRate: qwenModel.sampleRate,
+            name: "qwen-direct-volume-probe.wav",
+        )
+        let analysis = analyzeVolume(
+            samples: directSamples,
+            sampleRate: qwenModel.sampleRate,
+            windowSeconds: windowSeconds,
+        )
+
+        return CompareRun(
+            generatedFilePath: directOutputURL.path,
+            analysis: analysis,
+        )
+    }
+
+    static func profileRootURL(options: VolumeProbeOptions) -> URL {
+        if let profileRoot = options.profileRoot {
+            return URL(fileURLWithPath: profileRoot, isDirectory: true)
+        }
+
+        return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("SpeakSwiftly", isDirectory: true)
+    }
+
+    static func loadProfileManifest(from profileDirectoryURL: URL) throws -> ProbeProfileManifest {
+        let manifestURL = profileDirectoryURL.appendingPathComponent("profile.json", isDirectory: false)
+        let data = try Data(contentsOf: manifestURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ProbeProfileManifest.self, from: data)
+    }
+
+    static func loadStoredConditioning(
+        manifest: ProbeProfileManifest,
+        profileDirectoryURL: URL,
+    ) throws -> Qwen3TTSModel.Qwen3TTSReferenceConditioning? {
+        guard let artifactManifest = manifest.qwenConditioningArtifacts.first(where: { $0.backend == "qwen3" }) else {
+            return nil
+        }
+
+        let artifactURL = profileDirectoryURL.appendingPathComponent(
+            artifactManifest.artifactFile,
+            isDirectory: false,
+        )
+        let data = try Data(contentsOf: artifactURL)
+        let decoder = JSONDecoder()
+        let artifact = try decoder.decode(ProbePersistedQwenConditioningArtifact.self, from: data)
+        return artifact.makeConditioning()
+    }
+
+    static func loadReferenceAudio(at url: URL, sampleRate: Int) throws -> MLXArray {
+        let (_, audio) = try MLXAudioCore.loadAudioArray(from: url, sampleRate: sampleRate)
+        return audio
+    }
+
+    static func writeProbeWAV(
+        samples: [Float],
+        sampleRate: Int,
+        name: String,
+    ) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SpeakSwiftlyTesting", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(name, isDirectory: false)
+        try writeFloatWAV(samples: samples, sampleRate: sampleRate, to: url)
+        return url
+    }
+
+    static func writeFloatWAV(samples: [Float], sampleRate: Int, to url: URL) throws {
+        let channelCount = 1
+        let bitsPerSample = 32
+        let blockAlign = channelCount * (bitsPerSample / 8)
+        let byteRate = sampleRate * blockAlign
+        let audioDataSize = samples.count * MemoryLayout<Float>.size
+        let riffChunkSize = 4 + (8 + 16) + (8 + audioDataSize)
+
+        var data = Data()
+        data.append(contentsOf: Array("RIFF".utf8))
+        appendUInt32(UInt32(riffChunkSize), to: &data)
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        appendUInt32(16, to: &data)
+        appendUInt16(3, to: &data)
+        appendUInt16(UInt16(channelCount), to: &data)
+        appendUInt32(UInt32(sampleRate), to: &data)
+        appendUInt32(UInt32(byteRate), to: &data)
+        appendUInt16(UInt16(blockAlign), to: &data)
+        appendUInt16(UInt16(bitsPerSample), to: &data)
+        data.append(contentsOf: Array("data".utf8))
+        appendUInt32(UInt32(audioDataSize), to: &data)
+
+        samples.withUnsafeBufferPointer { buffer in
+            data.append(contentsOf: UnsafeRawBufferPointer(buffer))
+        }
+
+        try data.write(to: url)
+    }
+
+    static func appendUInt16(_ value: UInt16, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    static func appendUInt32(_ value: UInt32, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    static func analyzeVolume(
+        at path: String,
+        sampleRate: Int,
+        windowSeconds: Double,
+    ) throws -> ProbeAnalysis {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let wav = try parseFloatWAV(data)
+        return analyzeVolume(
+            samples: wav.samples,
+            sampleRate: sampleRate,
+            windowSeconds: windowSeconds,
+        )
+    }
+
+    static func analyzeVolume(
+        samples: [Float],
+        sampleRate: Int,
+        windowSeconds: Double,
+    ) -> ProbeAnalysis {
+        let framesPerWindow = max(1, Int((Double(sampleRate) * windowSeconds).rounded()))
+        var windows = [VolumeWindow]()
+        windows.reserveCapacity(max(1, samples.count / framesPerWindow))
+
+        var index = 0
+        var start = 0
+        while start < samples.count {
+            let end = min(start + framesPerWindow, samples.count)
+            let segment = Array(samples[start..<end])
+            let durationSeconds = Double(segment.count) / Double(sampleRate)
+            let rms = rootMeanSquare(segment)
+            let peak = segment.map { abs($0) }.max() ?? 0
+            windows.append(
+                VolumeWindow(
+                    index: index + 1,
+                    startSeconds: Double(start) / Double(sampleRate),
+                    durationSeconds: durationSeconds,
+                    rms: rms,
+                    peak: Double(peak),
+                ),
+            )
+            index += 1
+            start = end
+        }
+
+        return ProbeAnalysis(
+            sampleRate: sampleRate,
+            windows: windows,
+            summary: summarizeWindows(windows),
+        )
+    }
+
+    static func printAnalysis(
+        _ analysis: ProbeAnalysis,
+        prefix: String,
+        summaryLabel: String,
+    ) {
+        for window in analysis.windows {
+            print(
+                String(
+                    format: "%@_%02d: start=%.1fs duration=%.2fs rms=%.5f peak=%.5f",
+                    prefix,
+                    window.index,
+                    window.startSeconds,
+                    window.durationSeconds,
+                    window.rms,
+                    window.peak,
+                ),
+            )
+        }
+
+        if let summary = analysis.summary {
+            print(
+                String(
+                    format: "%@: first_rms=%.5f last_rms=%.5f rms_drop_pct=%.2f slope_per_window=%.6f first_peak=%.5f last_peak=%.5f",
+                    summaryLabel,
+                    summary.firstRMS,
+                    summary.lastRMS,
+                    summary.rmsDropPercent,
+                    summary.slopePerWindow,
+                    summary.firstPeak,
+                    summary.lastPeak,
+                ),
+            )
+        }
+    }
+
+    static func rootMeanSquare(_ samples: [Float]) -> Double {
+        guard !samples.isEmpty else { return 0 }
+        let sum = samples.reduce(into: 0.0) { partialResult, sample in
+            let value = Double(sample)
+            partialResult += value * value
+        }
+        return Foundation.sqrt(sum / Double(samples.count))
+    }
+
+    static func summarizeWindows(_ windows: [VolumeWindow]) -> VolumeSummary? {
+        guard let first = windows.first, let last = windows.last else { return nil }
+        let firstRMS = first.rms
+        let lastRMS = last.rms
+        let rmsDropPercent = firstRMS == 0 ? 0 : ((lastRMS - firstRMS) / firstRMS) * 100.0
+
+        let xValues = windows.map { Double($0.index - 1) }
+        let yValues = windows.map(\.rms)
+        let xMean = xValues.reduce(0, +) / Double(xValues.count)
+        let yMean = yValues.reduce(0, +) / Double(yValues.count)
+        let numerator = zip(xValues, yValues).reduce(into: 0.0) { partialResult, pair in
+            partialResult += (pair.0 - xMean) * (pair.1 - yMean)
+        }
+        let denominator = xValues.reduce(into: 0.0) { partialResult, x in
+            let offset = x - xMean
+            partialResult += offset * offset
+        }
+        let slopePerWindow = denominator == 0 ? 0 : numerator / denominator
+
+        return VolumeSummary(
+            firstRMS: firstRMS,
+            lastRMS: lastRMS,
+            rmsDropPercent: rmsDropPercent,
+            slopePerWindow: slopePerWindow,
+            firstPeak: first.peak,
+            lastPeak: last.peak,
+        )
+    }
+
+    static func parseFloatWAV(_ data: Data) throws -> (sampleRate: Int, channelCount: Int, samples: [Float]) {
+        func uint16(at offset: Int) -> UInt16 {
+            data.withUnsafeBytes { rawBuffer in
+                rawBuffer.load(fromByteOffset: offset, as: UInt16.self)
+            }.littleEndian
+        }
+
+        func uint32(at offset: Int) -> UInt32 {
+            data.withUnsafeBytes { rawBuffer in
+                rawBuffer.load(fromByteOffset: offset, as: UInt32.self)
+            }.littleEndian
+        }
+
+        guard data.count >= 12 else {
+            throw UsageError.invalidWAV("The generated file is too small to be a valid WAV container.")
+        }
+        guard String(decoding: data[0..<4], as: UTF8.self) == "RIFF",
+              String(decoding: data[8..<12], as: UTF8.self) == "WAVE" else {
+            throw UsageError.invalidWAV("The generated file is not a RIFF/WAVE container.")
+        }
+
+        var formatTag: UInt16?
+        var channelCount: UInt16?
+        var sampleRate: UInt32?
+        var bitsPerSample: UInt16?
+        var audioPayload: Data?
+        var offset = 12
+
+        while offset + 8 <= data.count {
+            let chunkID = String(decoding: data[offset..<(offset + 4)], as: UTF8.self)
+            let chunkSize = Int(uint32(at: offset + 4))
+            let chunkStart = offset + 8
+            let chunkEnd = chunkStart + chunkSize
+            guard chunkEnd <= data.count else {
+                throw UsageError.invalidWAV("A WAV chunk overruns the file boundary.")
+            }
+
+            if chunkID == "fmt " {
+                guard chunkSize >= 16 else {
+                    throw UsageError.invalidWAV("The WAV fmt chunk is too small.")
+                }
+                formatTag = uint16(at: chunkStart)
+                channelCount = uint16(at: chunkStart + 2)
+                sampleRate = uint32(at: chunkStart + 4)
+                bitsPerSample = uint16(at: chunkStart + 14)
+            } else if chunkID == "data" {
+                audioPayload = data[chunkStart..<chunkEnd]
+            }
+
+            offset = chunkEnd + (chunkSize % 2)
+        }
+
+        guard formatTag == 3 else {
+            throw UsageError.invalidWAV("SpeakSwiftlyTesting expected 32-bit float WAV output, but found format tag \(formatTag ?? 0).")
+        }
+        guard bitsPerSample == 32 else {
+            throw UsageError.invalidWAV("SpeakSwiftlyTesting expected 32-bit float WAV output, but found \(bitsPerSample ?? 0) bits per sample.")
+        }
+        guard let resolvedChannelCount = channelCount, let resolvedSampleRate = sampleRate, let payload = audioPayload else {
+            throw UsageError.invalidWAV("The WAV file is missing required fmt or data chunks.")
+        }
+        guard payload.count % 4 == 0 else {
+            throw UsageError.invalidWAV("The WAV float payload is not aligned to 32-bit samples.")
+        }
+
+        let interleaved = payload.withUnsafeBytes { rawBuffer in
+            Array(rawBuffer.bindMemory(to: Float.self))
+        }
+
+        if resolvedChannelCount == 1 {
+            return (
+                sampleRate: Int(resolvedSampleRate),
+                channelCount: Int(resolvedChannelCount),
+                samples: interleaved,
+            )
+        }
+
+        var mono = [Float]()
+        mono.reserveCapacity(interleaved.count / Int(resolvedChannelCount))
+        var sampleIndex = 0
+        while sampleIndex < interleaved.count {
+            mono.append(interleaved[sampleIndex])
+            sampleIndex += Int(resolvedChannelCount)
+        }
+
+        return (
+            sampleRate: Int(resolvedSampleRate),
+            channelCount: Int(resolvedChannelCount),
+            samples: mono,
+        )
+    }
+
     static func formatStatus(_ status: SpeakSwiftly.StatusEvent?) -> String {
         guard let status else {
             return "status payload missing"
@@ -99,7 +896,17 @@ extension SpeakSwiftlyTestingMain {
         case missingCommand
         case unknownCommand(String)
         case unexpectedArguments(String)
+        case missingOptionValue(String)
+        case missingRequiredOption(String)
+        case invalidOptionValue(String, String)
         case statusStreamEndedWithoutTerminalEvent
+        case volumeProbeEndedWithoutGeneratedFile
+        case createProfileEndedWithoutProfilePayload
+        case emptyProbeText
+        case invalidWAV(String)
+        case profileMissingQwenMaterialization(String)
+        case profileModelIsNotQwen(String)
+        case referenceAudioLoadFailed(String)
 
         var errorDescription: String? {
             switch self {
@@ -109,8 +916,28 @@ extension SpeakSwiftlyTestingMain {
                     "Unknown SpeakSwiftlyTesting command '\(command)'.\n\(usage)"
                 case let .unexpectedArguments(arguments):
                     "SpeakSwiftlyTesting received unexpected extra arguments: \(arguments).\n\(usage)"
+                case let .missingOptionValue(option):
+                    "SpeakSwiftlyTesting expected a value after '\(option)'.\n\(usage)"
+                case let .missingRequiredOption(option):
+                    "SpeakSwiftlyTesting requires option '\(option)' for this command.\n\(usage)"
+                case let .invalidOptionValue(option, value):
+                    "SpeakSwiftlyTesting could not use value '\(value)' for option '\(option)'.\n\(usage)"
                 case .statusStreamEndedWithoutTerminalEvent:
                     "SpeakSwiftlyTesting watched the runtime status stream, but it ended before an acknowledged or completed status payload arrived."
+                case .volumeProbeEndedWithoutGeneratedFile:
+                    "SpeakSwiftlyTesting submitted a retained audio generation request, but the request stream ended before a generated file payload arrived."
+                case .createProfileEndedWithoutProfilePayload:
+                    "SpeakSwiftlyTesting submitted a voice-design profile creation request, but the request stream ended before a created profile payload arrived."
+                case .emptyProbeText:
+                    "SpeakSwiftlyTesting could not run the volume probe because the selected text input was empty after trimming whitespace."
+                case let .invalidWAV(message):
+                    message
+                case let .profileMissingQwenMaterialization(path):
+                    "SpeakSwiftlyTesting could not find a stored qwen3 backend materialization in '\(path)/profile.json'."
+                case let .profileModelIsNotQwen(modelRepo):
+                    "SpeakSwiftlyTesting expected model repo '\(modelRepo)' to load as Qwen3TTSModel for the direct comparison path, but it resolved to a different speech model type."
+                case let .referenceAudioLoadFailed(path):
+                    "SpeakSwiftlyTesting could not decode any audio samples from '\(path)' for the direct Qwen comparison path."
             }
         }
 
@@ -120,6 +947,9 @@ extension SpeakSwiftlyTestingMain {
               swift run SpeakSwiftlyTesting resources
               swift run SpeakSwiftlyTesting status
               swift run SpeakSwiftlyTesting smoke
+              swift run SpeakSwiftlyTesting create-design-profile --profile NAME --voice DESCRIPTION [--text SOURCE] [--vibe femme|masc|neutral] [--profile-root PATH]
+              swift run SpeakSwiftlyTesting volume-probe [--profile NAME] [--profile-root PATH] [--text-file PATH] [--repeat COUNT] [--window-seconds SECONDS]
+              swift run SpeakSwiftlyTesting compare-volume [--profile NAME] [--profile-root PATH] [--text-file PATH] [--repeat COUNT] [--window-seconds SECONDS]
             """
         }
     }

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift
@@ -1,0 +1,307 @@
+#if os(macOS)
+import Foundation
+@testable import SpeakSwiftly
+import Testing
+
+private let backendBenchmarkSchemaVersion = 1
+
+@Suite(
+    .serialized,
+    .tags(.e2e, .benchmark),
+    .enabled(
+        if: speakSwiftlyE2ETestsEnabled(),
+        "These end-to-end worker tests are opt-in and require SPEAKSWIFTLY_E2E=1.",
+    ),
+    .enabled(
+        if: speakSwiftlyBackendBenchmarkE2ETestsEnabled(),
+        "This backend benchmark suite is opt-in and requires SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1.",
+    ),
+)
+struct BackendBenchmarkE2ETests {
+    @Test func `compare resident backends with two queued live requests`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        try await Self.provisionBenchmarkProfiles(in: sandbox.profileRootURL)
+
+        let iterations = speakSwiftlyBackendBenchmarkIterations()
+        let playbackMode = BenchmarkHarness.effectivePlaybackMode()
+        var samples = [BackendBenchmarkSample]()
+        samples.reserveCapacity(iterations * SpeakSwiftly.SpeechBackend.allCases.count)
+
+        for backend in SpeakSwiftly.SpeechBackend.allCases {
+            for iteration in 1...iterations {
+                try await samples.append(
+                    Self.runBenchmarkSample(
+                        profileRootURL: sandbox.profileRootURL,
+                        backend: backend,
+                        iteration: iteration,
+                        playbackMode: playbackMode,
+                    ),
+                )
+            }
+        }
+
+        let summary = BackendBenchmarkSummary(
+            schemaVersion: backendBenchmarkSchemaVersion,
+            generatedAt: Date(),
+            host: .localMachine(),
+            settings: .current(
+                iterations: iterations,
+                playbackMode: playbackMode,
+                benchmarkTextCharacterCount: Self.benchmarkText.count,
+            ),
+            backends: BackendBenchmarkReport.make(from: samples),
+        )
+        let summaryURL = try BenchmarkHarness.writeSummary(
+            summary,
+            timestampedStem: playbackMode == .audible ? "backend-live-audible-benchmark" : "backend-live-benchmark",
+            latestFilename: playbackMode == .audible ? "backend-live-audible-benchmark-latest.json" : "backend-live-benchmark-latest.json",
+            generatedAt: summary.generatedAt,
+        )
+
+        print("SpeakSwiftly backend benchmark summary: \(summaryURL.path)")
+        for report in summary.backends {
+            print(report.prettyDescription)
+        }
+    }
+}
+
+private extension BackendBenchmarkE2ETests {
+    static let benchmarkText = """
+    SpeakSwiftly backend benchmarking starts with a deliberate stretch of ordinary prose so the first live request has enough time to warm the resident model, enter buffering, reach preroll, and settle into sustained playback instead of disappearing before the timings become useful. The point of this paragraph is not theatrical reading. The point is to give the benchmark a realistic opening span with sentences long enough to expose startup cost, queue pressure, and early playback stability under normal language.
+
+    The second paragraph adds denser phrasing, longer clauses, and more punctuation so the benchmark does not flatten every backend into a tiny trivial request. We want the package to speak something that still sounds like real operator-facing text while being substantial enough to reveal how the second queued request behaves once the first request is already active. That lets us compare the queued-request tax across backends instead of pretending a one-line utterance tells the whole performance story.
+    """
+
+    static func profileName(for backend: SpeakSwiftly.SpeechBackend) -> String {
+        "benchmark-\(backend.rawValue)-profile"
+    }
+
+    static func provisionBenchmarkProfiles(in profileRootURL: URL) async throws {
+        for backend in SpeakSwiftly.SpeechBackend.allCases {
+            try await BenchmarkHarness.withBenchmarkRuntime(
+                profileRootURL: profileRootURL,
+                backend: backend,
+                qwenConditioningStrategy: .preparedConditioning,
+            ) { session in
+                _ = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
+
+                let handle = await session.runtime.voices.create(
+                    design: profileName(for: backend),
+                    from: E2EHarness.testingProfileText,
+                    vibe: .masc,
+                    voice: E2EHarness.testingProfileVoiceDescription,
+                )
+                _ = try await BenchmarkHarness.awaitSuccess(from: handle)
+            }
+        }
+    }
+
+    static func runBenchmarkSample(
+        profileRootURL: URL,
+        backend: SpeakSwiftly.SpeechBackend,
+        iteration: Int,
+        playbackMode: BenchmarkPlaybackMode,
+    ) async throws -> BackendBenchmarkSample {
+        try await BenchmarkHarness.withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: backend,
+            qwenConditioningStrategy: .preparedConditioning,
+            playbackMode: playbackMode,
+        ) { session in
+            let residentPreloadMS = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
+            let queuedPair = try await runQueuedLivePairBenchmark(
+                in: session,
+                backend: backend,
+            )
+
+            return BackendBenchmarkSample(
+                backend: backend,
+                iteration: iteration,
+                residentPreloadMS: residentPreloadMS,
+                queuedLivePair: queuedPair,
+            )
+        }
+    }
+
+    static func runQueuedLivePairBenchmark(
+        in session: BenchmarkRuntimeSession,
+        backend: SpeakSwiftly.SpeechBackend,
+    ) async throws -> BackendQueuedLivePairBenchmark {
+        let firstHandle = await session.runtime.generate.speech(
+            text: benchmarkText,
+            with: profileName(for: backend),
+        )
+        let secondHandle = await session.runtime.generate.speech(
+            text: benchmarkText,
+            with: profileName(for: backend),
+        )
+
+        async let firstRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: firstHandle,
+            logRecorder: session.logRecorder,
+        )
+        async let secondRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: secondHandle,
+            logRecorder: session.logRecorder,
+        )
+
+        let pair = try await BackendQueuedLivePairBenchmark(
+            firstRequest: firstRequest,
+            secondRequest: secondRequest,
+        )
+
+        guard pair.secondRequest.lifecycle.queuedAtMS != nil else {
+            throw BenchmarkError(
+                "Backend benchmark expected the second live request for backend '\(backend.rawValue)' to enter the queue, but it never reported a queued event.",
+            )
+        }
+
+        return pair
+    }
+}
+
+private struct BackendBenchmarkSummary: Codable {
+    let schemaVersion: Int
+    let generatedAt: Date
+    let host: BenchmarkHost
+    let settings: BackendBenchmarkSettings
+    let backends: [BackendBenchmarkReport]
+}
+
+private struct BackendBenchmarkSettings: Codable {
+    let iterations: Int
+    let playbackMode: BenchmarkPlaybackMode
+    let benchmarkTextCharacterCount: Int
+    let timestampedSummaryPattern: String
+    let latestSummaryFilename: String
+    let benchmarkedBackends: [SpeakSwiftly.SpeechBackend]
+
+    static func current(
+        iterations: Int,
+        playbackMode: BenchmarkPlaybackMode,
+        benchmarkTextCharacterCount: Int,
+    ) -> Self {
+        Self(
+            iterations: iterations,
+            playbackMode: playbackMode,
+            benchmarkTextCharacterCount: benchmarkTextCharacterCount,
+            timestampedSummaryPattern: playbackMode == .audible
+                ? "backend-live-audible-benchmark-<ISO8601>.json"
+                : "backend-live-benchmark-<ISO8601>.json",
+            latestSummaryFilename: playbackMode == .audible
+                ? "backend-live-audible-benchmark-latest.json"
+                : "backend-live-benchmark-latest.json",
+            benchmarkedBackends: SpeakSwiftly.SpeechBackend.allCases,
+        )
+    }
+}
+
+private struct BackendBenchmarkReport: Codable {
+    let backend: SpeakSwiftly.SpeechBackend
+    let profileName: String
+    let sampleCount: Int
+    let residentPreloadMS: BenchmarkMetricSummary
+    let queuedLivePair: BackendQueuedLivePairAggregate
+    let samples: [BackendBenchmarkSample]
+
+    var prettyDescription: String {
+        """
+        \(backend.rawValue): preload \(residentPreloadMS.prettyAverage) ms, first request complete \(queuedLivePair.firstRequest.lifecycle.completedMS.prettyAverage) ms, second request complete \(queuedLivePair.secondRequest.lifecycle.completedMS.prettyAverage) ms, second request queue wait \(queuedLivePair.penalties.secondRequestQueueWaitMS.prettyAverage) ms, second request first audio penalty \(queuedLivePair.penalties.secondRequestFirstAudioPenaltyMS.prettyAverage) ms
+        """
+    }
+
+    static func make(from samples: [BackendBenchmarkSample]) -> [Self] {
+        Dictionary(grouping: samples, by: \.backend)
+            .map { backend, backendSamples in
+                Self(
+                    backend: backend,
+                    profileName: BackendBenchmarkE2ETests.profileName(for: backend),
+                    sampleCount: backendSamples.count,
+                    residentPreloadMS: .make(from: backendSamples.map(\.residentPreloadMS)),
+                    queuedLivePair: .make(from: backendSamples.map(\.queuedLivePair)),
+                    samples: backendSamples.sorted { $0.iteration < $1.iteration },
+                )
+            }
+            .sorted { $0.backend.rawValue < $1.backend.rawValue }
+    }
+}
+
+private struct BackendBenchmarkSample: Codable {
+    let backend: SpeakSwiftly.SpeechBackend
+    let iteration: Int
+    let residentPreloadMS: Double
+    let queuedLivePair: BackendQueuedLivePairBenchmark
+}
+
+private struct BackendQueuedLivePairBenchmark: Codable {
+    let firstRequest: BenchmarkRequest
+    let secondRequest: BenchmarkRequest
+}
+
+private struct BackendQueuedLivePairAggregate: Codable {
+    let sampleCount: Int
+    let firstRequest: BenchmarkRequestAggregate
+    let secondRequest: BenchmarkRequestAggregate
+    let penalties: BackendQueuedLivePenaltyAggregate
+
+    static func make(from samples: [BackendQueuedLivePairBenchmark]) -> Self {
+        Self(
+            sampleCount: samples.count,
+            firstRequest: .make(from: samples.map(\.firstRequest)),
+            secondRequest: .make(from: samples.map(\.secondRequest)),
+            penalties: .make(from: samples),
+        )
+    }
+}
+
+private struct BackendQueuedLivePenaltyAggregate: Codable {
+    let secondRequestQueueWaitMS: BenchmarkMetricSummary
+    let secondRequestFirstAudioPenaltyMS: BenchmarkMetricSummary
+    let secondRequestCompletionPenaltyMS: BenchmarkMetricSummary
+
+    static func make(from samples: [BackendQueuedLivePairBenchmark]) -> Self {
+        Self(
+            secondRequestQueueWaitMS: .make(
+                from: samples.compactMap {
+                    Self.queueWaitMS(for: $0.secondRequest.lifecycle)
+                },
+            ),
+            secondRequestFirstAudioPenaltyMS: .make(
+                from: samples.compactMap {
+                    guard
+                        let first = $0.firstRequest.generation.firstAudioChunkAtMS,
+                        let second = $0.secondRequest.generation.firstAudioChunkAtMS
+                    else {
+                        return nil
+                    }
+                    return second - first
+                },
+            ),
+            secondRequestCompletionPenaltyMS: .make(
+                from: samples.compactMap {
+                    guard
+                        let first = $0.firstRequest.lifecycle.completedAtMS,
+                        let second = $0.secondRequest.lifecycle.completedAtMS
+                    else {
+                        return nil
+                    }
+                    return second - first
+                },
+            ),
+        )
+    }
+
+    private static func queueWaitMS(for lifecycle: BenchmarkRequestLifecycleMetrics) -> Double? {
+        guard
+            let queuedAtMS = lifecycle.queuedAtMS,
+            let startedAtMS = lifecycle.startedAtMS
+        else {
+            return nil
+        }
+
+        return startedAtMS - queuedAtMS
+    }
+}
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
@@ -1,0 +1,671 @@
+#if os(macOS)
+import Foundation
+@testable import SpeakSwiftly
+
+struct BenchmarkRuntimeSession {
+    let runtime: SpeakSwiftly.Runtime
+    let logRecorder: BenchmarkLogRecorder
+}
+
+enum BenchmarkPlaybackMode: String, Codable {
+    case silent
+    case audible
+}
+
+struct BenchmarkHost: Codable {
+    let machineArchitecture: String
+    let operatingSystemVersion: String
+    let activeProcessorCount: Int
+    let physicalMemoryBytes: UInt64
+
+    static func localMachine() -> Self {
+        let processInfo = ProcessInfo.processInfo
+        return Self(
+            machineArchitecture: hostMachineArchitecture(),
+            operatingSystemVersion: processInfo.operatingSystemVersionString,
+            activeProcessorCount: processInfo.activeProcessorCount,
+            physicalMemoryBytes: processInfo.physicalMemory,
+        )
+    }
+
+    private static func hostMachineArchitecture() -> String {
+        var systemInfo = utsname()
+        guard uname(&systemInfo) == 0 else { return "unknown" }
+
+        let machine = systemInfo.machine
+        return withUnsafePointer(to: machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: machine)) {
+                String(cString: $0)
+            }
+        }
+    }
+}
+
+struct BenchmarkMetricSummary: Codable {
+    let count: Int
+    let min: Double?
+    let average: Double?
+    let max: Double?
+
+    var prettyAverage: String {
+        guard let average else { return "n/a" }
+        return String(format: "%.2f", average)
+    }
+
+    static func make(from values: [Double]) -> Self {
+        guard !values.isEmpty else {
+            return Self(count: 0, min: nil, average: nil, max: nil)
+        }
+
+        return Self(
+            count: values.count,
+            min: values.min(),
+            average: values.reduce(0, +) / Double(values.count),
+            max: values.max(),
+        )
+    }
+}
+
+struct BenchmarkRequestLifecycleMetrics: Codable {
+    var queuedAtMS: Double?
+    var queueReason: String?
+    var queuePosition: Int?
+    var acknowledgedAtMS: Double?
+    var startedAtMS: Double?
+    var bufferingAudioAtMS: Double?
+    var prerollReadyAtMS: Double?
+    var playbackFinishedAtMS: Double?
+    var completedAtMS: Double?
+}
+
+struct BenchmarkRequestGenerationMetrics: Codable {
+    var firstTokenAtMS: Double?
+    var infoAtMS: Double?
+    var firstAudioChunkAtMS: Double?
+    var observedTokenCount = 0
+    var audioChunkCount = 0
+    var totalAudioSampleCount = 0
+    var promptTokenCount: Int?
+    var generationTokenCount: Int?
+    var prefillTimeMS: Double?
+    var generateTimeMS: Double?
+    var tokensPerSecond: Double?
+    var peakMemoryUsageGB: Double?
+}
+
+struct BenchmarkRequest: Codable {
+    let requestID: String
+    let operation: String
+    let generatedArtifactID: String?
+    let lifecycle: BenchmarkRequestLifecycleMetrics
+    let generation: BenchmarkRequestGenerationMetrics
+    let playback: BenchmarkPlaybackMetrics?
+}
+
+struct BenchmarkRequestAggregate: Codable {
+    let sampleCount: Int
+    let lifecycle: BenchmarkLifecycleMetricAggregate
+    let generation: BenchmarkGenerationMetricAggregate
+    let playback: BenchmarkPlaybackMetricAggregate
+
+    static func make(from samples: [BenchmarkRequest]) -> Self {
+        Self(
+            sampleCount: samples.count,
+            lifecycle: .make(from: samples.map(\.lifecycle)),
+            generation: .make(from: samples.map(\.generation)),
+            playback: .make(from: samples.compactMap(\.playback)),
+        )
+    }
+}
+
+struct BenchmarkLifecycleMetricAggregate: Codable {
+    let acknowledgedMS: BenchmarkMetricSummary
+    let startedMS: BenchmarkMetricSummary
+    let bufferingAudioMS: BenchmarkMetricSummary
+    let prerollReadyMS: BenchmarkMetricSummary
+    let playbackFinishedMS: BenchmarkMetricSummary
+    let completedMS: BenchmarkMetricSummary
+
+    static func make(from samples: [BenchmarkRequestLifecycleMetrics]) -> Self {
+        Self(
+            acknowledgedMS: .make(from: samples.compactMap(\.acknowledgedAtMS)),
+            startedMS: .make(from: samples.compactMap(\.startedAtMS)),
+            bufferingAudioMS: .make(from: samples.compactMap(\.bufferingAudioAtMS)),
+            prerollReadyMS: .make(from: samples.compactMap(\.prerollReadyAtMS)),
+            playbackFinishedMS: .make(from: samples.compactMap(\.playbackFinishedAtMS)),
+            completedMS: .make(from: samples.compactMap(\.completedAtMS)),
+        )
+    }
+}
+
+struct BenchmarkGenerationMetricAggregate: Codable {
+    let firstTokenMS: BenchmarkMetricSummary
+    let infoMS: BenchmarkMetricSummary
+    let firstAudioChunkMS: BenchmarkMetricSummary
+    let observedTokenCount: BenchmarkMetricSummary
+    let audioChunkCount: BenchmarkMetricSummary
+    let totalAudioSampleCount: BenchmarkMetricSummary
+    let promptTokenCount: BenchmarkMetricSummary
+    let generationTokenCount: BenchmarkMetricSummary
+    let prefillTimeMS: BenchmarkMetricSummary
+    let generateTimeMS: BenchmarkMetricSummary
+    let tokensPerSecond: BenchmarkMetricSummary
+    let peakMemoryUsageGB: BenchmarkMetricSummary
+
+    static func make(from samples: [BenchmarkRequestGenerationMetrics]) -> Self {
+        Self(
+            firstTokenMS: .make(from: samples.compactMap(\.firstTokenAtMS)),
+            infoMS: .make(from: samples.compactMap(\.infoAtMS)),
+            firstAudioChunkMS: .make(from: samples.compactMap(\.firstAudioChunkAtMS)),
+            observedTokenCount: .make(from: samples.map { Double($0.observedTokenCount) }),
+            audioChunkCount: .make(from: samples.map { Double($0.audioChunkCount) }),
+            totalAudioSampleCount: .make(from: samples.map { Double($0.totalAudioSampleCount) }),
+            promptTokenCount: .make(from: samples.compactMap { $0.promptTokenCount.map(Double.init) }),
+            generationTokenCount: .make(from: samples.compactMap { $0.generationTokenCount.map(Double.init) }),
+            prefillTimeMS: .make(from: samples.compactMap(\.prefillTimeMS)),
+            generateTimeMS: .make(from: samples.compactMap(\.generateTimeMS)),
+            tokensPerSecond: .make(from: samples.compactMap(\.tokensPerSecond)),
+            peakMemoryUsageGB: .make(from: samples.compactMap(\.peakMemoryUsageGB)),
+        )
+    }
+}
+
+struct BenchmarkPlaybackMetrics: Codable {
+    var startupBufferedAudioMS: Double?
+    var timeToFirstChunkMS: Double?
+    var timeToPrerollReadyMS: Double?
+    var timeFromPrerollReadyToDrainMS: Double?
+    var minQueuedAudioMS: Double?
+    var maxQueuedAudioMS: Double?
+    var avgQueuedAudioMS: Double?
+    var queueDepthSampleCount: Double?
+    var rebufferEventCount: Double?
+    var rebufferTotalDurationMS: Double?
+    var longestRebufferDurationMS: Double?
+    var starvationEventCount: Double?
+    var scheduleCallbackCount: Double?
+    var playedBackCallbackCount: Double?
+    var fadeInChunkCount: Double?
+    var maxInterChunkGapMS: Double?
+    var avgInterChunkGapMS: Double?
+    var maxScheduleGapMS: Double?
+    var avgScheduleGapMS: Double?
+    var maxBoundaryDiscontinuity: Double?
+    var maxLeadingAbsAmplitude: Double?
+    var maxTrailingAbsAmplitude: Double?
+}
+
+struct BenchmarkPlaybackMetricAggregate: Codable {
+    let sampleCount: Int
+    let startupBufferedAudioMS: BenchmarkMetricSummary
+    let timeToFirstChunkMS: BenchmarkMetricSummary
+    let timeToPrerollReadyMS: BenchmarkMetricSummary
+    let timeFromPrerollReadyToDrainMS: BenchmarkMetricSummary
+    let minQueuedAudioMS: BenchmarkMetricSummary
+    let maxQueuedAudioMS: BenchmarkMetricSummary
+    let avgQueuedAudioMS: BenchmarkMetricSummary
+    let queueDepthSampleCount: BenchmarkMetricSummary
+    let rebufferEventCount: BenchmarkMetricSummary
+    let rebufferTotalDurationMS: BenchmarkMetricSummary
+    let longestRebufferDurationMS: BenchmarkMetricSummary
+    let starvationEventCount: BenchmarkMetricSummary
+    let scheduleCallbackCount: BenchmarkMetricSummary
+    let playedBackCallbackCount: BenchmarkMetricSummary
+    let fadeInChunkCount: BenchmarkMetricSummary
+    let maxInterChunkGapMS: BenchmarkMetricSummary
+    let avgInterChunkGapMS: BenchmarkMetricSummary
+    let maxScheduleGapMS: BenchmarkMetricSummary
+    let avgScheduleGapMS: BenchmarkMetricSummary
+    let maxBoundaryDiscontinuity: BenchmarkMetricSummary
+    let maxLeadingAbsAmplitude: BenchmarkMetricSummary
+    let maxTrailingAbsAmplitude: BenchmarkMetricSummary
+
+    static func make(from samples: [BenchmarkPlaybackMetrics]) -> Self {
+        Self(
+            sampleCount: samples.count,
+            startupBufferedAudioMS: .make(from: samples.compactMap(\.startupBufferedAudioMS)),
+            timeToFirstChunkMS: .make(from: samples.compactMap(\.timeToFirstChunkMS)),
+            timeToPrerollReadyMS: .make(from: samples.compactMap(\.timeToPrerollReadyMS)),
+            timeFromPrerollReadyToDrainMS: .make(from: samples.compactMap(\.timeFromPrerollReadyToDrainMS)),
+            minQueuedAudioMS: .make(from: samples.compactMap(\.minQueuedAudioMS)),
+            maxQueuedAudioMS: .make(from: samples.compactMap(\.maxQueuedAudioMS)),
+            avgQueuedAudioMS: .make(from: samples.compactMap(\.avgQueuedAudioMS)),
+            queueDepthSampleCount: .make(from: samples.compactMap(\.queueDepthSampleCount)),
+            rebufferEventCount: .make(from: samples.compactMap(\.rebufferEventCount)),
+            rebufferTotalDurationMS: .make(from: samples.compactMap(\.rebufferTotalDurationMS)),
+            longestRebufferDurationMS: .make(from: samples.compactMap(\.longestRebufferDurationMS)),
+            starvationEventCount: .make(from: samples.compactMap(\.starvationEventCount)),
+            scheduleCallbackCount: .make(from: samples.compactMap(\.scheduleCallbackCount)),
+            playedBackCallbackCount: .make(from: samples.compactMap(\.playedBackCallbackCount)),
+            fadeInChunkCount: .make(from: samples.compactMap(\.fadeInChunkCount)),
+            maxInterChunkGapMS: .make(from: samples.compactMap(\.maxInterChunkGapMS)),
+            avgInterChunkGapMS: .make(from: samples.compactMap(\.avgInterChunkGapMS)),
+            maxScheduleGapMS: .make(from: samples.compactMap(\.maxScheduleGapMS)),
+            avgScheduleGapMS: .make(from: samples.compactMap(\.avgScheduleGapMS)),
+            maxBoundaryDiscontinuity: .make(from: samples.compactMap(\.maxBoundaryDiscontinuity)),
+            maxLeadingAbsAmplitude: .make(from: samples.compactMap(\.maxLeadingAbsAmplitude)),
+            maxTrailingAbsAmplitude: .make(from: samples.compactMap(\.maxTrailingAbsAmplitude)),
+        )
+    }
+}
+
+final class BenchmarkLogRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stderrObjects = [[String: Any]]()
+
+    func appendStderr(_ message: String) {
+        let lines = message
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map(String.init)
+
+        guard !lines.isEmpty else { return }
+
+        lock.withLock {
+            for line in lines {
+                guard let data = line.data(using: .utf8) else { continue }
+                guard
+                    let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                else {
+                    continue
+                }
+                stderrObjects.append(object)
+            }
+        }
+    }
+
+    func playbackMetrics(for requestID: String) -> BenchmarkPlaybackMetrics? {
+        lock.withLock {
+            guard let object = stderrObjects.last(where: {
+                $0["event"] as? String == "playback_finished"
+                    && $0["request_id"] as? String == requestID
+            }) else {
+                return nil
+            }
+
+            guard let details = object["details"] as? [String: Any] else {
+                return nil
+            }
+
+            return BenchmarkPlaybackMetrics(
+                startupBufferedAudioMS: Self.double(details["startup_buffered_audio_ms"]),
+                timeToFirstChunkMS: Self.double(details["time_to_first_chunk_ms"]),
+                timeToPrerollReadyMS: Self.double(details["time_to_preroll_ready_ms"]),
+                timeFromPrerollReadyToDrainMS: Self.double(details["time_from_preroll_ready_to_drain_ms"]),
+                minQueuedAudioMS: Self.double(details["min_queued_audio_ms"]),
+                maxQueuedAudioMS: Self.double(details["max_queued_audio_ms"]),
+                avgQueuedAudioMS: Self.double(details["avg_queued_audio_ms"]),
+                queueDepthSampleCount: Self.double(details["queue_depth_sample_count"]),
+                rebufferEventCount: Self.double(details["rebuffer_event_count"]),
+                rebufferTotalDurationMS: Self.double(details["rebuffer_total_duration_ms"]),
+                longestRebufferDurationMS: Self.double(details["longest_rebuffer_duration_ms"]),
+                starvationEventCount: Self.double(details["starvation_event_count"]),
+                scheduleCallbackCount: Self.double(details["schedule_callback_count"]),
+                playedBackCallbackCount: Self.double(details["played_back_callback_count"]),
+                fadeInChunkCount: Self.double(details["fade_in_chunk_count"]),
+                maxInterChunkGapMS: Self.double(details["max_inter_chunk_gap_ms"]),
+                avgInterChunkGapMS: Self.double(details["avg_inter_chunk_gap_ms"]),
+                maxScheduleGapMS: Self.double(details["max_schedule_gap_ms"]),
+                avgScheduleGapMS: Self.double(details["avg_schedule_gap_ms"]),
+                maxBoundaryDiscontinuity: Self.double(details["max_boundary_discontinuity"]),
+                maxLeadingAbsAmplitude: Self.double(details["max_leading_abs_amplitude"]),
+                maxTrailingAbsAmplitude: Self.double(details["max_trailing_abs_amplitude"]),
+            )
+        }
+    }
+
+    private static func double(_ value: Any?) -> Double? {
+        switch value {
+            case let int as Int:
+                Double(int)
+            case let double as Double:
+                double
+            case let number as NSNumber:
+                number.doubleValue
+            default:
+                nil
+        }
+    }
+}
+
+enum BenchmarkHarness {
+    static func effectivePlaybackMode() -> BenchmarkPlaybackMode {
+        speakSwiftlyBackendBenchmarkAudibleEnabled() ? .audible : .silent
+    }
+
+    static func withBenchmarkRuntime<T>(
+        profileRootURL: URL,
+        backend: SpeakSwiftly.SpeechBackend,
+        qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
+        playbackMode: BenchmarkPlaybackMode = .silent,
+        playbackTrace: Bool = false,
+        operation: @escaping @Sendable (BenchmarkRuntimeSession) async throws -> T,
+    ) async throws -> T {
+        let session = try await makeBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: backend,
+            qwenConditioningStrategy: qwenConditioningStrategy,
+            playbackMode: playbackMode,
+            playbackTrace: playbackTrace,
+        )
+
+        do {
+            let result = try await operation(session)
+            await session.runtime.shutdown()
+            return result
+        } catch {
+            await session.runtime.shutdown()
+            throw error
+        }
+    }
+
+    static func makeBenchmarkRuntime(
+        profileRootURL: URL,
+        backend: SpeakSwiftly.SpeechBackend,
+        qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
+        playbackMode: BenchmarkPlaybackMode,
+        playbackTrace: Bool,
+    ) async throws -> BenchmarkRuntimeSession {
+        _ = try SpeakSwiftly.SupportResources.mlxBundleURL()
+        _ = try SpeakSwiftly.SupportResources.defaultMetallibURL()
+
+        let liveDependencies = WorkerDependencies.live()
+        let logRecorder = BenchmarkLogRecorder()
+        let dependencies = WorkerDependencies(
+            fileManager: liveDependencies.fileManager,
+            loadResidentModels: liveDependencies.loadResidentModels,
+            loadProfileModel: liveDependencies.loadProfileModel,
+            loadCloneTranscriptionModel: liveDependencies.loadCloneTranscriptionModel,
+            makePlaybackController: {
+                switch playbackMode {
+                    case .silent:
+                        .silent(traceEnabled: playbackTrace)
+                    case .audible:
+                        AnyPlaybackController(AudioPlaybackDriver(traceEnabled: playbackTrace))
+                }
+            },
+            writeWAV: liveDependencies.writeWAV,
+            loadAudioSamples: liveDependencies.loadAudioSamples,
+            loadAudioFloats: liveDependencies.loadAudioFloats,
+            writeStdout: { _ in },
+            writeStderr: { message in
+                logRecorder.appendStderr(message)
+                fputs("SpeakSwiftly benchmark runtime stderr: \(message)\n", stderr)
+            },
+            now: liveDependencies.now,
+            readRuntimeMemory: liveDependencies.readRuntimeMemory,
+        )
+
+        let profileStore = ProfileStore(
+            rootURL: profileRootURL,
+            fileManager: dependencies.fileManager,
+        )
+        let generatedFileStore = GeneratedFileStore(
+            rootURL: profileStore.rootURL.appendingPathComponent(GeneratedFileStore.directoryName, isDirectory: true),
+            fileManager: dependencies.fileManager,
+        )
+        let generationJobStore = GenerationJobStore(
+            rootURL: profileStore.rootURL.appendingPathComponent(GenerationJobStore.directoryName, isDirectory: true),
+            fileManager: dependencies.fileManager,
+        )
+        let normalizer = try SpeakSwiftly.Normalizer(
+            persistenceURL: ProfileStore.defaultTextProfilesURL(
+                fileManager: dependencies.fileManager,
+                profileRootOverride: profileRootURL.path,
+            ),
+        )
+        let playbackController = await PlaybackController(driver: dependencies.makePlaybackController())
+
+        let runtime = SpeakSwiftly.Runtime(
+            dependencies: dependencies,
+            speechBackend: backend,
+            qwenConditioningStrategy: qwenConditioningStrategy,
+            profileStore: profileStore,
+            generatedFileStore: generatedFileStore,
+            generationJobStore: generationJobStore,
+            normalizer: normalizer,
+            playbackController: playbackController,
+        )
+        await runtime.installPlaybackHooks()
+        return BenchmarkRuntimeSession(runtime: runtime, logRecorder: logRecorder)
+    }
+
+    static func awaitResidentReady(on runtime: SpeakSwiftly.Runtime) async throws -> Double {
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        let statuses = await runtime.statusEvents()
+
+        await runtime.start()
+
+        for await status in statuses {
+            switch status.stage {
+                case .residentModelReady:
+                    return milliseconds(since: startedAt, clock: clock)
+                case .residentModelFailed:
+                    throw BenchmarkError("SpeakSwiftly benchmark runtime failed before the resident models became ready.")
+                case .warmingResidentModel, .residentModelsUnloaded:
+                    continue
+            }
+        }
+
+        throw BenchmarkError("SpeakSwiftly benchmark runtime stopped emitting status updates before reporting resident_model_ready.")
+    }
+
+    static func awaitSuccess(
+        from handle: SpeakSwiftly.RequestHandle,
+    ) async throws -> SpeakSwiftly.Success {
+        var acknowledgedSuccess: SpeakSwiftly.Success?
+
+        for try await event in handle.events {
+            switch event {
+                case let .acknowledged(success):
+                    acknowledgedSuccess = success
+                case let .completed(success):
+                    return success
+                case .queued, .started, .progress:
+                    continue
+            }
+        }
+
+        if let acknowledgedSuccess {
+            return acknowledgedSuccess
+        }
+
+        throw BenchmarkError("Request '\(handle.id)' ended before it reported an acknowledged or completed success payload.")
+    }
+
+    static func runRequestBenchmark(
+        handle: SpeakSwiftly.RequestHandle,
+        logRecorder: BenchmarkLogRecorder? = nil,
+    ) async throws -> BenchmarkRequest {
+        let clock = ContinuousClock()
+        let submittedAt = clock.now
+
+        async let lifecycle = collectLifecycleMetrics(
+            from: handle.events,
+            submittedAt: submittedAt,
+            clock: clock,
+        )
+        async let generation = collectGenerationMetrics(
+            from: handle.generationEvents,
+            submittedAt: submittedAt,
+            clock: clock,
+        )
+
+        let (lifecycleMetrics, success) = try await lifecycle
+        let generationMetrics = try await generation
+        let playbackMetrics = try await awaitPlaybackMetrics(
+            for: handle.id,
+            operation: handle.operation,
+            logRecorder: logRecorder,
+        )
+
+        return BenchmarkRequest(
+            requestID: handle.id,
+            operation: handle.operation,
+            generatedArtifactID: success.generatedFile?.artifactID,
+            lifecycle: lifecycleMetrics,
+            generation: generationMetrics,
+            playback: playbackMetrics,
+        )
+    }
+
+    static func writeSummary<Summary: Encodable>(
+        _ summary: Summary,
+        timestampedStem: String,
+        latestFilename: String,
+        generatedAt: Date,
+    ) throws -> URL {
+        let benchmarksRoot = try packageRootURL()
+            .appendingPathComponent(".local/benchmarks", isDirectory: true)
+        try FileManager.default.createDirectory(at: benchmarksRoot, withIntermediateDirectories: true)
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let stamp = formatter.string(from: generatedAt).replacingOccurrences(of: ":", with: "-")
+        let summaryURL = benchmarksRoot.appendingPathComponent("\(timestampedStem)-\(stamp).json", isDirectory: false)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let encoded = try encoder.encode(summary)
+        try encoded.write(to: summaryURL, options: .atomic)
+
+        let latestSummaryURL = benchmarksRoot.appendingPathComponent(latestFilename, isDirectory: false)
+        try encoded.write(to: latestSummaryURL, options: .atomic)
+        return summaryURL
+    }
+
+    static func packageRootURL() throws -> URL {
+        let fileManager = FileManager.default
+        var candidateURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+        while true {
+            let manifestURL = candidateURL.appendingPathComponent("Package.swift", isDirectory: false)
+            if fileManager.fileExists(atPath: manifestURL.path) {
+                return candidateURL
+            }
+
+            let parentURL = candidateURL.deletingLastPathComponent()
+            guard parentURL != candidateURL else {
+                throw BenchmarkError("The SpeakSwiftly benchmark harness could not find the package root while walking upward from '\(#filePath)'.")
+            }
+
+            candidateURL = parentURL
+        }
+    }
+
+    static func milliseconds(
+        since instant: ContinuousClock.Instant,
+        clock: ContinuousClock,
+    ) -> Double {
+        let duration = clock.now - instant
+        let components = duration.components
+        return Double(components.seconds) * 1000
+            + Double(components.attoseconds) / 1_000_000_000_000_000
+    }
+
+    private static func collectLifecycleMetrics(
+        from events: AsyncThrowingStream<SpeakSwiftly.RequestEvent, any Swift.Error>,
+        submittedAt: ContinuousClock.Instant,
+        clock: ContinuousClock,
+    ) async throws -> (BenchmarkRequestLifecycleMetrics, SpeakSwiftly.Success) {
+        var metrics = BenchmarkRequestLifecycleMetrics()
+        var acknowledgedSuccess: SpeakSwiftly.Success?
+
+        for try await event in events {
+            let elapsedMS = milliseconds(since: submittedAt, clock: clock)
+
+            switch event {
+                case let .queued(queued):
+                    metrics.queuedAtMS = metrics.queuedAtMS ?? elapsedMS
+                    metrics.queueReason = queued.reason.rawValue
+                    metrics.queuePosition = queued.queuePosition
+                case let .acknowledged(success):
+                    metrics.acknowledgedAtMS = metrics.acknowledgedAtMS ?? elapsedMS
+                    acknowledgedSuccess = success
+                case .started:
+                    metrics.startedAtMS = metrics.startedAtMS ?? elapsedMS
+                case let .progress(progress):
+                    switch progress.stage {
+                        case .bufferingAudio:
+                            metrics.bufferingAudioAtMS = metrics.bufferingAudioAtMS ?? elapsedMS
+                        case .prerollReady:
+                            metrics.prerollReadyAtMS = metrics.prerollReadyAtMS ?? elapsedMS
+                        case .playbackFinished:
+                            metrics.playbackFinishedAtMS = metrics.playbackFinishedAtMS ?? elapsedMS
+                        default:
+                            continue
+                    }
+                case let .completed(success):
+                    metrics.completedAtMS = metrics.completedAtMS ?? elapsedMS
+                    return (metrics, success)
+            }
+        }
+
+        if let acknowledgedSuccess {
+            return (metrics, acknowledgedSuccess)
+        }
+
+        throw BenchmarkError("A benchmark request stream ended before it reported terminal success.")
+    }
+
+    private static func collectGenerationMetrics(
+        from events: AsyncThrowingStream<SpeakSwiftly.GenerationEventUpdate, any Swift.Error>,
+        submittedAt: ContinuousClock.Instant,
+        clock: ContinuousClock,
+    ) async throws -> BenchmarkRequestGenerationMetrics {
+        var metrics = BenchmarkRequestGenerationMetrics()
+
+        for try await update in events {
+            let elapsedMS = milliseconds(since: submittedAt, clock: clock)
+
+            switch update.event {
+                case .token:
+                    metrics.firstTokenAtMS = metrics.firstTokenAtMS ?? elapsedMS
+                    metrics.observedTokenCount += 1
+                case let .info(info):
+                    metrics.infoAtMS = metrics.infoAtMS ?? elapsedMS
+                    metrics.promptTokenCount = info.promptTokenCount
+                    metrics.generationTokenCount = info.generationTokenCount
+                    metrics.prefillTimeMS = info.prefillTime * 1000
+                    metrics.generateTimeMS = info.generateTime * 1000
+                    metrics.tokensPerSecond = info.tokensPerSecond
+                    metrics.peakMemoryUsageGB = info.peakMemoryUsage
+                case let .audioChunk(sampleCount):
+                    metrics.firstAudioChunkAtMS = metrics.firstAudioChunkAtMS ?? elapsedMS
+                    metrics.audioChunkCount += 1
+                    metrics.totalAudioSampleCount += sampleCount
+            }
+        }
+
+        return metrics
+    }
+
+    private static func awaitPlaybackMetrics(
+        for requestID: String,
+        operation: String,
+        logRecorder: BenchmarkLogRecorder?,
+    ) async throws -> BenchmarkPlaybackMetrics? {
+        guard operation == "generate_speech" else { return nil }
+        guard let logRecorder else { return nil }
+
+        for _ in 0..<40 {
+            if let metrics = logRecorder.playbackMetrics(for: requestID) {
+                return metrics
+            }
+
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        throw BenchmarkError("Benchmark harness did not observe a playback_finished summary for request '\(requestID)'.")
+    }
+}
+
+struct BenchmarkError: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
@@ -48,10 +48,16 @@ struct QwenBenchmarkE2ETests {
                 iterations: iterations,
                 benchmarkProfileName: Self.benchmarkProfileName,
                 playbackTextCharacterCount: E2EHarness.testingPlaybackText.count,
+                playbackMode: BenchmarkHarness.effectivePlaybackMode(),
             ),
             strategies: QwenConditioningStrategyBenchmarkReport.make(from: samples),
         )
-        let summaryURL = try Self.writeBenchmarkSummary(summary)
+        let summaryURL = try BenchmarkHarness.writeSummary(
+            summary,
+            timestampedStem: "qwen-resident-benchmark",
+            latestFilename: "qwen-resident-benchmark-latest.json",
+            generatedAt: summary.generatedAt,
+        )
 
         print("SpeakSwiftly qwen benchmark summary: \(summaryURL.path)")
         for strategy in summary.strategies {
@@ -64,20 +70,20 @@ private extension QwenBenchmarkE2ETests {
     static let benchmarkProfileName = "benchmark-profile"
 
     static func provisionBenchmarkProfile(in profileRootURL: URL) async throws {
-        try await withBenchmarkRuntime(
+        try await BenchmarkHarness.withBenchmarkRuntime(
             profileRootURL: profileRootURL,
             backend: .qwen3,
             qwenConditioningStrategy: .preparedConditioning,
-        ) { runtime in
-            _ = try await awaitResidentReady(on: runtime)
+        ) { session in
+            _ = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
 
-            let handle = await runtime.voices.create(
+            let handle = await session.runtime.voices.create(
                 design: benchmarkProfileName,
                 from: E2EHarness.testingProfileText,
                 vibe: .masc,
                 voice: E2EHarness.testingProfileVoiceDescription,
             )
-            _ = try await awaitSuccess(from: handle)
+            _ = try await BenchmarkHarness.awaitSuccess(from: handle)
         }
     }
 
@@ -86,23 +92,26 @@ private extension QwenBenchmarkE2ETests {
         strategy: SpeakSwiftly.QwenConditioningStrategy,
         iteration: Int,
     ) async throws -> QwenBenchmarkSample {
-        try await withBenchmarkRuntime(
+        try await BenchmarkHarness.withBenchmarkRuntime(
             profileRootURL: profileRootURL,
             backend: .qwen3,
             qwenConditioningStrategy: strategy,
-        ) { runtime in
-            let preloadMS = try await awaitResidentReady(on: runtime)
-            let generatedFile = try await runRequestBenchmark(
-                handle: runtime.generate.audio(
+            playbackMode: BenchmarkHarness.effectivePlaybackMode(),
+        ) { session in
+            let preloadMS = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
+            let generatedFile = try await BenchmarkHarness.runRequestBenchmark(
+                handle: session.runtime.generate.audio(
                     text: E2EHarness.testingPlaybackText,
                     with: benchmarkProfileName,
                 ),
+                logRecorder: session.logRecorder,
             )
-            let liveSpeech = try await runRequestBenchmark(
-                handle: runtime.generate.speech(
+            let liveSpeech = try await BenchmarkHarness.runRequestBenchmark(
+                handle: session.runtime.generate.speech(
                     text: E2EHarness.testingPlaybackText,
                     with: benchmarkProfileName,
                 ),
+                logRecorder: session.logRecorder,
             )
 
             return QwenBenchmarkSample(
@@ -114,339 +123,21 @@ private extension QwenBenchmarkE2ETests {
             )
         }
     }
-
-    static func withBenchmarkRuntime<T>(
-        profileRootURL: URL,
-        backend: SpeakSwiftly.SpeechBackend,
-        qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
-        operation: @escaping @Sendable (SpeakSwiftly.Runtime) async throws -> T,
-    ) async throws -> T {
-        let runtime = try await makeBenchmarkRuntime(
-            profileRootURL: profileRootURL,
-            backend: backend,
-            qwenConditioningStrategy: qwenConditioningStrategy,
-        )
-
-        do {
-            let result = try await operation(runtime)
-            await runtime.shutdown()
-            return result
-        } catch {
-            await runtime.shutdown()
-            throw error
-        }
-    }
-
-    static func makeBenchmarkRuntime(
-        profileRootURL: URL,
-        backend: SpeakSwiftly.SpeechBackend,
-        qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
-    ) async throws -> SpeakSwiftly.Runtime {
-        _ = try SpeakSwiftly.SupportResources.mlxBundleURL()
-        _ = try SpeakSwiftly.SupportResources.defaultMetallibURL()
-
-        let liveDependencies = WorkerDependencies.live()
-        let dependencies = WorkerDependencies(
-            fileManager: liveDependencies.fileManager,
-            loadResidentModels: liveDependencies.loadResidentModels,
-            loadProfileModel: liveDependencies.loadProfileModel,
-            loadCloneTranscriptionModel: liveDependencies.loadCloneTranscriptionModel,
-            makePlaybackController: {
-                .silent(traceEnabled: false)
-            },
-            writeWAV: liveDependencies.writeWAV,
-            loadAudioSamples: liveDependencies.loadAudioSamples,
-            loadAudioFloats: liveDependencies.loadAudioFloats,
-            writeStdout: { _ in },
-            writeStderr: { message in
-                fputs("SpeakSwiftly benchmark runtime stderr: \(message)\n", stderr)
-            },
-            now: liveDependencies.now,
-            readRuntimeMemory: liveDependencies.readRuntimeMemory,
-        )
-
-        let profileStore = ProfileStore(
-            rootURL: profileRootURL,
-            fileManager: dependencies.fileManager,
-        )
-        let generatedFileStore = GeneratedFileStore(
-            rootURL: profileStore.rootURL.appendingPathComponent(GeneratedFileStore.directoryName, isDirectory: true),
-            fileManager: dependencies.fileManager,
-        )
-        let generationJobStore = GenerationJobStore(
-            rootURL: profileStore.rootURL.appendingPathComponent(GenerationJobStore.directoryName, isDirectory: true),
-            fileManager: dependencies.fileManager,
-        )
-        let normalizer = try SpeakSwiftly.Normalizer(
-            persistenceURL: ProfileStore.defaultTextProfilesURL(
-                fileManager: dependencies.fileManager,
-                profileRootOverride: profileRootURL.path,
-            ),
-        )
-        let playbackController = await PlaybackController(driver: dependencies.makePlaybackController())
-
-        let runtime = SpeakSwiftly.Runtime(
-            dependencies: dependencies,
-            speechBackend: backend,
-            qwenConditioningStrategy: qwenConditioningStrategy,
-            profileStore: profileStore,
-            generatedFileStore: generatedFileStore,
-            generationJobStore: generationJobStore,
-            normalizer: normalizer,
-            playbackController: playbackController,
-        )
-        await runtime.installPlaybackHooks()
-        return runtime
-    }
-
-    static func awaitResidentReady(on runtime: SpeakSwiftly.Runtime) async throws -> Double {
-        let clock = ContinuousClock()
-        let startedAt = clock.now
-        let statuses = await runtime.statusEvents()
-
-        await runtime.start()
-
-        for await status in statuses {
-            switch status.stage {
-                case .residentModelReady:
-                    return milliseconds(since: startedAt, clock: clock)
-                case .residentModelFailed:
-                    throw BenchmarkError("SpeakSwiftly benchmark runtime failed before the resident models became ready.")
-                case .warmingResidentModel, .residentModelsUnloaded:
-                    continue
-            }
-        }
-
-        throw BenchmarkError("SpeakSwiftly benchmark runtime stopped emitting status updates before reporting resident_model_ready.")
-    }
-
-    static func awaitSuccess(
-        from handle: SpeakSwiftly.RequestHandle,
-    ) async throws -> SpeakSwiftly.Success {
-        var acknowledgedSuccess: SpeakSwiftly.Success?
-
-        for try await event in handle.events {
-            switch event {
-                case let .acknowledged(success):
-                    acknowledgedSuccess = success
-                case let .completed(success):
-                    return success
-                case .queued, .started, .progress:
-                    continue
-            }
-        }
-
-        if let acknowledgedSuccess {
-            return acknowledgedSuccess
-        }
-
-        throw BenchmarkError("Request '\(handle.id)' ended before it reported an acknowledged or completed success payload.")
-    }
-
-    static func runRequestBenchmark(
-        handle: SpeakSwiftly.RequestHandle,
-    ) async throws -> QwenRequestBenchmark {
-        let clock = ContinuousClock()
-        let submittedAt = clock.now
-
-        async let lifecycle = collectLifecycleMetrics(
-            from: handle.events,
-            submittedAt: submittedAt,
-            clock: clock,
-        )
-        async let generation = collectGenerationMetrics(
-            from: handle.generationEvents,
-            submittedAt: submittedAt,
-            clock: clock,
-        )
-
-        let (lifecycleMetrics, success) = try await lifecycle
-        let generationMetrics = try await generation
-
-        return QwenRequestBenchmark(
-            requestID: handle.id,
-            operation: handle.operation,
-            generatedArtifactID: success.generatedFile?.artifactID,
-            lifecycle: lifecycleMetrics,
-            generation: generationMetrics,
-        )
-    }
-
-    static func collectLifecycleMetrics(
-        from events: AsyncThrowingStream<SpeakSwiftly.RequestEvent, any Swift.Error>,
-        submittedAt: ContinuousClock.Instant,
-        clock: ContinuousClock,
-    ) async throws -> (QwenLifecycleMetrics, SpeakSwiftly.Success) {
-        var metrics = QwenLifecycleMetrics()
-        var acknowledgedSuccess: SpeakSwiftly.Success?
-
-        for try await event in events {
-            let elapsedMS = milliseconds(since: submittedAt, clock: clock)
-
-            switch event {
-                case let .queued(queued):
-                    metrics.queuedAtMS = metrics.queuedAtMS ?? elapsedMS
-                    metrics.queueReason = queued.reason.rawValue
-                    metrics.queuePosition = queued.queuePosition
-
-                case let .acknowledged(success):
-                    metrics.acknowledgedAtMS = metrics.acknowledgedAtMS ?? elapsedMS
-                    acknowledgedSuccess = success
-
-                case .started:
-                    metrics.startedAtMS = metrics.startedAtMS ?? elapsedMS
-
-                case let .progress(progress):
-                    switch progress.stage {
-                        case .bufferingAudio:
-                            metrics.bufferingAudioAtMS = metrics.bufferingAudioAtMS ?? elapsedMS
-                        case .prerollReady:
-                            metrics.prerollReadyAtMS = metrics.prerollReadyAtMS ?? elapsedMS
-                        case .playbackFinished:
-                            metrics.playbackFinishedAtMS = metrics.playbackFinishedAtMS ?? elapsedMS
-                        default:
-                            continue
-                    }
-
-                case let .completed(success):
-                    metrics.completedAtMS = metrics.completedAtMS ?? elapsedMS
-                    return (metrics, success)
-            }
-        }
-
-        if let acknowledgedSuccess {
-            return (metrics, acknowledgedSuccess)
-        }
-
-        throw BenchmarkError("A benchmark request stream ended before it reported terminal success.")
-    }
-
-    static func collectGenerationMetrics(
-        from events: AsyncThrowingStream<SpeakSwiftly.GenerationEventUpdate, any Swift.Error>,
-        submittedAt: ContinuousClock.Instant,
-        clock: ContinuousClock,
-    ) async throws -> QwenGenerationMetrics {
-        var metrics = QwenGenerationMetrics()
-
-        for try await update in events {
-            let elapsedMS = milliseconds(since: submittedAt, clock: clock)
-
-            switch update.event {
-                case .token:
-                    metrics.firstTokenAtMS = metrics.firstTokenAtMS ?? elapsedMS
-                    metrics.observedTokenCount += 1
-
-                case let .info(info):
-                    metrics.infoAtMS = metrics.infoAtMS ?? elapsedMS
-                    metrics.promptTokenCount = info.promptTokenCount
-                    metrics.generationTokenCount = info.generationTokenCount
-                    metrics.prefillTimeMS = info.prefillTime * 1000
-                    metrics.generateTimeMS = info.generateTime * 1000
-                    metrics.tokensPerSecond = info.tokensPerSecond
-                    metrics.peakMemoryUsageGB = info.peakMemoryUsage
-
-                case let .audioChunk(sampleCount):
-                    metrics.firstAudioChunkAtMS = metrics.firstAudioChunkAtMS ?? elapsedMS
-                    metrics.audioChunkCount += 1
-                    metrics.totalAudioSampleCount += sampleCount
-            }
-        }
-
-        return metrics
-    }
-
-    static func writeBenchmarkSummary(_ summary: QwenBenchmarkSummary) throws -> URL {
-        let benchmarksRoot = try packageRootURL()
-            .appendingPathComponent(".local/benchmarks", isDirectory: true)
-        try FileManager.default.createDirectory(at: benchmarksRoot, withIntermediateDirectories: true)
-
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        let stamp = formatter.string(from: summary.generatedAt).replacingOccurrences(of: ":", with: "-")
-        let summaryURL = benchmarksRoot.appendingPathComponent("qwen-resident-benchmark-\(stamp).json", isDirectory: false)
-
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        let encoded = try encoder.encode(summary)
-        try encoded.write(to: summaryURL, options: .atomic)
-
-        let latestSummaryURL = benchmarksRoot.appendingPathComponent("qwen-resident-benchmark-latest.json", isDirectory: false)
-        try encoded.write(to: latestSummaryURL, options: .atomic)
-        return summaryURL
-    }
-
-    static func packageRootURL() throws -> URL {
-        let fileManager = FileManager.default
-        var candidateURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
-
-        while true {
-            let manifestURL = candidateURL.appendingPathComponent("Package.swift", isDirectory: false)
-            if fileManager.fileExists(atPath: manifestURL.path) {
-                return candidateURL
-            }
-
-            let parentURL = candidateURL.deletingLastPathComponent()
-            guard parentURL != candidateURL else {
-                throw BenchmarkError("The qwen benchmark suite could not find the package root while walking upward from '\(#filePath)'.")
-            }
-
-            candidateURL = parentURL
-        }
-    }
-
-    static func milliseconds(
-        since instant: ContinuousClock.Instant,
-        clock: ContinuousClock,
-    ) -> Double {
-        let duration = clock.now - instant
-        let components = duration.components
-        return Double(components.seconds) * 1000
-            + Double(components.attoseconds) / 1_000_000_000_000_000
-    }
 }
 
 private struct QwenBenchmarkSummary: Codable {
     let schemaVersion: Int
     let generatedAt: Date
-    let host: QwenBenchmarkHost
+    let host: BenchmarkHost
     let settings: QwenBenchmarkSettings
     let strategies: [QwenConditioningStrategyBenchmarkReport]
-}
-
-private struct QwenBenchmarkHost: Codable {
-    let machineArchitecture: String
-    let operatingSystemVersion: String
-    let activeProcessorCount: Int
-    let physicalMemoryBytes: UInt64
-
-    static func localMachine() -> Self {
-        let processInfo = ProcessInfo.processInfo
-        return Self(
-            machineArchitecture: hostMachineArchitecture(),
-            operatingSystemVersion: processInfo.operatingSystemVersionString,
-            activeProcessorCount: processInfo.activeProcessorCount,
-            physicalMemoryBytes: processInfo.physicalMemory,
-        )
-    }
-
-    private static func hostMachineArchitecture() -> String {
-        var systemInfo = utsname()
-        guard uname(&systemInfo) == 0 else { return "unknown" }
-
-        let machine = systemInfo.machine
-        return withUnsafePointer(to: machine) {
-            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: machine)) {
-                String(cString: $0)
-            }
-        }
-    }
 }
 
 private struct QwenBenchmarkSettings: Codable {
     let iterations: Int
     let benchmarkProfileName: String
     let playbackTextCharacterCount: Int
+    let playbackMode: BenchmarkPlaybackMode
     let timestampedSummaryPattern: String
     let latestSummaryFilename: String
     let comparedStrategies: [SpeakSwiftly.QwenConditioningStrategy]
@@ -455,11 +146,13 @@ private struct QwenBenchmarkSettings: Codable {
         iterations: Int,
         benchmarkProfileName: String,
         playbackTextCharacterCount: Int,
+        playbackMode: BenchmarkPlaybackMode,
     ) -> Self {
         Self(
             iterations: iterations,
             benchmarkProfileName: benchmarkProfileName,
             playbackTextCharacterCount: playbackTextCharacterCount,
+            playbackMode: playbackMode,
             timestampedSummaryPattern: "qwen-resident-benchmark-<ISO8601>.json",
             latestSummaryFilename: "qwen-resident-benchmark-latest.json",
             comparedStrategies: [.legacyRaw, .preparedConditioning],
@@ -470,9 +163,9 @@ private struct QwenBenchmarkSettings: Codable {
 private struct QwenConditioningStrategyBenchmarkReport: Codable {
     let strategy: SpeakSwiftly.QwenConditioningStrategy
     let sampleCount: Int
-    let residentPreloadMS: QwenMetricSummary
-    let generatedFile: QwenRequestBenchmarkAggregate
-    let liveSpeech: QwenRequestBenchmarkAggregate
+    let residentPreloadMS: BenchmarkMetricSummary
+    let generatedFile: BenchmarkRequestAggregate
+    let liveSpeech: BenchmarkRequestAggregate
     let samples: [QwenBenchmarkSample]
 
     var prettyDescription: String {
@@ -501,142 +194,7 @@ private struct QwenBenchmarkSample: Codable {
     let strategy: SpeakSwiftly.QwenConditioningStrategy
     let iteration: Int
     let residentPreloadMS: Double
-    let generatedFile: QwenRequestBenchmark
-    let liveSpeech: QwenRequestBenchmark
-}
-
-private struct QwenRequestBenchmark: Codable {
-    let requestID: String
-    let operation: String
-    let generatedArtifactID: String?
-    let lifecycle: QwenLifecycleMetrics
-    let generation: QwenGenerationMetrics
-}
-
-private struct QwenLifecycleMetrics: Codable {
-    var queuedAtMS: Double?
-    var queueReason: String?
-    var queuePosition: Int?
-    var acknowledgedAtMS: Double?
-    var startedAtMS: Double?
-    var bufferingAudioAtMS: Double?
-    var prerollReadyAtMS: Double?
-    var playbackFinishedAtMS: Double?
-    var completedAtMS: Double?
-}
-
-private struct QwenGenerationMetrics: Codable {
-    var firstTokenAtMS: Double?
-    var infoAtMS: Double?
-    var firstAudioChunkAtMS: Double?
-    var observedTokenCount = 0
-    var audioChunkCount = 0
-    var totalAudioSampleCount = 0
-    var promptTokenCount: Int?
-    var generationTokenCount: Int?
-    var prefillTimeMS: Double?
-    var generateTimeMS: Double?
-    var tokensPerSecond: Double?
-    var peakMemoryUsageGB: Double?
-}
-
-private struct QwenRequestBenchmarkAggregate: Codable {
-    let sampleCount: Int
-    let lifecycle: QwenLifecycleMetricAggregate
-    let generation: QwenGenerationMetricAggregate
-
-    static func make(from samples: [QwenRequestBenchmark]) -> Self {
-        Self(
-            sampleCount: samples.count,
-            lifecycle: .make(from: samples.map(\.lifecycle)),
-            generation: .make(from: samples.map(\.generation)),
-        )
-    }
-}
-
-private struct QwenLifecycleMetricAggregate: Codable {
-    let acknowledgedMS: QwenMetricSummary
-    let startedMS: QwenMetricSummary
-    let bufferingAudioMS: QwenMetricSummary
-    let prerollReadyMS: QwenMetricSummary
-    let playbackFinishedMS: QwenMetricSummary
-    let completedMS: QwenMetricSummary
-
-    static func make(from samples: [QwenLifecycleMetrics]) -> Self {
-        Self(
-            acknowledgedMS: .make(from: samples.compactMap(\.acknowledgedAtMS)),
-            startedMS: .make(from: samples.compactMap(\.startedAtMS)),
-            bufferingAudioMS: .make(from: samples.compactMap(\.bufferingAudioAtMS)),
-            prerollReadyMS: .make(from: samples.compactMap(\.prerollReadyAtMS)),
-            playbackFinishedMS: .make(from: samples.compactMap(\.playbackFinishedAtMS)),
-            completedMS: .make(from: samples.compactMap(\.completedAtMS)),
-        )
-    }
-}
-
-private struct QwenGenerationMetricAggregate: Codable {
-    let firstTokenMS: QwenMetricSummary
-    let infoMS: QwenMetricSummary
-    let firstAudioChunkMS: QwenMetricSummary
-    let observedTokenCount: QwenMetricSummary
-    let audioChunkCount: QwenMetricSummary
-    let totalAudioSampleCount: QwenMetricSummary
-    let promptTokenCount: QwenMetricSummary
-    let generationTokenCount: QwenMetricSummary
-    let prefillTimeMS: QwenMetricSummary
-    let generateTimeMS: QwenMetricSummary
-    let tokensPerSecond: QwenMetricSummary
-    let peakMemoryUsageGB: QwenMetricSummary
-
-    static func make(from samples: [QwenGenerationMetrics]) -> Self {
-        Self(
-            firstTokenMS: .make(from: samples.compactMap(\.firstTokenAtMS)),
-            infoMS: .make(from: samples.compactMap(\.infoAtMS)),
-            firstAudioChunkMS: .make(from: samples.compactMap(\.firstAudioChunkAtMS)),
-            observedTokenCount: .make(from: samples.map { Double($0.observedTokenCount) }),
-            audioChunkCount: .make(from: samples.map { Double($0.audioChunkCount) }),
-            totalAudioSampleCount: .make(from: samples.map { Double($0.totalAudioSampleCount) }),
-            promptTokenCount: .make(from: samples.compactMap { $0.promptTokenCount.map(Double.init) }),
-            generationTokenCount: .make(from: samples.compactMap { $0.generationTokenCount.map(Double.init) }),
-            prefillTimeMS: .make(from: samples.compactMap(\.prefillTimeMS)),
-            generateTimeMS: .make(from: samples.compactMap(\.generateTimeMS)),
-            tokensPerSecond: .make(from: samples.compactMap(\.tokensPerSecond)),
-            peakMemoryUsageGB: .make(from: samples.compactMap(\.peakMemoryUsageGB)),
-        )
-    }
-}
-
-private struct QwenMetricSummary: Codable {
-    let count: Int
-    let min: Double?
-    let average: Double?
-    let max: Double?
-
-    var prettyAverage: String {
-        guard let average else { return "n/a" }
-
-        return String(format: "%.2f", average)
-    }
-
-    static func make(from values: [Double]) -> Self {
-        guard !values.isEmpty else {
-            return Self(count: 0, min: nil, average: nil, max: nil)
-        }
-
-        return Self(
-            count: values.count,
-            min: values.min(),
-            average: values.reduce(0, +) / Double(values.count),
-            max: values.max(),
-        )
-    }
-}
-
-private struct BenchmarkError: Error, CustomStringConvertible {
-    let description: String
-
-    init(_ description: String) {
-        self.description = description
-    }
+    let generatedFile: BenchmarkRequest
+    let liveSpeech: BenchmarkRequest
 }
 #endif

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
@@ -18,11 +18,32 @@ func speakSwiftlyDeepTraceE2ETestsEnabled() -> Bool {
 }
 
 func speakSwiftlyQwenBenchmarkE2ETestsEnabled() -> Bool {
-    ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_BENCHMARK_E2E"] == "1"
+    let environment = ProcessInfo.processInfo.environment
+    return environment["SPEAKSWIFTLY_QWEN_BENCHMARK_E2E"] == "1"
+        || environment["SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E"] == "1"
 }
 
 func speakSwiftlyQwenBenchmarkIterations() -> Int {
     let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS"] ?? ""
+    if let parsed = Int(rawValue) {
+        return max(1, parsed)
+    }
+
+    return speakSwiftlyBackendBenchmarkIterations()
+}
+
+func speakSwiftlyBackendBenchmarkE2ETestsEnabled() -> Bool {
+    ProcessInfo.processInfo.environment["SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E"] == "1"
+}
+
+func speakSwiftlyBackendBenchmarkIterations() -> Int {
+    let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS"] ?? ""
     return max(1, Int(rawValue) ?? 1)
+}
+
+func speakSwiftlyBackendBenchmarkAudibleEnabled() -> Bool {
+    let environment = ProcessInfo.processInfo.environment
+    return environment["SPEAKSWIFTLY_BACKEND_BENCHMARK_AUDIBLE"] == "1"
+        || environment["SPEAKSWIFTLY_AUDIBLE_E2E"] == "1"
 }
 #endif

--- a/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
+++ b/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
@@ -1,0 +1,477 @@
+# Backend Benchmarking Plan
+
+## Status
+
+This note started as a design plan for a repo-native benchmark suite. Parts of
+that plan are now implemented, but the longer-term GPU profiling and deeper
+playback-analysis story still remains incomplete.
+
+What exists already:
+
+- one shared benchmark harness under
+  `Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift`
+- one opt-in backend-wide benchmark suite under
+  `Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift`
+- one opt-in Qwen resident benchmark suite under
+  `Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift`
+- per-request generation event metrics such as prefill time, generation time,
+  tokens per second, and model-reported peak memory
+- runtime memory snapshots for process CPU time, process memory footprint, and
+  MLX memory usage
+- playback summary and playback trace surfaces that already report queue-depth,
+  rebuffer, starvation, and scheduling behavior
+- one repo-maintenance benchmark wrapper under
+  `scripts/repo-maintenance/run-benchmark.sh`
+
+What does not exist yet:
+
+- one separate Instruments-oriented GPU profiling wrapper
+- one deeper retained playback-analysis report beyond the current per-request
+  playback summary aggregates
+- one broader benchmark history or comparison tool that diff-checks retained
+  JSON summaries across runs
+
+## Why This Exists
+
+The package already has several useful performance surfaces, but they are still
+split across different seams:
+
+- Qwen has a dedicated benchmark suite
+- playback quality shows up in playback summaries and trace events
+- runtime resource usage shows up in runtime memory snapshots
+- backend-generation timing shows up in generation event info
+
+That is enough to support real benchmarking work. The missing piece is one
+maintainer-owned benchmark model that asks every backend to do the same job and
+stores the results in one comparable shape.
+
+The immediate goal is not abstract benchmarking infrastructure for its own
+future sake. The immediate goal is simpler:
+
+- run the same standard speech-generation workload on `qwen3`,
+  `chatterbox_turbo`, and `marvis`
+- capture speed, throughput, memory pressure, CPU load, and playback stability
+- see what changes between backends and between queued job positions
+- keep the results durable enough that later optimization work is based on
+  evidence instead of recollection
+
+## The Standard Scenario
+
+The benchmark suite should standardize around one package-owned scenario:
+
+- one resident runtime per benchmark sample
+- one selected backend
+- one stored benchmark voice profile
+- two live speech requests submitted back-to-back
+- each request contains two paragraphs of fixed benchmark text
+- the second request should be accepted while the first request is still active
+  so the queue path is exercised on purpose
+
+This is the core scenario because it exercises the part of the package that is
+most likely to feel slow or unstable to a real caller:
+
+- resident model warmup
+- first live playback startup
+- queue admission and waiting behavior
+- overlap between generation and playback
+- contention effects on the second request
+
+The benchmark text should stay checked in and stable. Do not let ad hoc local
+paragraphs drift between runs.
+
+Recommended benchmark fixture shape:
+
+- paragraph 1: normal prose with ordinary sentence structure
+- paragraph 2: slightly denser prose with longer clauses and punctuation
+
+That gives us something closer to real operator usage than a single short
+sentence while avoiding a bizarre stress-only corpus that no one would actually
+send to the package.
+
+## Recommended Benchmark Lanes
+
+The benchmark suite should be split into three lanes with different goals.
+
+### Lane 1: Canonical Backend Comparison
+
+This should become the default backend-comparison lane.
+
+Shape:
+
+- real models
+- real resident runtime
+- silent playback driver
+- the standard two-job live scenario
+- multiple iterations
+
+Why it exists:
+
+- it keeps backend-to-backend comparisons relatively stable
+- it avoids host speaker routing and output-device quirks dominating the numbers
+- it still exercises live generation, preroll, queueing, and drain behavior
+
+This lane should be the source of truth for:
+
+- timing regressions
+- throughput changes
+- process and MLX memory changes
+- queue and playback stability changes
+
+### Lane 2: Audible Stress Lane
+
+This should run the same standard scenario, but through real audible playback.
+
+Shape:
+
+- real models
+- real resident runtime
+- audible playback enabled
+- the standard two-job live scenario
+- fewer iterations than the canonical lane
+
+Why it exists:
+
+- it answers the real-world question "does this sound stable on the machine"
+- it catches rebuffering, underruns, and device-specific playback pain that a
+  silent driver can hide
+- it gives maintainers a deliberate path for "is the package usable right now"
+  verification without confusing those runs with the cleaner backend-comparison
+  numbers
+
+Do not treat this lane as the primary regression baseline unless the package
+later grows a more controlled audio-device test environment. It is important,
+but it is noisier.
+
+### Lane 3: Instruments and GPU Profiling Lane
+
+This lane should stay separate from the ordinary benchmark suite.
+
+Shape:
+
+- one targeted scenario at a time
+- Xcode-backed or Instruments-driven profiling session
+- signposts and trace alignment when deeper diagnosis is needed
+
+Why it exists:
+
+- immediate package-side benchmark runs can tell us that one backend got slower
+  or more memory-hungry
+- they cannot fully answer where Apple-silicon GPU time went in a clean,
+  per-test, package-native way
+
+Use this lane when a canonical benchmark already proved that a regression
+exists and we need to inspect CPU hot spots, Metal scheduling pressure, or
+unified-memory pressure in more depth.
+
+## Why XCTest Performance Metrics Are Not The Primary Plan
+
+Apple's XCTest performance APIs can directly measure:
+
+- elapsed wall time
+- CPU activity
+- memory deltas
+- signposted regions
+
+That is useful, but it is not the best primary fit here.
+
+This package is already structured around worker-backed e2e flows, async event
+streams, runtime-owned playback, and retained JSON benchmark output. A plain
+`measure { ... }` block would not capture the package's real request lifecycle
+as cleanly as the existing event-driven harness can.
+
+More importantly, the GPU story is different:
+
+- MetricKit exposes GPU metrics, including cumulative GPU time
+- MetricKit reports are app-delivered and aggregate over time
+- that makes MetricKit a poor primary source for one immediate package test run
+
+So the practical design should be:
+
+- package-native benchmark harness first
+- XCTest performance metrics only if we later want one smaller host-process
+  microbenchmark around a narrow operation
+- Instruments or app-hosted profiling as the GPU-deep-dive lane
+
+## Metrics To Capture
+
+The benchmark result model should separate:
+
+- suite-level settings
+- per-sample host details
+- per-request lifecycle metrics
+- per-request generation metrics
+- per-request resource metrics
+- per-request playback metrics
+- backend-level aggregate summaries
+
+### Required Metrics
+
+These should be present for every backend benchmark sample.
+
+Timing:
+
+- resident preload time
+- queue admission time
+- queue wait time
+- time to acknowledged
+- time to started
+- time to first token
+- time to first audio chunk
+- time to buffering
+- time to preroll ready
+- time to playback finished
+- total completion time
+
+Generation:
+
+- observed token count
+- prompt token count when available
+- generation token count when available
+- prefill time when available
+- generation time when available
+- tokens per second when available
+
+Runtime resource usage:
+
+- process resident bytes before and after request
+- process physical footprint bytes before and after request
+- process user CPU time before and after request
+- process system CPU time before and after request
+- MLX active memory before and after request
+- MLX cache memory before and after request
+- MLX peak memory after request
+
+Playback stability:
+
+- startup buffered audio
+- time to first chunk
+- time to preroll ready
+- min queued audio
+- max queued audio
+- average queued audio
+- queue depth sample count
+- rebuffer event count
+- total rebuffer duration
+- longest rebuffer duration
+- starvation event count
+- max and average inter-chunk gap
+- max and average schedule gap
+
+### Optional Metrics
+
+These should be recorded when the backend or lane can support them cleanly.
+
+- generated artifact ID for retained file outputs
+- model-native peak memory usage from generation info
+- host audio-device metadata for audible runs
+- signpost-linked region durations for Instruments-oriented captures
+
+Optional metrics should be explicit `null` values in JSON, not silently missing
+fields, so later comparison code can tell the difference between "not provided"
+and "forgotten in this schema version."
+
+## How To Treat The Second Job
+
+The second request is not just another sample. It is the most important part of
+the scenario.
+
+For each benchmark sample, store metrics for:
+
+- job 1
+- job 2
+- sample-level aggregate comparisons
+
+The suite should call out at least these derived values:
+
+- job 2 queue wait minus job 1 queue wait
+- job 2 first-audio latency minus job 1 first-audio latency
+- job 2 completion time minus job 1 completion time
+- job 2 rebuffer count minus job 1 rebuffer count
+
+That makes the queued-request tax obvious instead of forcing maintainers to
+infer it from two large JSON blobs.
+
+## Expected Backend Differences
+
+The benchmark suite should not force every backend into fake symmetry.
+
+`qwen3` can already surface richer generation info and should continue doing so.
+
+`chatterbox_turbo` and `marvis` may not currently produce the same info payload
+shape on every run. That is acceptable as long as:
+
+- the shared benchmark schema keeps the fields stable
+- optional metrics are recorded explicitly when unavailable
+- the suite still captures the common timing, process-resource, and playback
+  metrics for all backends
+
+The benchmark model should prefer honest partial comparison over flattening the
+backend differences into misleading generic numbers.
+
+## Result Storage
+
+The current Qwen benchmark already writes JSON summaries under `.local/benchmarks`.
+The generalized backend suite should keep that storage root and adopt a stable
+family naming pattern such as:
+
+- `backend-live-benchmark-<ISO8601>.json`
+- `backend-live-benchmark-latest.json`
+- `backend-live-audible-benchmark-<ISO8601>.json`
+- `backend-live-audible-benchmark-latest.json`
+
+The summary should record:
+
+- schema version
+- generation timestamp
+- host machine description
+- backend list
+- iteration count
+- playback mode
+- benchmark text fixture identity
+- profile identity
+- all sample results
+- aggregate reports per backend
+
+Keep the schema versioned so comparison tooling can evolve without corrupting
+older retained runs.
+
+## Suggested Test Layout
+
+The current Qwen benchmark suite proves the basic shape already works. The next
+step should be to generalize it instead of creating a second unrelated harness.
+
+Recommended test layout:
+
+- `Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift`
+- `Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkSupport.swift`
+- `Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift`
+  extended with backend-benchmark environment gates
+
+Recommended policy flags:
+
+- `SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1`
+- `SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS=<n>`
+- `SPEAKSWIFTLY_BACKEND_BENCHMARK_AUDIBLE=1`
+
+Recommended suite tags:
+
+- `.e2e`
+- `.benchmark`
+- backend-specific tags when useful
+
+Keep the suite serialized. This repository already treats heavy worker-backed
+model tests as strictly one-at-a-time work.
+
+## Suggested Implementation Slices
+
+### Slice 1: Generalize The Existing Qwen Benchmark Harness
+
+Goal:
+
+- extract shared benchmark support from the current Qwen suite
+- preserve the current Qwen lane while moving common code into reusable support
+
+What to move into shared support:
+
+- benchmark runtime bootstrapping
+- request lifecycle collection
+- generation metric collection
+- benchmark summary writing
+- host and settings capture
+
+### Slice 2: Add A Shared Two-Job Live Scenario
+
+Goal:
+
+- replace the current one-request Qwen benchmark shape with the standard
+  two-queued-job scenario
+
+Important rule:
+
+- submit job 2 while job 1 is still active
+- do not wait for job 1 to finish first
+
+That is the only way the benchmark can honestly claim it measures queue
+behavior.
+
+### Slice 3: Add Playback Summary Capture Per Request
+
+Goal:
+
+- attach playback summary data to each benchmarked request
+
+This is the slice that makes the benchmark useful for "speed" and "did the user
+actually hear stable audio" at the same time.
+
+### Slice 4: Widen The Suite To All Backends
+
+Goal:
+
+- run the same scenario against `.qwen3`, `.chatterboxTurbo`, and `.marvis`
+
+Do not wait for every backend to surface identical model-native metrics before
+landing this slice. The comparison is still valuable with the shared timing,
+process-resource, and playback metrics.
+
+### Slice 5: Add The Audible Lane
+
+Goal:
+
+- add a deliberate audible variant of the same suite
+
+Keep this lane opt-in and lower-iteration.
+
+### Slice 6: Add Repo-Maintenance Commands
+
+Goal:
+
+- make the benchmark suite easy to discover and re-run
+
+Recommended shape:
+
+- one repo-maintenance wrapper for canonical backend comparison
+- one repo-maintenance wrapper or flag for audible backend comparison
+
+## GPU Strategy
+
+The benchmark suite should report what it can measure directly now, and it
+should be explicit about the GPU boundary.
+
+What the package can measure directly today:
+
+- MLX memory state
+- process CPU time
+- process memory footprint
+- end-to-end timing
+- playback stability
+
+What the package should not pretend it already has:
+
+- clean immediate per-sample GPU time per request from a plain package test
+
+If we need deeper GPU visibility, the next honest step is:
+
+- add or reuse signposts around resident preload, first token, first audio
+  chunk, preroll ready, and playback drain
+- line those signposts up in Instruments
+- keep that workflow documented as a profiling lane, not as the ordinary
+  backend benchmark suite
+
+## Recommended Outcome
+
+The best immediate path is:
+
+1. generalize the current Qwen benchmark harness
+2. standardize on the two-queued-live-job scenario
+3. make the silent canonical lane the default backend-comparison source of truth
+4. add the audible lane as a second opt-in benchmark story
+5. keep GPU-deep-dive work in a separate profiling workflow
+
+That gives the package one benchmark system that matches the real runtime job
+it is doing for Gale:
+
+- speak two substantial requests
+- queue the second one behind the first
+- show how fast each backend starts speaking
+- show how hard each backend pushes the machine
+- show whether playback stays stable while it happens

--- a/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
+++ b/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
@@ -335,6 +335,21 @@ The summary should record:
 Keep the schema versioned so comparison tooling can evolve without corrupting
 older retained runs.
 
+## Near-Term Follow-Up
+
+Investigate the Qwen long-form volume-decay regression soon as a dedicated
+follow-up pass.
+
+- Re-run the retained-file `volume-probe` and direct-vs-stream
+  `compare-volume` paths after dependency updates, profile rerolls, and any
+  upstream `mlx-audio-swift` changes that could affect Qwen decode behavior.
+- Keep comparing saved profiles against fresh voice-design profiles so prompt
+  content and profile materialization changes can be separated from model-side
+  drift.
+- Record whether the decay is present in direct non-stream decode, streamed
+  retained-file generation, or both before attributing regressions to playback
+  shaping.
+
 ## Suggested Test Layout
 
 The current Qwen benchmark suite proves the basic shape already works. The next

--- a/docs/maintainers/validation-lanes.md
+++ b/docs/maintainers/validation-lanes.md
@@ -200,6 +200,26 @@ xcodebuild test-without-building -quiet \
 That lane excludes the opt-in `DeepTraceE2ETests` and `QwenBenchmarkE2ETests`
 families unless you deliberately inject their extra environment flags too.
 
+For the broader backend-comparison benchmark design that should eventually
+replace the Qwen-only benchmark as the main package benchmark lane, see:
+
+- [backend-benchmarking-plan-2026-04-20.md](backend-benchmarking-plan-2026-04-20.md)
+
+The package now also has an opt-in backend-wide benchmark suite behind:
+
+- `SPEAKSWIFTLY_E2E=1`
+- `SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1`
+- optional `SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS=<n>`
+- optional `SPEAKSWIFTLY_BACKEND_BENCHMARK_AUDIBLE=1`
+
+Prefer the repo-maintenance wrapper instead of exporting those by hand:
+
+```bash
+sh scripts/repo-maintenance/run-benchmark.sh
+sh scripts/repo-maintenance/run-benchmark.sh --audible --iterations 3
+sh scripts/repo-maintenance/run-benchmark.sh --qwen --iterations 5
+```
+
 For Marvis overlap and trace work, prefer the dedicated runbook:
 
 - [marvis-overlap-profiling-runbook-2026-04-16.md](marvis-overlap-profiling-runbook-2026-04-16.md)

--- a/scripts/repo-maintenance/run-benchmark.sh
+++ b/scripts/repo-maintenance/run-benchmark.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env sh
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SELF_DIR/lib/common.sh"
+
+load_env_file "$SELF_DIR/config/validation.env"
+ensure_git_repo
+
+benchmark_target="backend"
+audible="false"
+playback_trace="false"
+iterations=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --backend)
+      benchmark_target="backend"
+      shift
+      ;;
+    --qwen)
+      benchmark_target="qwen"
+      shift
+      ;;
+    --audible)
+      audible="true"
+      shift
+      ;;
+    --playback-trace)
+      playback_trace="true"
+      shift
+      ;;
+    --iterations)
+      iterations="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage:
+  run-benchmark.sh [--backend|--qwen] [--audible] [--playback-trace] [--iterations <count>]
+
+Defaults:
+  --backend is the default benchmark target.
+
+Examples:
+  sh scripts/repo-maintenance/run-benchmark.sh
+  sh scripts/repo-maintenance/run-benchmark.sh --audible --iterations 3
+  sh scripts/repo-maintenance/run-benchmark.sh --qwen --iterations 5
+USAGE
+      exit 0
+      ;;
+    *)
+      die "Unknown run-benchmark argument: $1"
+      ;;
+  esac
+done
+
+suite_name="backend-benchmark"
+if [ "$benchmark_target" = "qwen" ]; then
+  suite_name="qwen-benchmark"
+fi
+
+suite_args=""
+if [ "$audible" = "true" ]; then
+  suite_args="$suite_args --audible"
+fi
+if [ "$playback_trace" = "true" ]; then
+  suite_args="$suite_args --playback-trace"
+fi
+if [ -n "$iterations" ]; then
+  suite_args="$suite_args --benchmark-iterations $iterations"
+fi
+
+log "Running SpeakSwiftly benchmark target '$benchmark_target' via suite '$suite_name'."
+# shellcheck disable=SC2086
+sh "$SELF_DIR/run-e2e.sh" --suite "$suite_name" $suite_args

--- a/scripts/repo-maintenance/run-e2e.sh
+++ b/scripts/repo-maintenance/run-e2e.sh
@@ -55,6 +55,7 @@ Suite names:
   trace | TraceCaptureE2ETests
   deep-trace | DeepTraceE2ETests
   qwen-benchmark | QwenBenchmarkE2ETests
+  backend-benchmark | BackendBenchmarkE2ETests
 
 Flags:
   --audible
@@ -84,6 +85,7 @@ resolve_suite_name() {
     trace|TraceCaptureE2ETests) printf '%s\n' "TraceCaptureE2ETests" ;;
     deep-trace|DeepTraceE2ETests) printf '%s\n' "DeepTraceE2ETests" ;;
     qwen-benchmark|QwenBenchmarkE2ETests) printf '%s\n' "QwenBenchmarkE2ETests" ;;
+    backend-benchmark|BackendBenchmarkE2ETests) printf '%s\n' "BackendBenchmarkE2ETests" ;;
     *)
       return 1
       ;;
@@ -94,7 +96,7 @@ suite_name=$(resolve_suite_name "$suite_arg") \
   || die "Unsupported E2E suite '$suite_arg'. Use --help to see the supported top-level suite names."
 
 case "$suite_name" in
-  QuickE2ETests|GeneratedFileE2ETests|GeneratedBatchE2ETests|ChatterboxE2ETests|MarvisE2ETests|QwenE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests)
+  QuickE2ETests|GeneratedFileE2ETests|GeneratedBatchE2ETests|ChatterboxE2ETests|MarvisE2ETests|QwenE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests|BackendBenchmarkE2ETests)
     ;;
   *)
     die "Refusing to run '$suite_name' because only one top-level E2E suite may run per invocation."
@@ -119,12 +121,21 @@ if [ "$deep_trace" = "true" ]; then
   export SPEAKSWIFTLY_DEEP_TRACE_E2E=1
 fi
 
-if [ "$benchmark" = "true" ]; then
+if [ "$benchmark" = "true" ] || [ "$suite_name" = "QwenBenchmarkE2ETests" ]; then
   export SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1
 fi
 
 if [ -n "$benchmark_iterations" ]; then
   export SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS="$benchmark_iterations"
+  export SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS="$benchmark_iterations"
+fi
+
+if [ "$suite_name" = "BackendBenchmarkE2ETests" ]; then
+  export SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1
+fi
+
+if [ "$suite_name" = "BackendBenchmarkE2ETests" ] && [ "$audible" = "true" ]; then
+  export SPEAKSWIFTLY_BACKEND_BENCHMARK_AUDIBLE=1
 fi
 
 log "Running SpeakSwiftly E2E suite '$suite_name' through plain SwiftPM."


### PR DESCRIPTION
## Summary
- align the direct mlx-swift manifest requirement style with mlx-audio-swift
- keep the Qwen volume probe and comparison harness updates in place
- add a maintainer follow-up note to continue investigating long-form volume decay

## Verification
- swift build
