### PR TITLE
release: remove hardcoded qwen language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,7 +285,7 @@ Current live-playback behavior:
 - `generate_audio_file` follows that same backend-routing path, then saves the completed WAV under the generated-file store instead of scheduling playback.
 - Marvis resident warmup keeps both `conversational_a` and `conversational_b` loaded at once because the model is small enough that preset switching does not need another preload cycle.
 - Profile `vibe` currently drives Marvis routing like this: `.femme` -> `conversational_a`, `.androgenous` -> `conversational_a`, `.masc` -> `conversational_b`.
-- Resident generation currently streams chunks at the `0.18` cadence.
+- Resident Qwen3 generation now uses the model's own language auto-detection and streams chunks at the `0.32` cadence. Marvis keeps its own tuned `0.10` / `0.18` live-playback profiles, and the ordinary non-Qwen resident baseline stays `0.18`.
 - Playback uses adaptive duration-based startup and low-water thresholds rather than a fixed one-chunk gate.
 
 Current generated-file behavior:
@@ -585,7 +585,7 @@ swift build
 swift test
 ```
 
-The current `mlx-audio-swift` `69.2.0` fork pin restores the ordinary SwiftPM
+The current `mlx-audio-swift` `0.7.0` fork pin restores the ordinary SwiftPM
 lane for this repository, including the worker-backed `QuickE2ETests` path.
 Treat plain `swift build` and `swift test` as the default verification story
 again.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "45b1192a75535e522b815a08dcce27584621c12e8c3b55fc0441236b57595aa3",
+  "originHash" : "99e00111bf538cf83bd8b07d052f14a2a374e8eeadeba58583915446ea93c328",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "810ad9e60650d8d9617aa61060f461dfcfe43839",
-        "version" : "0.18.2"
+        "revision" : "78f935b6da04f923854fd5bc14394deb10c132c4",
+        "version" : "0.18.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/gaelic-ghost/TextForSpeech.git",
-            .upToNextMajor(from: "0.18.2"),
+            .upToNextMajor(from: "0.18.3"),
         ),
         .package(
             url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ try configuration.save(to: URL(fileURLWithPath: "/tmp/speakswiftly-configuration
 let runtime = await SpeakSwiftly.liftoff(configuration: configuration)
 ```
 
-For Qwen generation, `qwenConditioningStrategy` controls whether the runtime keeps using raw `refAudio` and `refText` on each request or persists reusable prepared conditioning on the voice profile. The default configuration now uses `.preparedConditioning`, and legacy serialized `qwen3_custom_voice` backend values are normalized onto `qwen3` during load.
+For Qwen generation, `qwenConditioningStrategy` controls whether the runtime keeps using raw `refAudio` and `refText` on each request or persists reusable prepared conditioning on the voice profile. The default configuration now uses `.preparedConditioning`, legacy serialized `qwen3_custom_voice` backend values are normalized onto `qwen3` during load, and resident Qwen generation now leaves language selection to the upstream model's auto-detection instead of hardcoding a spoken language override.
 
 `chatterbox_turbo` uses the resident 8-bit Chatterbox Turbo model, is currently English-only, and reuses the stored profile reference audio when one is available. When no profile-specific clone audio is needed, the resident model falls back to Chatterbox Turbo's built-in default conditioning. For live playback, SpeakSwiftly now segments normalized text into speakable chunks up front and synthesizes those chunks sequentially, so Chatterbox can start feeding completed audio into playback without waiting for one full-request waveform.
 

--- a/Sources/SpeakSwiftly/Generation/FileGenerationOperations+ResidentInputs.swift
+++ b/Sources/SpeakSwiftly/Generation/FileGenerationOperations+ResidentInputs.swift
@@ -209,7 +209,7 @@ extension SpeakSwiftly.Runtime {
         let preparedConditioning = try model.prepareQwenReferenceConditioning(
             refAudio: refAudio,
             refText: materialization.manifest.referenceText,
-            language: "English",
+            language: nil,
         )
         await logRequestEvent(
             "qwen_reference_conditioning_prepared",

--- a/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
+++ b/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
@@ -65,7 +65,10 @@ extension SpeakSwiftly.Runtime {
             text: normalizedText,
             inputs: residentInputs,
             generationParameters: GenerationPolicy.residentParameters(for: normalizedText),
-            streamingInterval: PlaybackConfiguration.residentStreamingInterval,
+            streamingInterval: PlaybackConfiguration.residentStreamingInterval(
+                for: speechBackend,
+                cadenceProfile: .standard,
+            ),
         )
         var audio = [Float]()
         for try await chunk in stream {

--- a/Sources/SpeakSwiftly/Generation/SpeechGeneration+Qwen.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechGeneration+Qwen.swift
@@ -31,7 +31,7 @@ extension SpeakSwiftly.Runtime {
             voice: nil,
             refAudio: refAudio,
             refText: materialization.manifest.referenceText,
-            language: "English",
+            language: nil,
             generationParameters: generationParameters,
             streamingInterval: streamingInterval,
         )

--- a/Sources/SpeakSwiftly/Generation/VoiceProfileOperations+Reroll.swift
+++ b/Sources/SpeakSwiftly/Generation/VoiceProfileOperations+Reroll.swift
@@ -30,7 +30,7 @@ extension SpeakSwiftly.Runtime {
             voice: storedProfile.manifest.voiceDescription,
             refAudio: nil,
             refText: nil,
-            language: "English",
+            language: nil,
             generationParameters: GenerationPolicy.profileParameters(for: storedProfile.manifest.sourceText),
         )
         await logRequestEvent(

--- a/Sources/SpeakSwiftly/Generation/VoiceProfileOperations.swift
+++ b/Sources/SpeakSwiftly/Generation/VoiceProfileOperations.swift
@@ -50,7 +50,7 @@ extension SpeakSwiftly.Runtime {
             voice: voiceDescription,
             refAudio: nil,
             refText: nil,
-            language: "English",
+            language: nil,
             generationParameters: GenerationPolicy.profileParameters(for: text),
         )
         await logRequestEvent(

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
@@ -28,7 +28,8 @@ public extension SpeakSwiftly {
 
             /// Shorter chunk cadence gives playback a second chunk in reserve before
             /// the first one drains, which reduces audible shudder from one-chunk starts.
-            static let residentStreamingInterval = 0.18
+            static let standardResidentStreamingInterval = 0.18
+            static let qwenResidentStreamingInterval = 0.32
 
             /// The first drained live Marvis request is the only path that has to
             /// bootstrap audible reserve from nothing. Give it a tighter resident
@@ -61,11 +62,25 @@ public extension SpeakSwiftly {
             }
 
             static func residentStreamingInterval(
+                for speechBackend: SpeakSwiftly.SpeechBackend,
+                cadenceProfile: ResidentStreamingCadenceProfile,
+            ) -> Double {
+                switch cadenceProfile {
+                    case .standard:
+                        speechBackend == .qwen3 ? qwenResidentStreamingInterval : standardResidentStreamingInterval
+                    case .firstDrainedLiveMarvis:
+                        firstDrainedLiveMarvisStreamingInterval
+                    case .overlapSecondLaneDuringFirstDrain:
+                        overlapSecondLaneDuringFirstDrainStreamingInterval
+                }
+            }
+
+            static func residentStreamingInterval(
                 for cadenceProfile: ResidentStreamingCadenceProfile,
             ) -> Double {
                 switch cadenceProfile {
                     case .standard:
-                        residentStreamingInterval
+                        standardResidentStreamingInterval
                     case .firstDrainedLiveMarvis:
                         firstDrainedLiveMarvisStreamingInterval
                     case .overlapSecondLaneDuringFirstDrain:

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
@@ -223,7 +223,8 @@ extension SpeakSwiftly.Runtime {
             existingPlaybackJobCount: existingPlaybackJobCount,
         )
         let residentStreamingInterval = PlaybackConfiguration.residentStreamingInterval(
-            for: residentStreamingCadenceProfile,
+            for: speechBackend,
+            cadenceProfile: residentStreamingCadenceProfile,
         )
         return LiveSpeechRequestState(
             request: request,

--- a/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
+++ b/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
@@ -556,7 +556,7 @@ struct SpeakSwiftlyTestingMain {
                 voice: nil,
                 refAudio: refAudio,
                 refText: materialization.referenceText,
-                language: "English",
+                language: nil,
                 generationParameters: generationParameters,
             )
             .asArray(Float.self)

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -275,8 +275,17 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
 }
 
 @Test func `marvis live cadence roles keep the first request faster without slowing the follower by default`() {
-    let standardInterval = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingInterval(
-        for: .standard,
+    let qwenStandardInterval = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingInterval(
+        for: .qwen3,
+        cadenceProfile: .standard,
+    )
+    let marvisStandardInterval = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingInterval(
+        for: .marvis,
+        cadenceProfile: .standard,
+    )
+    let chatterboxStandardInterval = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingInterval(
+        for: .chatterboxTurbo,
+        cadenceProfile: .standard,
     )
     let firstRequestInterval = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingInterval(
         for: .firstDrainedLiveMarvis,
@@ -285,11 +294,13 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
         for: .overlapSecondLaneDuringFirstDrain,
     )
 
-    #expect(standardInterval == 0.18)
+    #expect(qwenStandardInterval == 0.32)
+    #expect(marvisStandardInterval == 0.18)
+    #expect(chatterboxStandardInterval == 0.18)
     #expect(firstRequestInterval == 0.10)
     #expect(overlapSecondLaneInterval == 0.18)
-    #expect(firstRequestInterval < standardInterval)
-    #expect(overlapSecondLaneInterval == standardInterval)
+    #expect(firstRequestInterval < marvisStandardInterval)
+    #expect(overlapSecondLaneInterval == marvisStandardInterval)
 }
 
 @Test func `marvis live cadence role selection distinguishes first request from overlap follower`() {
@@ -764,7 +775,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
             }
 
             return details["chunk_count"] as? Int == 3
-                && details["streaming_interval"] as? Double == 0.18
+                && details["streaming_interval"] as? Double == 0.32
                 && (details["startup_buffer_target_ms"] as? Int ?? 0) >= 360
                 && (details["low_water_target_ms"] as? Int ?? 0) >= 140
                 && (details["chunk_gap_warning_threshold_ms"] as? Int ?? 0) >= 450

--- a/docs/releases/v3-2-2-release-notes.md
+++ b/docs/releases/v3-2-2-release-notes.md
@@ -1,0 +1,40 @@
+# v3.2.2 Release Notes
+
+## What changed
+
+- removed SpeakSwiftly's hardcoded Qwen `"English"` generation override and now
+  let the upstream Qwen3 model auto-detect language during resident generation
+- applied that same Qwen auto-detection path to prepared conditioning, profile
+  design generation, reroll generation, and the direct testing probe path
+- raised the standard Qwen resident streaming cadence to `0.32` for live and
+  generated-file output while keeping Marvis-specific tuned cadences unchanged
+- bumped `TextForSpeech` from `0.18.2` to `0.18.3`
+- kept the `mlx-audio-swift` fork pin on its current latest release, `0.7.0`
+- documented the new Qwen behavior in README and CONTRIBUTING
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- this is a patch release focused on backend behavior alignment and validation
+- if you relied on SpeakSwiftly always forcing Qwen resident generation to
+  English, that language override is now gone and the upstream model decides
+  language from its own auto-detection path
+- the `mlx-audio-swift` dependency remains intentionally pinned to the same
+  exact fork release as before
+
+## Verification performed
+
+```bash
+swift build
+```
+
+```bash
+swift test
+```
+
+```bash
+sh scripts/repo-maintenance/run-e2e-full.sh
+```

--- a/docs/releases/v3-2-2-release-prep.md
+++ b/docs/releases/v3-2-2-release-prep.md
@@ -1,0 +1,64 @@
+# v3.2.2 Release Prep
+
+Date: 2026-04-21
+
+This note captures the intended scope and validation story for the `v3.2.2`
+patch release.
+
+## Intended Scope
+
+The release should be framed as:
+
+- a Qwen3 backend-behavior alignment pass
+- a dependency refresh for the current `TextForSpeech` release
+- a small resident-generation tuning update for Qwen live and file output
+
+Included work on the current branch:
+
+- remove the hardcoded Qwen `"English"` generation override and rely on the
+  upstream model's language auto-detection instead
+- apply the same no-hardcoded-language rule to prepared conditioning, profile
+  design generation, reroll generation, and the direct Qwen testing probe path
+- raise the standard Qwen resident streaming cadence to `0.32` while leaving
+  Marvis-specific tuned cadences unchanged
+- bump the `TextForSpeech` package dependency from `0.18.2` to `0.18.3`
+- keep the `mlx-audio-swift` fork pin on the current latest release, `0.7.0`
+- document the new Qwen behavior in README and CONTRIBUTING
+
+Not included:
+
+- a new public API surface
+- a change to the current Chatterbox or Marvis backend semantics
+- a move away from the exact `mlx-audio-swift` fork pin
+
+## SemVer Framing
+
+- this should ship as a patch release
+- the change adjusts backend defaults and dependency pins, but it does not add
+  a new consumer-facing API or break the existing public contract
+
+## Validation Performed
+
+Shared package validation:
+
+```bash
+swift build
+swift test
+```
+
+Full release-safe real-model e2e lane:
+
+```bash
+sh scripts/repo-maintenance/run-e2e-full.sh
+```
+
+## Release Checklist
+
+- keep the notes focused on Qwen3 behavior alignment and validation, not as a
+  broader architecture release
+- call out that Qwen now leans on upstream language auto-detection instead of
+  a SpeakSwiftly-owned hardcoded override
+- mention that `TextForSpeech` moved to `0.18.3` and that the
+  `mlx-audio-swift` fork pin remains `0.7.0`
+- mention that the full release-safe e2e lane passed across Quick,
+  GeneratedFile, GeneratedBatch, Chatterbox, Marvis, and Qwen


### PR DESCRIPTION
## Summary
- remove SpeakSwiftly's hardcoded Qwen language override and rely on upstream auto-detection
- raise standard Qwen resident cadence to 0.32 without changing the Marvis-specific tuned profiles
- bump TextForSpeech to 0.18.3 and add v3.2.2 release docs

## Verification
- swift build
- swift test
- sh scripts/repo-maintenance/run-e2e-full.sh
- sh scripts/repo-maintenance/release.sh --version v3.2.2