### PR TITLE
release: align qwen token defaults for v3.2.3

### DIFF
--- a/Sources/SpeakSwiftly/Generation/ModelClients.swift
+++ b/Sources/SpeakSwiftly/Generation/ModelClients.swift
@@ -5,6 +5,7 @@ import MLXAudioTTS
 @preconcurrency import MLXLMCommon
 
 enum GenerationPolicy {
+    private static let qwenDefaultMaxTokens = 4096
     private static let residentTemperature: Float = 0.9
     private static let residentTopP: Float = 1.0
     private static let residentRepetitionPenalty: Float = 1.05
@@ -17,7 +18,7 @@ enum GenerationPolicy {
 
     static func residentParameters(for text: String) -> GenerateParameters {
         GenerateParameters(
-            maxTokens: residentMaxTokens(for: text),
+            maxTokens: qwenDefaultMaxTokens,
             temperature: residentTemperature,
             topP: residentTopP,
             repetitionPenalty: residentRepetitionPenalty,
@@ -26,7 +27,7 @@ enum GenerationPolicy {
 
     static func profileParameters(for text: String) -> GenerateParameters {
         GenerateParameters(
-            maxTokens: profileMaxTokens(for: text),
+            maxTokens: qwenDefaultMaxTokens,
             temperature: profileTemperature,
             topP: profileTopP,
             repetitionPenalty: profileRepetitionPenalty,
@@ -44,16 +45,6 @@ enum GenerationPolicy {
             chunkDuration: cloneTranscriptionChunkDuration,
             minChunkDuration: cloneTranscriptionMinimumChunkDuration,
         )
-    }
-
-    private static func residentMaxTokens(for text: String) -> Int {
-        let wordCount = max(SpeakSwiftly.DeepTrace.words(in: text).count, 1)
-        return min(2048, max(56, wordCount * 8))
-    }
-
-    private static func profileMaxTokens(for text: String) -> Int {
-        let wordCount = max(SpeakSwiftly.DeepTrace.words(in: text).count, 1)
-        return min(3072, max(96, wordCount * 10))
     }
 }
 

--- a/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
+++ b/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
@@ -531,8 +531,6 @@ struct SpeakSwiftlyTestingMain {
         }
 
         var generationParameters = qwenModel.defaultGenerationParameters
-        let wordCount = max(text.split(whereSeparator: \.isWhitespace).count, 1)
-        generationParameters.maxTokens = min(2048, max(56, wordCount * 8))
         generationParameters.temperature = 0.9
         generationParameters.topP = 1.0
         generationParameters.repetitionPenalty = 1.05

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeRequestObservationTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeRequestObservationTests.swift
@@ -370,7 +370,7 @@ import TextForSpeech
     })
 
     #expect(recorder.lastText == "Hello there, gale wumbo.")
-    #expect(recorder.lastGenerationParameters?.maxTokens == 56)
+    #expect(recorder.lastGenerationParameters?.maxTokens == 4096)
     #expect(recorder.lastGenerationParameters?.temperature == 0.9)
     #expect(recorder.lastGenerationParameters?.topP == 1.0)
     #expect(recorder.lastGenerationParameters?.repetitionPenalty == 1.05)

--- a/docs/releases/v3-2-3-release-notes.md
+++ b/docs/releases/v3-2-3-release-notes.md
@@ -1,0 +1,60 @@
+# v3.2.3 Release Notes
+
+## What changed
+
+- aligned SpeakSwiftly's Qwen generation token budget with the upstream
+  `mlx-audio-swift` default by using `4096` max tokens for resident generation
+  and profile generation instead of SpeakSwiftly's local word-count-derived cap
+- applied that same upstream-default token budget to the direct Qwen testing
+  probe path in `SpeakSwiftlyTesting`
+- updated the resident generation-parameter unit coverage to assert the new
+  upstream-aligned Qwen token budget
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- this is a patch release focused on Qwen backend behavior alignment
+- long-form Qwen generations now inherit the upstream token budget instead of
+  SpeakSwiftly's shorter local heuristic cap
+
+## Verification performed
+
+```bash
+swift test
+```
+
+```bash
+xcodebuild build-for-testing -quiet \
+  -scheme SpeakSwiftly-Package \
+  -destination 'platform=macOS' \
+  -derivedDataPath .local/derived-data/validation \
+  -clonedSourcePackagesDirPath .local/source-packages
+```
+
+```bash
+xcodebuild test-without-building -quiet \
+  -xctestrun "$(find .local/derived-data/validation/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/WorkerRuntimePlaybackTests'
+```
+
+```bash
+xcodebuild test-without-building -quiet \
+  -xctestrun "$(find .local/derived-data/validation/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests'
+```
+
+```bash
+xcodebuild test-without-building -quiet \
+  -xctestrun "$(find .local/derived-data/validation/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/ModelClientsTests'
+```
+
+```bash
+sh scripts/repo-maintenance/run-e2e.sh --suite qwen
+```

--- a/docs/releases/v3-2-3-release-prep.md
+++ b/docs/releases/v3-2-3-release-prep.md
@@ -1,0 +1,89 @@
+# v3.2.3 Release Prep
+
+Date: 2026-04-21
+
+This note captures the intended scope and validation story for the `v3.2.3`
+patch release.
+
+## Intended Scope
+
+The release should be framed as:
+
+- a Qwen3 token-budget alignment pass
+- a small backend-default correction so SpeakSwiftly matches the current
+  upstream `mlx-audio-swift` behavior more closely
+
+Included work on the current branch:
+
+- remove SpeakSwiftly's local word-count-derived Qwen max-token cap for
+  resident generation
+- remove SpeakSwiftly's local word-count-derived Qwen max-token cap for profile
+  generation
+- keep the direct Qwen testing probe path on the same upstream-default
+  generation token budget
+- update the resident-generation parameter test to assert the upstream-aligned
+  token budget
+
+Not included:
+
+- a new public API surface
+- a change to current Chatterbox or Marvis backend semantics
+- a dependency bump or MLX bundle refresh
+
+## SemVer Framing
+
+- this should ship as a patch release
+- the change corrects a backend default but does not add or break a public API
+
+## Validation Performed
+
+Shared package validation:
+
+```bash
+swift test
+```
+
+Documented Xcode-backed macOS package validation:
+
+```bash
+xcodebuild build-for-testing -quiet \
+  -scheme SpeakSwiftly-Package \
+  -destination 'platform=macOS' \
+  -derivedDataPath .local/derived-data/validation \
+  -clonedSourcePackagesDirPath .local/source-packages
+```
+
+```bash
+xcodebuild test-without-building -quiet \
+  -xctestrun "$(find .local/derived-data/validation/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/WorkerRuntimePlaybackTests'
+```
+
+```bash
+xcodebuild test-without-building -quiet \
+  -xctestrun "$(find .local/derived-data/validation/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests'
+```
+
+```bash
+xcodebuild test-without-building -quiet \
+  -xctestrun "$(find .local/derived-data/validation/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" \
+  -destination 'platform=macOS' \
+  -only-testing:'SpeakSwiftlyTests/ModelClientsTests'
+```
+
+Qwen real-model e2e coverage:
+
+```bash
+sh scripts/repo-maintenance/run-e2e.sh --suite qwen
+```
+
+## Release Checklist
+
+- keep the notes focused on Qwen token-budget alignment, not as a broader
+  architecture release
+- call out that SpeakSwiftly now matches the upstream Qwen default max-token
+  budget instead of using its own shorter local heuristic
+- mention that the Qwen e2e lane passed after the alignment change


### PR DESCRIPTION
## Summary
- align SpeakSwiftly Qwen generation token limits with the upstream mlx-audio-swift default
- keep the direct Qwen testing probe path on the same default token budget
- add v3.2.3 release prep and release notes, then tag and publish the patch release

## Verification
- swift test
- xcodebuild build-for-testing -quiet -scheme SpeakSwiftly-Package -destination 'platform=macOS' -derivedDataPath .local/derived-data/validation -clonedSourcePackagesDirPath .local/source-packages
- xcodebuild test-without-building -quiet -xctestrun "$(find .local/derived-data/validation/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/WorkerRuntimePlaybackTests'
- xcodebuild test-without-building -quiet -xctestrun "$(find .local/derived-data/validation/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests'
- xcodebuild test-without-building -quiet -xctestrun "$(find .local/derived-data/validation/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" -destination 'platform=macOS' -only-testing:'SpeakSwiftlyTests/ModelClientsTests'
- sh scripts/repo-maintenance/run-e2e.sh --suite qwen