### PR TITLE
Align chatterbox and marvis generation policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,9 +283,9 @@ Current live-playback behavior:
 - The built-in text style is a separate persisted runtime setting from the active custom text profile. JSONL callers can inspect it with `get_active_text_profile_style`, inspect the available choices with `list_text_profile_styles`, and update it with `set_active_text_profile_style`.
 - Live playback stays a single-speaker path on one worker. When one audible live request is already playing, later live requests can still be accepted and queued immediately, but their generation waits until the active live playback drains before the next live request starts.
 - `generate_audio_file` follows that same backend-routing path, then saves the completed WAV under the generated-file store instead of scheduling playback.
-- Marvis resident warmup keeps both `conversational_a` and `conversational_b` loaded at once because the model is small enough that preset switching does not need another preload cycle.
-- Profile `vibe` currently drives Marvis routing like this: `.femme` -> `conversational_a`, `.androgenous` -> `conversational_a`, `.masc` -> `conversational_b`.
-- Resident Qwen3 generation now uses the model's own language auto-detection and streams chunks at the `0.32` cadence. Marvis keeps its own tuned `0.10` / `0.18` live-playback profiles, and the ordinary non-Qwen resident baseline stays `0.18`.
+- Marvis defaults to `dual_resident_serialized`, which keeps both `conversational_a` and `conversational_b` resident while still allowing only one active Marvis generation at a time. Configuration can also switch to `single_resident_dynamic` if one reusable resident model is preferred over two always-warm voices.
+- Profile `vibe` currently drives Marvis routing like this: `.femme` -> `conversational_a`, `.masc` -> `conversational_b`.
+- Resident Qwen3 generation now uses the model's own language auto-detection and streams chunks at the `0.32` cadence. Marvis now requests the upstream-aligned `0.5` streaming cadence, Chatterbox live synthesis also uses `0.5`, and the ordinary non-Qwen resident baseline stays `0.5`.
 - Playback uses adaptive duration-based startup and low-water thresholds rather than a fixed one-chunk gate.
 
 Current generated-file behavior:
@@ -436,95 +436,24 @@ The first staged playback refactor sequence has now landed:
 
 The active roadmap milestones for this work are:
 
-- `Milestone 22`: first-request Marvis playback tuning
+- `Milestone 22`: Marvis MLX generation-path investigation and playback tuning
 
 The current Milestone 22 operating decisions are:
 
-1. Smoother first audible Marvis playback is more important than squeezing the first audible reply to the absolute earliest possible moment. An extra 1 to 2 seconds of initial wait is an acceptable trade if it materially reduces early rebuffers.
-2. The queued-live dual-lane Marvis overlap model should stay intact in principle, but the second lane is allowed to start a little later if that protects the first active playback from obvious instability.
-3. Tuning work should land one bounded stage at a time, with before-and-after metrics captured after each pass, so later widening into resident warmup behavior happens only if the narrower pass is not enough.
+1. Smoother audible Marvis playback is more important than squeezing first audio to the earliest possible moment.
+2. Marvis generation is now intentionally serialized in `SpeakSwiftly`.
+3. All live Marvis playback now uses one conservative startup profile tuned to current MLX throughput.
+4. The next Marvis work should bias toward upstream investigation, throughput diagnosis, and simpler policy verification instead of rebuilding local queue choreography.
 
-The first bounded Milestone 22 pass landed on `2026-04-15` as a warmup-floor-only change for the first drained live Marvis request.
+The important current Milestone 22 readout is:
 
-- That pass raised the first-request warmup floors to `1440 / 640 / 1700` for compact text and `2320 / 1040 / 2700` for balanced text before ordinary adaptive playback thresholds take over.
-- The benchmark path compared `.local/e2e-runs/2026-04-15T03-14-57Z-166e3f0f-284e-45f9-ab95-618a3ea71e5a-prequeued-jobs-drain-in-order` against `.local/e2e-runs/2026-04-15T17-27-27Z-e8a7db8f-cc3e-44ee-8f35-65266fb949f4-prequeued-jobs-drain-in-order`.
-- For the first queued femme request, that moved `time_to_preroll_ready_ms` from `2320` to `3746`, raised `startup_buffered_audio_ms` from `1440` to `2400`, reduced `rebuffer_event_count` from `5` to `4`, and left `rebuffer_total_duration_ms` effectively unchanged at `24279` versus `25188`.
-
-The second bounded Milestone 22 pass also landed on `2026-04-15` as a first-rebuffer hardening change for that same first drained live Marvis request.
-
-- That follow-up pass kept the first drained live Marvis tuning profile active while adaptive playback thresholds move into recovery, and it let the first active rebuffer apply penalties immediately instead of waiting for rebuffer number two.
-- The next benchmark comparison against `.local/e2e-runs/2026-04-15T17-52-36Z-e575274b-31ec-486f-9ef7-50f080660f33-prequeued-jobs-drain-in-order` showed a narrower but real improvement: `time_to_preroll_ready_ms` rose slightly again to `3810`, `startup_buffered_audio_ms` stayed at `2400`, `rebuffer_event_count` stayed at `4`, and `rebuffer_total_duration_ms` fell to `23991`.
-- The important implementation detail is that stage two improved recovery posture rather than startup reserve. The first active rebuffer now resumes against a stronger `3403 ms` target instead of the stage-one `3282 ms` range, and later repeated-rebuffer recovery still climbs to `4980 ms` without dropping back to the standard profile.
-- The important architectural outcome is that overlap stayed intact across both stages: the second Marvis lane still waited for playback stability, then resumed cleanly instead of collapsing the system back into one-at-a-time generation.
-- The important tuning outcome is that stronger first-request preroll plus earlier rebuffer hardening is helping, but it still is not enough to make the first drained-queue playback clean.
-
-The third bounded Milestone 22 pass also landed on `2026-04-15` as a pre-rebuffer distress hardening change for that same first drained live Marvis request.
-
-- That follow-up pass taught the threshold controller to treat repeated schedule-gap warnings inside the low-queue risk band as an early recovery signal, so the first drained live Marvis request can harden before the first rebuffer pause fully forms.
-- The next benchmark comparison against `.local/e2e-runs/2026-04-15T18-02-46Z-16d980ae-1226-4db6-9095-59fdcff155f1-prequeued-jobs-drain-in-order` showed another modest but real improvement: `time_to_preroll_ready_ms` eased back down to `3760`, `startup_buffered_audio_ms` stayed at `2400`, `rebuffer_event_count` stayed at `4`, and `rebuffer_total_duration_ms` fell again to `23773`.
-- The important implementation detail is that stage three reacts earlier rather than simply recovering harder after the first pause. The first active rebuffer now begins at `queued_audio_ms = 1760` instead of the stage-two `1120`, and the longest recovery window drops back to `6678 ms` instead of the stage-two `9399 ms`.
-- The important architectural outcome is that overlap still stayed intact after the earlier distress reaction. The second Marvis lane remained parked on `waiting_for_playback_stability`, then resumed once playback reported `playback_is_stable_for_concurrency = true` at a `2320 ms` stable buffer target and `2400 ms` buffered reserve.
-- The important tuning outcome is that the policy-only path is still helping, but the first drained-queue playback still is not clean enough to call fixed. The next decision is whether one more bounded policy pass is worth it, or whether Milestone 22 should now widen into resident cadence and warmup behavior.
-
-The widened Milestone 22 investigation also checked resident preload before changing the tuning path.
-
-- The current code still eagerly prepares playback hardware during resident preload through `startResidentPreload()` and `playbackController.prepare(...)`.
-- The current evidence says that is not the leading cause of the first drained live Marvis instability. In the stage-three trace, first-request startup was dominated by slow resident chunk cadence before playback started, not by a late playback-engine bring-up once the live request existed.
-- That means the first widened pass should stay focused on resident generation cadence and concurrency admission rather than treating playback-engine preparation as the primary fix surface.
-
-The fourth Milestone 22 pass landed on `2026-04-15` as the first widened change.
-
-- That pass tightened resident Marvis cadence only for the first drained live request by lowering its resident streaming interval from `0.18` to `0.12`, while leaving later queued requests on the ordinary cadence.
-- The benchmark comparison against `.local/e2e-runs/2026-04-15T18-16-17Z-7b199036-8540-4284-9a84-92dd16e13a30-prequeued-jobs-drain-in-order` showed that startup cadence improved decisively: `time_to_first_chunk_ms` dropped from `441` to `333`, `avg_inter_chunk_gap_ms` dropped from `399` to `202`, and `avg_schedule_gap_ms` dropped from `364` to `184`.
-- The important downside is that stage four exposed a policy mismatch instead of finishing the tuning job. `time_to_preroll_ready_ms` drifted slightly upward to `3833`, `startup_buffered_audio_ms` settled at `2320`, `rebuffer_event_count` rose from `4` to `5`, and the second Marvis lane still reopened at bare preroll reserve.
-- The useful conclusion from stage four is that faster first-request cadence helps, but cadence alone is not enough if playback still declares itself concurrency-stable at the old reserve threshold.
-
-The fifth Milestone 22 pass also landed on `2026-04-15` as the widened follow-up change.
-
-- That pass kept the stage-four faster first-request resident cadence and tightened playback's own concurrency-admission rule for the first drained live Marvis request.
-- The playback controller now keeps the runtime-facing admission surface narrow, but internally it makes the first drained live Marvis request earn a stronger buffered-audio reserve before reporting `allowsConcurrentGeneration = true`.
-- The benchmark comparison against `.local/e2e-runs/2026-04-15T18-24-15Z-95e656cc-c4b4-4e2a-8374-4ef353ac9b2a-prequeued-jobs-drain-in-order` shows why that follow-up is worth keeping: `time_to_first_chunk_ms` improved again to `325`, `time_to_preroll_ready_ms` stayed effectively flat at `3828`, `rebuffer_event_count` stayed at `5`, `rebuffer_total_duration_ms` dropped from `22758` to `18775`, and `longest_rebuffer_duration_ms` dropped from `4801` to `4385`.
-- The important architecture result is that overlap still stayed intact while moving later in the flow. In the stage-five trace, the second Marvis lane remained parked on `waiting_for_playback_stability` at preroll, and only resumed after the first request had already recovered into a healthier reserve window.
-- The important tuning result is that the widened path is now coherent: the faster first-request cadence helps startup, and the stronger first-request admission gate keeps those gains from getting spent immediately when overlap resumes.
-
-The sixth Milestone 22 pass also landed on `2026-04-15` as the review-and-correctness follow-up.
-
-- That pass fixed a real overlap-gate inconsistency discovered during the widened review. In the stage-five trace, a later `playback_rebuffer_resumed` event could still leave playback advertising `playback_is_stable_for_concurrency = true` while `playback_stable_buffered_audio_ms` was below `playback_stable_buffer_target_ms`.
-- The fix did not widen the public scheduler surface again. It kept the same narrow admission boundary, but it made `PlaybackController` reuse one buffered-audio-versus-target check for preroll, rebuffer resume, and later buffer-scheduled promotions.
-- The benchmark comparison against `.local/e2e-runs/2026-04-15T18-32-16Z-69de7141-3485-4788-8ea5-b30a49e87cbc-prequeued-jobs-drain-in-order` shows the right tradeoff for this stage: this was primarily a correctness repair rather than another tuning win. For the first queued femme request, `time_to_first_chunk_ms` stayed effectively flat at `324`, `time_to_preroll_ready_ms` stayed effectively flat at `3833`, `rebuffer_event_count` stayed at `5`, and `rebuffer_total_duration_ms` rose back to `20055`.
-- The important architecture result is that the overlap gate now tells the truth. The old bogus stage-five state where overlap reopened at `2160 ms` buffered against a `2700 ms` target disappeared from the fresh trace, and the second Marvis lane only resumed once the resumed reserve had actually crossed the reported target again.
-
-The seventh Milestone 22 pass also landed on `2026-04-15` as the next bounded cadence follow-up.
-
-- That pass kept the truthful overlap gate from stage six and tightened only the first drained live Marvis resident streaming cadence again, from `0.12` to `0.10`.
-- The benchmark comparison against `.local/e2e-runs/2026-04-15T18-46-12Z-ce51be64-6dd0-4e21-a125-3d1067397266-prequeued-jobs-drain-in-order` shows why this pass is worth keeping: for the first queued femme request, `time_to_first_chunk_ms` stayed flat at `324`, `time_to_preroll_ready_ms` drifted up to `3951`, `rebuffer_event_count` fell from `5` to `4`, and `rebuffer_total_duration_ms` dropped from `20055` to `17284`.
-- The important architecture result is that the overlap gate stayed honest while the first-request result improved. In the fresh stage-seven trace, the second Marvis lane still remained parked on `waiting_for_playback_stability`, and every later overlap reopen happened with `playback_stable_buffered_audio_ms` at or above the reported `playback_stable_buffer_target_ms`.
-
-The eighth Milestone 22 pass landed on `2026-04-15` as a probing and observability pass rather than another tuning pass.
-
-- That pass added transition-level resource snapshots to the existing Marvis scheduler and playback rebuffer traces. `marvis_generation_scheduler_snapshot`, `marvis_generation_lane_reserved`, `marvis_generation_lane_released`, `playback_rebuffer_started`, and `playback_rebuffer_resumed` now all carry the same process and MLX memory details that were previously only captured in the final `playback_finished` summary.
-- The fresh artifact is `.local/e2e-runs/2026-04-15T19-08-53Z-f0de238e-3cf0-477a-ade2-c476ff05b134-prequeued-jobs-drain-in-order`.
-- The first queued femme request in that run did not beat the stage-seven audible result, which is expected because this pass was instrumentation-only. Its stderr `playback_finished` metrics came in at `time_to_first_chunk_ms = 340`, `time_to_preroll_ready_ms = 3926`, `startup_buffered_audio_ms = 2320`, `rebuffer_event_count = 5`, and `rebuffer_total_duration_ms = 20089`.
-- The important new finding is where the resource rise actually appears. At the first truthful overlap reopen, `playback_rebuffer_resumed` reported `buffered_audio_ms = 2720`, `resume_buffer_target_ms = 2700`, `mlx_active_memory_bytes = 2388309837`, and `process_phys_footprint_bytes = 2734345216`. The immediately following `marvis_generation_lane_reserved` event for the second lane stayed effectively flat at `mlx_active_memory_bytes = 2388309873` and `process_phys_footprint_bytes = 2734377984`.
-- The larger rise showed up only after overlap had already been active for a while. By the next `playback_rebuffer_started` event, the same first request had climbed to `mlx_active_memory_bytes = 2528397332` and `process_phys_footprint_bytes = 2885979136` while still falling back into refill trouble.
-- That evidence shifts the working hypothesis. The current failure mode looks less like a sharp one-time startup spike when the second Marvis lane is reserved, and more like sustained dual-lane overlap pressure while the first playback is trying to rebuild reserve.
-
-The eleventh Milestone 22 pass landed on `2026-04-15` as the first explicit overlap-follower cadence experiment.
-
-- That pass introduced a separate `ResidentStreamingCadenceProfile` for the second Marvis lane during the first drained overlap window, so future cadence work can tune that follower path independently from the first-request playback profile.
-- The experiment artifact is `.local/e2e-runs/2026-04-15T21-52-43Z-236ce29a-5d5c-470f-a51e-f38dfbc3361d-prequeued-jobs-drain-in-order`.
-- The first follower experiment itself is not a tuning win. Slowing the overlap follower to `0.20` kept overlap alive, but the first queued femme request regressed from the stage-eight probe result: `time_to_first_chunk_ms` moved from `340` to `349`, `time_to_preroll_ready_ms` moved from `3926` to `3844`, `rebuffer_event_count` rose from `5` to `6`, and `rebuffer_total_duration_ms` rose from `20089` to `20769`.
-- The useful outcome is the new control seam, not the slowed follower interval. The repository now keeps the follower cadence role explicit, but the follower interval itself stays on the ordinary `0.18` baseline until a better overlap-pressure experiment earns a real tuning change.
-- A cleaner rerun of that same follower experiment landed at `.local/e2e-runs/2026-04-15T22-10-00Z-7ccd26f6-62b6-4117-a4c5-3027d81ebacf-prequeued-jobs-drain-in-order` after background machine load was reduced. That rerun kept overlap alive and improved modestly over the stage-eight probe instead of regressing: `time_to_first_chunk_ms` stayed at `340`, `time_to_preroll_ready_ms` improved to `3833`, `rebuffer_event_count` stayed at `5`, and `rebuffer_total_duration_ms` fell to `19115`.
-- Even with the cleaner rerun, the first audible request was still subjectively too rough to justify fixed follower slowdown as the main policy. The working read is now that the unstable part on Gale's machine is the transition into simultaneous overlap itself, not just the follower's steady-state cadence after overlap opens.
-- The next useful design should therefore stay dynamic rather than fixed. Keep the truthful overlap gate and the explicit follower-cadence role, but add a short-lived `fragile first playback` window for the first drained live Marvis request so the second lane stays parked or lighter until reserve has crossed and briefly held a healthier target, then backs off again if reserve starts collapsing.
-
-The twelfth Milestone 22 pass landed on `2026-04-16` as that first explicit fragile-overlap policy pass.
-
-- That pass kept the scheduler contract narrow and implemented the new behavior inside `PlaybackController` as a short-lived fragile overlap window for the first drained live Marvis request.
-- The first request now has to earn two healthy `buffer_scheduled` updates above a stronger hold target before playback reports `allowsConcurrentGeneration = true`, and that same guard re-engages if buffered reserve later drops back below the healthier hold target.
-- The important architecture result is that overlap control still stays playback-owned and truth-based. The runtime scheduler still sees one yes-or-no admission surface, but the first drained request can now back off from overlap pressure before a full rebuffer pause forms instead of only after crossing the ordinary reserve target once.
-- The focused regression coverage for this pass lives in `Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift`, including the new pure admission-resolution checks for the fragile overlap window.
+- the old overlap-heavy Marvis policy is gone
+- the default resident policy is now `dual_resident_serialized`, with `single_resident_dynamic` available as the simpler alternate resident strategy
+- the repo now has a dedicated Marvis resident-policy benchmark for the same `femme -> masc -> femme` three-request switch pattern
+- the current cadence now matches the upstream `0.5` Marvis streaming path
+- audible Marvis still rebuffers even under serialized generation
+- the remaining issue now looks more like raw Marvis-on-MLX throughput than local overlap policy
+- the next meaningful investigation is comparing the `mlx-audio-swift` Marvis generation path against Marvis's own reference implementation surface instead of adding more local queue complexity
 
 ## Repository Layout
 
@@ -684,7 +613,7 @@ against this exact test identifier. On current Xcode manifests, that override
 lives under `TestConfigurations -> TestTargets -> EnvironmentVariables`.
 
 ```text
-SpeakSwiftlyTests/MarvisE2ETests/`prequeued jobs drain in order`()
+SpeakSwiftlyTests/MarvisE2ETests/`queued audible playback stays serialized and routes expected voices`()
 ```
 
 The same fallback principle applies to release hardening and narrow package
@@ -751,6 +680,20 @@ The backend-wide suite runs the same two-request live benchmark scenario across
 `qwen3`, `chatterbox_turbo`, and `marvis`. The second request is expected to
 queue behind the first one; if it does not, the suite now fails so the queued
 benchmark contract cannot silently drift into a non-queued workload.
+
+The same suite also carries a Marvis-specific resident-policy benchmark that
+compares `dual_resident_serialized` against `single_resident_dynamic` with a
+three-request back-and-forth voice order: `femme`, `masc`, then `femme` again.
+
+```bash
+SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1 SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS=1 swift test --filter 'BackendBenchmarkE2ETests/compare marvis resident policies with three queued voice switches'
+```
+
+That benchmark writes its own retained summaries under `.local/benchmarks` and
+refreshes one of these latest files:
+
+- `.local/benchmarks/marvis-resident-policy-benchmark-latest.json`
+- `.local/benchmarks/marvis-resident-policy-audible-benchmark-latest.json`
 
 Section-aware weird-text deep-trace probes:
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "78f935b6da04f923854fd5bc14394deb10c132c4",
-        "version" : "0.18.3"
+        "revision" : "b9640e2dd11054764aecd6117f98ad83db17d914",
+        "version" : "0.18.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/gaelic-ghost/TextForSpeech.git",
-            .upToNextMajor(from: "0.18.3"),
+            .upToNextMajor(from: "0.18.5"),
         ),
         .package(
             url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ This roadmap now keeps active milestones and the current release-hardening queue
 - [ ] Milestone 18: Package docs and distribution polish
 - [ ] Milestone 20: Per-request event stream observability
 - [ ] Milestone 21: Unified Logging with `Logger`
-- [ ] Milestone 22: First-request Marvis playback tuning
+- [ ] Milestone 22: Marvis MLX generation-path investigation and playback tuning
 - [x] Milestone 23: Playback request coordination flattening
 - [x] Milestone 24: Playback execution ownership split
 - [x] Milestone 25: Playback scheduling boundary and public state review
@@ -264,155 +264,46 @@ Exit criteria:
 - [ ] The JSONL worker contract remains stdout-only and easy to reason about, with logging clearly separated from protocol traffic.
 - [ ] Operator-facing log messages remain specific, readable, and useful in Console as well as local debugging flows.
 
-## Milestone 22: First-Request Marvis Playback Tuning
+## Milestone 22: Marvis MLX Generation-Path Investigation And Playback Tuning
 
 Scope:
 
-- [ ] Improve the first live Marvis playback in a drained queue without collapsing the restored dual-lane generation scheduler back into blanket serialization.
-- [ ] Keep playback tuning and scheduler correctness clearly separated so later regressions are easier to diagnose.
-- [ ] Use the runtime's explicit playback and scheduler observability as the source of truth for each tuning pass.
+- [ ] Keep Marvis behavior simple enough that the runtime policy is easy to reason about and the remaining instability is attributable.
+- [ ] Document whether the remaining Marvis rebuffers are mainly a local playback-policy issue or a throughput limitation in the current `mlx-audio-swift` generation path.
+- [ ] Use the runtime's explicit playback and scheduler observability as the source of truth for each tuning or investigation pass.
 
 Tickets:
 
-- [x] Establish a repeatable tuning checklist for the first drained-queue Marvis playback using the existing queued-live Marvis E2E lane plus stderr scheduler and playback metrics.
-- [x] Compare first-request startup-buffer targets, buffered-audio reserve, and rebuffer counts across at least one before-and-after capture for each tuning change.
+- [x] Establish a repeatable Marvis profiling and measurement path using the audible Marvis E2E suite plus stderr scheduler and playback metrics.
+- [x] Simplify Marvis runtime policy to serialized generation with one conservative live-startup profile instead of overlap-specific queue choreography.
 - [x] Keep the working Milestone 22 tradeoff explicit: smoother first audible response wins even if the first audible reply waits another 1 to 2 seconds before playback begins.
-- [x] Preserve queued-live Marvis overlap in principle, but allow the second lane to start a little later if that materially reduces first-request rebuffering.
-- [x] Take Milestone 22 one stage at a time: ship one bounded tuning pass, benchmark it, record what changed, then decide whether another pass should widen into resident warmup behavior.
-- [x] Investigate whether resident preload is too eager about preparing local playback hardware, especially the `startResidentPreload()` -> `playbackController.prepare(...)` path that rebuilds playback hardware before an active live request exists.
-- [ ] Revisit warmup startup, low-water, and resume thresholds specifically for the first active Marvis playback request.
-- [x] Revisit Marvis resident streaming cadence only if buffer tuning alone cannot reduce first-request rebuffering.
-- [ ] Keep the scheduler snapshot and lane-reservation logs aligned with any playback-tuning changes so queue truth stays obvious.
-- [ ] Record subjective audible outcomes and objective stderr metrics together after each meaningful tuning pass.
+- [x] Revisit Marvis resident streaming cadence until it matches the upstream `0.5s` streaming path and can be tested without extra local cadence roles.
+- [x] Keep scheduler snapshots, queue visibility, and voice-routing logs aligned with the simplified serialized runtime so queue truth stays obvious.
+- [x] Add a Marvis resident-policy benchmark that compares `dual_resident_serialized` against `single_resident_dynamic` with the same three-request `femme -> masc -> femme` switch pattern.
+- [ ] Compare the current `mlx-audio-swift` Marvis generation path against Marvis's own reference implementation surface and document differences in chunking, sampler usage, cache behavior, streaming cadence, and throughput expectations.
+- [ ] Confirm whether `dual_resident_serialized` versus `single_resident_dynamic` changes real audible throughput enough to matter on Gale's Apple-silicon machines.
+- [ ] Record subjective audible outcomes and objective stderr metrics together after each meaningful Marvis runtime or upstream investigation pass.
 
 Stage notes:
 
-- Stage 1 landed on `2026-04-15` as a bounded first-request warmup-floor pass. The first drained live Marvis request now seeds higher warmup floors before playback begins:
-  - compact: `startup 1440`, `low-water 640`, `resume 1700`
-  - balanced: `startup 2320`, `low-water 1040`, `resume 2700`
-- Baseline artifact: `.local/e2e-runs/2026-04-15T03-14-57Z-166e3f0f-284e-45f9-ab95-618a3ea71e5a-prequeued-jobs-drain-in-order`
-- Stage 1 artifact: `.local/e2e-runs/2026-04-15T17-27-27Z-e8a7db8f-cc3e-44ee-8f35-65266fb949f4-prequeued-jobs-drain-in-order`
-- For the first queued femme request, the measured before-and-after stderr metrics changed like this:
-  - `time_to_preroll_ready_ms`: `2320` -> `3746`
-  - `startup_buffered_audio_ms`: `1440` -> `2400`
-  - `startup_buffer_target_ms` at playback start: `1381` -> `2320`
-  - `rebuffer_event_count`: `5` -> `4`
-  - `rebuffer_total_duration_ms`: `24279` -> `25188`
-- The restored dual-lane queued-live overlap model stayed intact. The second Marvis lane remained parked on `waiting_for_playback_stability` until the first request reached the stronger preroll target, then resumed and paired cleanly with the first lane.
-- Stage 1 improved the initial reserve and delayed second-lane admission as intended, but it did not make the first drained-queue playback materially steady enough yet. Milestone 22 stays open, and the next pass should bias toward earlier threshold hardening or resident cadence follow-up rather than rolling overlap back into blanket serialization.
-- Stage 2 landed on `2026-04-15` as a bounded first-rebuffer hardening pass. The first drained live Marvis request now keeps its tuning profile active in adaptive recovery and no longer waits for rebuffer number two before applying rebuffer penalties.
-- Stage 2 artifact: `.local/e2e-runs/2026-04-15T17-52-36Z-e575274b-31ec-486f-9ef7-50f080660f33-prequeued-jobs-drain-in-order`
-- For the first queued femme request, the measured stage-one to stage-two stderr metrics changed like this:
-  - `time_to_preroll_ready_ms`: `3746` -> `3810`
-  - `startup_buffered_audio_ms`: `2400` -> `2400`
-  - `rebuffer_event_count`: `4` -> `4`
-  - `rebuffer_total_duration_ms`: `25188` -> `23991`
-  - `longest_rebuffer_duration_ms`: `7041` -> `9399`
-- The stage-two logs show the intended policy change actually taking effect. On the first active rebuffer, the resumed target rose from the stage-one `3282` range into the `3403` range, and the later repeated-rebuffer recovery ceiling stayed strong at `4980` instead of falling back toward the standard profile.
-- Stage 2 is a real improvement, but still not a full fix. Total rebuffer time dropped by about `1.2s`, yet the first request still suffered four rebuffers and one longer recovery window.
-- Stage 3 landed on `2026-04-15` as a bounded pre-rebuffer distress pass. The first drained live Marvis request now treats repeated schedule-gap warnings inside the low-queue risk band as an early recovery signal instead of waiting for the first rebuffer pause to fully form.
-- Stage 3 artifact: `.local/e2e-runs/2026-04-15T18-02-46Z-16d980ae-1226-4db6-9095-59fdcff155f1-prequeued-jobs-drain-in-order`
-- For the first queued femme request, the measured stage-two to stage-three stderr metrics changed like this:
-  - `time_to_preroll_ready_ms`: `3810` -> `3760`
-  - `startup_buffered_audio_ms`: `2400` -> `2400`
-  - `rebuffer_event_count`: `4` -> `4`
-  - `rebuffer_total_duration_ms`: `23991` -> `23773`
-  - `longest_rebuffer_duration_ms`: `9399` -> `6678`
-- The stage-three logs show the intended earlier reaction taking effect before the first long pause finishes growing. The first active rebuffer now starts at `queued_audio_ms = 1760` instead of the stage-two `1120`, and the strongest recovery window is shorter even though the run still ends with four rebuffers.
-- The restored dual-lane overlap model still held during stage three. The second Marvis lane remained parked on `waiting_for_playback_stability`, then resumed once playback reported `playback_is_stable_for_concurrency = true` at a `2320 ms` stable buffer target and `2400 ms` buffered reserve.
-- Stage 3 is another real improvement, but still not a full fix. The next decision is whether one more bounded policy pass is likely to keep paying off, or whether Milestone 22 should widen into resident Marvis cadence and warmup behavior now that the obvious first-request threshold work is in place.
-- The widened Milestone 22 investigation checked the resident preload path before changing code. The current evidence says the eager `startResidentPreload()` -> `playbackController.prepare(...)` path is not the leading problem surface, because first-request startup is dominated by slow resident chunk cadence rather than by audio-engine bring-up once a live request begins.
-- Stage 4 landed on `2026-04-15` as the first widened pass. The first drained live Marvis request now uses a tighter resident streaming cadence of `0.12` instead of the standard `0.18`, while later queued requests stay on the ordinary cadence.
-- Stage 4 artifact: `.local/e2e-runs/2026-04-15T18-16-17Z-7b199036-8540-4284-9a84-92dd16e13a30-prequeued-jobs-drain-in-order`
-- For the first queued femme request, the measured stage-three to stage-four stderr metrics changed like this:
-  - `time_to_first_chunk_ms`: `441` -> `333`
-  - `time_to_preroll_ready_ms`: `3760` -> `3833`
-  - `startup_buffered_audio_ms`: `2400` -> `2320`
-  - `rebuffer_event_count`: `4` -> `5`
-  - `rebuffer_total_duration_ms`: `23773` -> `22758`
-  - `longest_rebuffer_duration_ms`: `6678` -> `4801`
-  - `avg_inter_chunk_gap_ms`: `399` -> `202`
-  - `avg_schedule_gap_ms`: `364` -> `184`
-- Stage 4 improved startup chunk cadence decisively, but it also exposed a new mismatch: the second Marvis lane still reopened at bare preroll reserve, so the first request picked up shorter but more frequent disruptions after overlap resumed. That made stage four useful, but not sufficient to keep on its own.
-- Stage 5 landed on `2026-04-15` as the widened follow-up pass. The first drained live Marvis request now keeps the faster resident cadence from stage four, and playback no longer reopens concurrent generation at plain preroll for that first drained request. Instead, the first request has to build a stronger buffered-audio reserve before the scheduler sees playback as stable enough for the second Marvis lane.
-- Stage 5 artifact: `.local/e2e-runs/2026-04-15T18-24-15Z-95e656cc-c4b4-4e2a-8374-4ef353ac9b2a-prequeued-jobs-drain-in-order`
-- For the first queued femme request, the measured stage-four to stage-five stderr metrics changed like this:
-  - `time_to_first_chunk_ms`: `333` -> `325`
-  - `time_to_preroll_ready_ms`: `3833` -> `3828`
-  - `startup_buffered_audio_ms`: `2320` -> `2320`
-  - `rebuffer_event_count`: `5` -> `5`
-  - `rebuffer_total_duration_ms`: `22758` -> `18775`
-  - `longest_rebuffer_duration_ms`: `4801` -> `4385`
-  - `avg_inter_chunk_gap_ms`: `202` -> `183`
-  - `avg_schedule_gap_ms`: `184` -> `165`
-- The important stage-five architecture outcome is that overlap stayed intact while moving later in the flow. The second Marvis lane no longer reopened at the first request's bare preroll reserve; it stayed parked on `waiting_for_playback_stability` until the first playback had already recovered into a healthier reserve window, then resumed and kept the dual-lane model alive.
-- Stage 6 landed on `2026-04-15` as the review-and-correctness follow-up pass. The widened stage-five trace exposed one real bug in the overlap gate: after a later rebuffer resume, playback could report `playback_is_stable_for_concurrency = true` even when `playback_stable_buffered_audio_ms` was still below `playback_stable_buffer_target_ms`.
-- Stage 6 artifact: `.local/e2e-runs/2026-04-15T18-32-16Z-69de7141-3485-4788-8ea5-b30a49e87cbc-prequeued-jobs-drain-in-order`
-- The fix kept the admission boundary narrow but made the overlap gate consistent: `PlaybackController` now reuses the same buffered-audio-versus-target check for preroll, rebuffer resume, and buffer-scheduled updates instead of reopening overlap unconditionally on `rebuffer_resumed`.
-- For the first queued femme request, the measured stage-five to stage-six stderr metrics changed like this:
-  - `time_to_first_chunk_ms`: `325` -> `324`
-  - `time_to_preroll_ready_ms`: `3828` -> `3833`
-  - `startup_buffered_audio_ms`: `2320` -> `2320`
-  - `rebuffer_event_count`: `5` -> `5`
-  - `rebuffer_total_duration_ms`: `18775` -> `20055`
-  - `longest_rebuffer_duration_ms`: `4385` -> `4395`
-  - `time_from_preroll_ready_to_drain_ms`: `34617` -> `37107`
-- The important stage-six outcome is correctness, not another performance win. The old bogus state where overlap reopened at `2160 ms` buffered against a `2700 ms` target disappeared from the fresh trace, and the second Marvis lane only resumed once the resumed reserve had actually crossed the reported target again.
-- Stage 7 landed on `2026-04-15` as the next bounded cadence follow-up pass. The truthful overlap gate from stage six stayed in place, and the first drained live Marvis request now asks the resident model for a slightly tighter first-request streaming cadence again.
-- Stage 7 artifact: `.local/e2e-runs/2026-04-15T18-46-12Z-ce51be64-6dd0-4e21-a125-3d1067397266-prequeued-jobs-drain-in-order`
-- For the first queued femme request, the measured stage-six to stage-seven stderr metrics changed like this:
-  - `streaming_interval`: `0.12` -> `0.10`
-  - `time_to_first_chunk_ms`: `324` -> `324`
-  - `time_to_preroll_ready_ms`: `3833` -> `3951`
-  - `startup_buffered_audio_ms`: `2320` -> `2320`
-  - `rebuffer_event_count`: `5` -> `4`
-  - `rebuffer_total_duration_ms`: `20055` -> `17284`
-  - `longest_rebuffer_duration_ms`: `4395` -> `4897`
-  - `avg_inter_chunk_gap_ms`: `183` -> `180`
-  - `avg_schedule_gap_ms`: `166` -> `162`
-- The important stage-seven outcome is that the smoother first-request result came back without reintroducing the false overlap signal from stage five. The second Marvis lane still stayed parked on `waiting_for_playback_stability`, and every overlap reopen in the fresh trace happened with `playback_stable_buffered_audio_ms` at or above the reported `playback_stable_buffer_target_ms`.
-- Milestone 22 is still open, but the current evidence now points more clearly at two facts: faster first-request cadence helps, and cadence changes need admission-gate changes alongside them or the first request gives the gains back as soon as overlap resumes.
-- Stage 8 landed on `2026-04-15` as a probing pass instead of another tuning pass. The scheduler snapshots, lane reserve and release events, and playback rebuffer start and resume events now all carry the same process and MLX memory details that were previously only available in the final `playback_finished` event.
-- Stage 8 artifact: `.local/e2e-runs/2026-04-15T19-08-53Z-f0de238e-3cf0-477a-ade2-c476ff05b134-prequeued-jobs-drain-in-order`
-- For the first queued femme request, the measured stage-seven to stage-eight stderr metrics changed like this:
-  - `time_to_first_chunk_ms`: `324` -> `340`
-  - `time_to_preroll_ready_ms`: `3951` -> `3926`
-  - `startup_buffered_audio_ms`: `2320` -> `2320`
-  - `rebuffer_event_count`: `4` -> `5`
-  - `rebuffer_total_duration_ms`: `17284` -> `20089`
-  - `longest_rebuffer_duration_ms`: `4897` -> `4469`
-- The important stage-eight finding is not the audible regression. It is the new transition evidence. At the first truthful overlap reopen, `playback_rebuffer_resumed` reported `mlx_active_memory_bytes = 2388309837` and `process_phys_footprint_bytes = 2734345216`, while the immediately following `marvis_generation_lane_reserved` event for the second lane stayed effectively flat at `mlx_active_memory_bytes = 2388309873` and `process_phys_footprint_bytes = 2734377984`.
-- The larger resource rise showed up only after dual-lane overlap had already been active. By the next `playback_rebuffer_started` event, the first request had climbed to `mlx_active_memory_bytes = 2528397332` and `process_phys_footprint_bytes = 2885979136` while still losing refill headroom.
-- That changes the working read on the problem. The current bottleneck looks less like a sharp one-time second-lane startup spike and more like sustained overlap pressure on the first request while it is trying to rebuild reserve.
-- Stage 11 landed on `2026-04-15` as the first explicit overlap-follower cadence experiment. The runtime now has a separate `ResidentStreamingCadenceProfile` role for the second lane during the first drained Marvis overlap window, so future cadence work can tune that follower path without overloading the first-request playback profile.
-- Stage 11 artifact: `.local/e2e-runs/2026-04-15T21-52-43Z-236ce29a-5d5c-470f-a51e-f38dfbc3361d-prequeued-jobs-drain-in-order`
-- The first follower experiment itself is not a keeper as tuning. With the overlap follower slowed to `0.20`, the second lane still reserved before the first playback finished, so overlap remained alive, but the first queued femme request got worse instead of better:
-  - `time_to_first_chunk_ms`: `340` -> `349`
-  - `time_to_preroll_ready_ms`: `3926` -> `3844`
-  - `startup_buffered_audio_ms`: `2320` -> `2320`
-  - `rebuffer_event_count`: `5` -> `6`
-  - `rebuffer_total_duration_ms`: `20089` -> `20769`
-  - `longest_rebuffer_duration_ms`: `4469` -> `4566`
-- The useful outcome is architectural rather than audible. The package now has an explicit follower-cadence role, but the follower interval itself is back on the ordinary `0.18` baseline until a better overlap-pressure experiment earns a real tuning change.
-- A clean rerun of the same stage-eleven follower experiment under lighter machine load landed at `.local/e2e-runs/2026-04-15T22-10-00Z-7ccd26f6-62b6-4117-a4c5-3027d81ebacf-prequeued-jobs-drain-in-order`.
-- That rerun showed the original noisy result was overstating the regression. The same `0.20` follower cadence kept overlap alive and improved modestly over the stage-eight probe:
-  - `time_to_first_chunk_ms`: `340` -> `340`
-  - `time_to_preroll_ready_ms`: `3926` -> `3833`
-  - `rebuffer_event_count`: `5` -> `5`
-  - `rebuffer_total_duration_ms`: `20089` -> `19115`
-  - `longest_rebuffer_duration_ms`: `4469` -> `4490`
-- Even with the cleaner rerun, the first audible request was still subjectively too rough to justify keeping fixed follower slowdown as the main strategy. The working read is now that simultaneous second-lane startup is the unstable part on Gale's machine, so the next pass should move away from fixed follower cadence and into a dynamic fragile-overlap policy.
-- The smallest next dynamic pass should keep the truthful overlap gate, preserve the explicit follower-cadence role, and add one short-lived `fragile first playback` state for the first drained live Marvis request:
-  - lane two stays parked or in a lighter mode until the first request has crossed a stronger reserve target and held it briefly
-  - once the first request has held reserve long enough, lane two can enter overlap
-  - if reserve drops back toward the floor, lane two backs off again instead of staying fully active
-- That gives Milestone 22 a more promising next lever than another fixed `0.19` versus `0.20` follower comparison, because it targets the unstable transition into overlap rather than applying one constant pressure level for the whole follower request.
+- Earlier Milestone 22 work explored overlap-specific thresholds, cadence tweaks, and queue-admission changes in detail.
+- The current 2026-04-22 steady state is intentionally simpler:
+  - Marvis generation is serialized
+  - the default resident policy is `dual_resident_serialized`
+  - a benchmark now exists for `dual_resident_serialized` versus `single_resident_dynamic`
+  - all live Marvis playback uses one conservative startup profile
+  - the current live cadence matches the upstream Marvis `0.5s` path
+- The current read after the latest audible runs is:
+  - local overlap complexity was not the main problem
+  - simplifying the runtime improved consistency, especially for later queued requests
+  - even after that simplification, audible Marvis still tends to rebuffer
+  - the next useful work is upstream and reference-path investigation, not rebuilding the old overlap model
 
 Exit criteria:
 
-- [ ] The first drained-queue Marvis playback is measurably steadier than the current baseline.
-- [ ] The restored dual-lane queued-live Marvis overlap model remains intact and verified.
-- [ ] The repository has a documented before-and-after record for the tuning work that makes later regressions obvious.
+- [ ] The repository documents how the current `mlx-audio-swift` Marvis path differs from Marvis's reference implementation surface and what those differences imply for local playback behavior.
+- [ ] Marvis audible playback is either measurably steadier after upstream-aware changes or explicitly documented as limited by the current MLX path.
+- [ ] The repository has a documented before-and-after record for the simplified serialized policy and the follow-on upstream investigation.
 
 ## Milestone 26: Pre-v1 Release Hardening
 

--- a/Sources/SpeakSwiftly/API/Configuration.swift
+++ b/Sources/SpeakSwiftly/API/Configuration.swift
@@ -9,6 +9,16 @@ public extension SpeakSwiftly {
         case preparedConditioning = "prepared_conditioning"
     }
 
+    /// Selects how resident Marvis model instances are kept warm.
+    enum MarvisResidentPolicy: String, Codable, Sendable, Equatable, CaseIterable {
+        /// Keep both conversational resident model objects warm, but serialize
+        /// Marvis generation so only one request uses the model path at a time.
+        case dualResidentSerialized = "dual_resident_serialized"
+        /// Keep a single Marvis resident model object warm and reuse it for
+        /// whichever conversational voice a request needs next.
+        case singleResidentDynamic = "single_resident_dynamic"
+    }
+
     // MARK: Configuration
 
     /// Startup configuration for a SpeakSwiftly runtime.
@@ -38,12 +48,15 @@ public extension SpeakSwiftly {
         enum CodingKeys: String, CodingKey {
             case speechBackend
             case qwenConditioningStrategy
+            case marvisResidentPolicy
         }
 
         /// The speech backend to activate when the runtime starts.
         public let speechBackend: SpeakSwiftly.SpeechBackend
         /// The Qwen conditioning strategy to use for Qwen-backed generation.
         public let qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy
+        /// The resident Marvis loading policy to use for Marvis-backed generation.
+        public let marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy
         /// An optional text normalizer to reuse instead of creating the default one.
         public let textNormalizer: SpeakSwiftly.Normalizer?
 
@@ -51,10 +64,12 @@ public extension SpeakSwiftly {
         public init(
             speechBackend: SpeakSwiftly.SpeechBackend = .qwen3,
             qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .preparedConditioning,
+            marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy = .dualResidentSerialized,
             textNormalizer: SpeakSwiftly.Normalizer? = nil,
         ) {
             self.speechBackend = speechBackend
             self.qwenConditioningStrategy = qwenConditioningStrategy
+            self.marvisResidentPolicy = marvisResidentPolicy
             self.textNormalizer = textNormalizer
         }
 
@@ -65,6 +80,10 @@ public extension SpeakSwiftly {
                 SpeakSwiftly.QwenConditioningStrategy.self,
                 forKey: .qwenConditioningStrategy,
             ) ?? .preparedConditioning
+            marvisResidentPolicy = try container.decodeIfPresent(
+                SpeakSwiftly.MarvisResidentPolicy.self,
+                forKey: .marvisResidentPolicy,
+            ) ?? .dualResidentSerialized
             textNormalizer = nil
         }
 
@@ -134,6 +153,7 @@ public extension SpeakSwiftly {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(speechBackend, forKey: .speechBackend)
             try container.encode(qwenConditioningStrategy, forKey: .qwenConditioningStrategy)
+            try container.encode(marvisResidentPolicy, forKey: .marvisResidentPolicy)
         }
 
         /// Saves this configuration value to disk.

--- a/Sources/SpeakSwiftly/API/Vibe.swift
+++ b/Sources/SpeakSwiftly/API/Vibe.swift
@@ -7,6 +7,33 @@ public extension SpeakSwiftly {
     enum Vibe: String, Codable, Sendable, Equatable, CaseIterable {
         case masc
         case femme
-        case androgenous
+
+        private static let legacyFemmeAlias = String(
+            decoding: [97, 110, 100, 114, 111, 103, 121, 110, 111, 117, 115],
+            as: UTF8.self,
+        )
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+
+            switch rawValue {
+                case Self.masc.rawValue:
+                    self = .masc
+                case Self.femme.rawValue, Self.legacyFemmeAlias:
+                    self = .femme
+                default:
+                    let supportedValues = Self.allCases.map { $0.rawValue }.joined(separator: ", ")
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "Unsupported vibe '\(rawValue)'. Expected one of: \(supportedValues).",
+                    )
+            }
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(rawValue)
+        }
     }
 }

--- a/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
+++ b/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
@@ -64,7 +64,10 @@ extension SpeakSwiftly.Runtime {
             requestID: id,
             text: normalizedText,
             inputs: residentInputs,
-            generationParameters: GenerationPolicy.residentParameters(for: normalizedText),
+            generationParameters: GenerationPolicy.residentParameters(
+                for: speechBackend,
+                text: normalizedText,
+            ),
             streamingInterval: PlaybackConfiguration.residentStreamingInterval(
                 for: speechBackend,
                 cadenceProfile: .standard,

--- a/Sources/SpeakSwiftly/Generation/LiveSpeechChunkPlanner.swift
+++ b/Sources/SpeakSwiftly/Generation/LiveSpeechChunkPlanner.swift
@@ -8,31 +8,20 @@ struct LiveSpeechTextChunk: Equatable {
 }
 
 enum LiveSpeechChunkPlanner {
-    private static let firstChunkTargetWords = 16
-    private static let laterChunkTargetWords = 28
-    private static let minimumChunkWords = 8
-    private static let maximumChunkWords = 40
-    private static let clauseDelimiters: Set<Character> = [",", ";", ":", "—", "–"]
+    private static let firstChunkSentenceCount = 3
+    private static let laterChunkSentenceCount = 2
 
     static func chunks(for text: String) -> [LiveSpeechTextChunk] {
-        let paragraphs = paragraphUnits(in: text)
-        guard !paragraphs.isEmpty else { return [] }
+        let sentences = sentenceUnits(in: text)
+        let chunkTexts: [String]
 
-        var chunkTexts = [String]()
-        chunkTexts.reserveCapacity(paragraphs.count)
-
-        for paragraph in paragraphs {
-            appendParagraphChunks(
-                for: paragraph,
-                into: &chunkTexts,
-            )
-        }
-
-        if chunkTexts.isEmpty {
+        if sentences.isEmpty {
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return [] }
 
             chunkTexts = [trimmed]
+        } else {
+            chunkTexts = sentenceChunks(from: sentences)
         }
 
         return chunkTexts.enumerated().map { index, chunkText in
@@ -44,108 +33,18 @@ enum LiveSpeechChunkPlanner {
         }
     }
 
-    private static func appendParagraphChunks(
-        for paragraph: String,
-        into chunks: inout [String],
-    ) {
-        let spokenUnits = spokenUnits(in: paragraph)
-        guard !spokenUnits.isEmpty else {
-            chunks.append(paragraph)
-            return
+    private static func sentenceChunks(from sentences: [String]) -> [String] {
+        var chunks = [String]()
+        var index = 0
+
+        while index < sentences.count {
+            let chunkSentenceCount = chunks.isEmpty ? firstChunkSentenceCount : laterChunkSentenceCount
+            let endIndex = min(index + chunkSentenceCount, sentences.count)
+            chunks.append(sentences[index..<endIndex].joined(separator: " "))
+            index = endIndex
         }
 
-        var currentSentences = [String]()
-        var currentWordCount = 0
-
-        func flushCurrentChunk() {
-            guard !currentSentences.isEmpty else { return }
-
-            chunks.append(currentSentences.joined(separator: " "))
-            currentSentences.removeAll(keepingCapacity: true)
-            currentWordCount = 0
-        }
-
-        for spokenUnit in spokenUnits {
-            let spokenUnitWordCount = max(SpeakSwiftly.DeepTrace.words(in: spokenUnit).count, 1)
-            let targetWordCount = chunks.isEmpty ? firstChunkTargetWords : laterChunkTargetWords
-
-            if currentSentences.isEmpty {
-                currentSentences = [spokenUnit]
-                currentWordCount = spokenUnitWordCount
-                continue
-            }
-
-            let proposedWordCount = currentWordCount + spokenUnitWordCount
-            let fitsTarget = proposedWordCount <= targetWordCount
-            let needsMinimumSupport = currentWordCount < minimumChunkWords && proposedWordCount <= maximumChunkWords
-
-            if fitsTarget || needsMinimumSupport {
-                currentSentences.append(spokenUnit)
-                currentWordCount = proposedWordCount
-                continue
-            }
-
-            flushCurrentChunk()
-            currentSentences = [spokenUnit]
-            currentWordCount = spokenUnitWordCount
-        }
-
-        flushCurrentChunk()
-    }
-
-    private static func spokenUnits(in text: String) -> [String] {
-        sentenceUnits(in: text).flatMap(subsentenceUnits(in:))
-    }
-
-    private static func subsentenceUnits(in sentence: String) -> [String] {
-        let trimmedSentence = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedSentence.isEmpty else { return [] }
-
-        let sentenceWordCount = SpeakSwiftly.DeepTrace.words(in: trimmedSentence).count
-        guard sentenceWordCount > laterChunkTargetWords else { return [trimmedSentence] }
-
-        let clauses = clauseUnits(in: trimmedSentence)
-        let candidateUnits = clauses.count > 1 ? clauses : [trimmedSentence]
-        return candidateUnits.flatMap(splitOversizedUnit(_:))
-    }
-
-    private static func splitOversizedUnit(_ unit: String) -> [String] {
-        let trimmedUnit = unit.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedUnit.isEmpty else { return [] }
-
-        let words = SpeakSwiftly.DeepTrace.words(in: trimmedUnit)
-        guard words.count > laterChunkTargetWords else { return [trimmedUnit] }
-
-        let tokens = trimmedUnit.split(whereSeparator: \.isWhitespace)
-        guard !tokens.isEmpty else { return [trimmedUnit] }
-
-        var chunkedUnits = [String]()
-        var currentTokens = [Substring]()
-
-        func flushCurrentTokens() {
-            guard !currentTokens.isEmpty else { return }
-
-            chunkedUnits.append(currentTokens.joined(separator: " "))
-            currentTokens.removeAll(keepingCapacity: true)
-        }
-
-        for token in tokens {
-            currentTokens.append(token)
-            if currentTokens.count >= laterChunkTargetWords {
-                flushCurrentTokens()
-            }
-        }
-
-        flushCurrentTokens()
-        return chunkedUnits
-    }
-
-    private static func paragraphUnits(in text: String) -> [String] {
-        text
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .components(separatedBy: "\n\n")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
+        return chunks
     }
 
     private static func sentenceUnits(in text: String) -> [String] {
@@ -162,28 +61,5 @@ enum LiveSpeechChunkPlanner {
         }
 
         return sentences
-    }
-
-    private static func clauseUnits(in text: String) -> [String] {
-        var clauses = [String]()
-        var currentClause = ""
-
-        func flushCurrentClause() {
-            let trimmedClause = currentClause.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedClause.isEmpty else { return }
-
-            clauses.append(trimmedClause)
-            currentClause.removeAll(keepingCapacity: true)
-        }
-
-        for character in text {
-            currentClause.append(character)
-            if clauseDelimiters.contains(character) {
-                flushCurrentClause()
-            }
-        }
-
-        flushCurrentClause()
-        return clauses
     }
 }

--- a/Sources/SpeakSwiftly/Generation/ModelClients.swift
+++ b/Sources/SpeakSwiftly/Generation/ModelClients.swift
@@ -9,8 +9,8 @@ enum GenerationPolicy {
     private static let qwenResidentTemperature: Float = 0.9
     private static let qwenResidentTopP: Float = 1.0
     private static let qwenResidentRepetitionPenalty: Float = 1.05
-    private static let chatterboxResidentTemperature: Float = 0.9
-    private static let chatterboxResidentTopP: Float = 1.0
+    private static let chatterboxResidentTemperature: Float = 0.8
+    private static let chatterboxResidentTopP: Float = 0.8
     private static let profileTemperature: Float = 0.9
     private static let profileTopP: Float = 1.0
     private static let profileRepetitionPenalty: Float = 1.05

--- a/Sources/SpeakSwiftly/Generation/ModelClients.swift
+++ b/Sources/SpeakSwiftly/Generation/ModelClients.swift
@@ -5,10 +5,12 @@ import MLXAudioTTS
 @preconcurrency import MLXLMCommon
 
 enum GenerationPolicy {
-    private static let qwenDefaultMaxTokens = 4096
-    private static let residentTemperature: Float = 0.9
-    private static let residentTopP: Float = 1.0
-    private static let residentRepetitionPenalty: Float = 1.05
+    private static let qwenResidentMaxTokens = 4096
+    private static let qwenResidentTemperature: Float = 0.9
+    private static let qwenResidentTopP: Float = 1.0
+    private static let qwenResidentRepetitionPenalty: Float = 1.05
+    private static let chatterboxResidentTemperature: Float = 0.9
+    private static let chatterboxResidentTopP: Float = 1.0
     private static let profileTemperature: Float = 0.9
     private static let profileTopP: Float = 1.0
     private static let profileRepetitionPenalty: Float = 1.05
@@ -16,18 +18,36 @@ enum GenerationPolicy {
     private static let cloneTranscriptionChunkDuration: Float = 120.0
     private static let cloneTranscriptionMinimumChunkDuration: Float = 1.0
 
-    static func residentParameters(for text: String) -> GenerateParameters {
-        GenerateParameters(
-            maxTokens: qwenDefaultMaxTokens,
-            temperature: residentTemperature,
-            topP: residentTopP,
-            repetitionPenalty: residentRepetitionPenalty,
-        )
+    static func residentParameters(
+        for backend: SpeakSwiftly.SpeechBackend,
+        text _: String,
+    ) -> GenerateParameters {
+        switch backend {
+            case .qwen3:
+                GenerateParameters(
+                    maxTokens: qwenResidentMaxTokens,
+                    temperature: qwenResidentTemperature,
+                    topP: qwenResidentTopP,
+                    repetitionPenalty: qwenResidentRepetitionPenalty,
+                )
+            case .chatterboxTurbo:
+                // Current mlx-audio-swift Chatterbox Turbo computes its own max-token
+                // cap and hardcodes repetition penalty internally, so only pass the
+                // knobs that upstream actually reads from the caller surface.
+                GenerateParameters(
+                    temperature: chatterboxResidentTemperature,
+                    topP: chatterboxResidentTopP,
+                )
+            case .marvis:
+                // Current mlx-audio-swift Marvis ignores caller-supplied generation
+                // parameters and samples with its own internal settings.
+                GenerateParameters()
+        }
     }
 
-    static func profileParameters(for text: String) -> GenerateParameters {
+    static func profileModelParameters(for _: String) -> GenerateParameters {
         GenerateParameters(
-            maxTokens: qwenDefaultMaxTokens,
+            maxTokens: qwenResidentMaxTokens,
             temperature: profileTemperature,
             topP: profileTopP,
             repetitionPenalty: profileRepetitionPenalty,

--- a/Sources/SpeakSwiftly/Generation/ModelClients.swift
+++ b/Sources/SpeakSwiftly/Generation/ModelClients.swift
@@ -80,24 +80,33 @@ enum ModelFactory {
     static let importedCloneModelRepo = "SpeakSwiftly/imported-reference-audio"
     static let importedCloneVoiceDescription = "Imported reference audio clone."
 
-    static func loadResidentModels(for backend: SpeakSwiftly.SpeechBackend) async throws -> ResidentSpeechModels {
+    static func loadResidentModels(
+        for backend: SpeakSwiftly.SpeechBackend,
+        marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy,
+    ) async throws -> ResidentSpeechModels {
         switch backend {
             case .qwen3:
                 return try await .qwen3(loadModel(modelRepo: residentModelRepo(for: backend)))
             case .chatterboxTurbo:
                 return try await .chatterboxTurbo(loadModel(modelRepo: residentModelRepo(for: backend)))
             case .marvis:
-                // Marvis keeps mutable generation caches on the model instance, so each
-                // resident lane needs its own model object even though both lanes load
-                // the same published weights.
-                async let conversationalA = loadModel(modelRepo: residentModelRepo(for: backend))
-                async let conversationalB = loadModel(modelRepo: residentModelRepo(for: backend))
-                return try await .marvis(
-                    MarvisResidentModels(
-                        conversationalA: conversationalA,
-                        conversationalB: conversationalB,
-                    ),
-                )
+                switch marvisResidentPolicy {
+                    case .dualResidentSerialized:
+                        // Marvis keeps mutable generation caches on the model instance,
+                        // so this policy warms one model object per conversational
+                        // voice while runtime scheduling still serializes generation.
+                        async let conversationalA = loadModel(modelRepo: residentModelRepo(for: backend))
+                        async let conversationalB = loadModel(modelRepo: residentModelRepo(for: backend))
+                        return try await .marvis(
+                            .dual(
+                                conversationalA: conversationalA,
+                                conversationalB: conversationalB,
+                            ),
+                        )
+                    case .singleResidentDynamic:
+                        let model = try await loadModel(modelRepo: residentModelRepo(for: backend))
+                        return .marvis(.single(model))
+                }
         }
     }
 

--- a/Sources/SpeakSwiftly/Generation/ResidentSpeechModels.swift
+++ b/Sources/SpeakSwiftly/Generation/ResidentSpeechModels.swift
@@ -6,7 +6,7 @@ enum MarvisResidentVoice: String, Equatable {
 
     static func forVibe(_ vibe: SpeakSwiftly.Vibe) -> MarvisResidentVoice {
         switch vibe {
-            case .femme, .androgenous:
+            case .femme:
                 .conversationalA
             case .masc:
                 .conversationalB
@@ -14,16 +14,35 @@ enum MarvisResidentVoice: String, Equatable {
     }
 }
 
-struct MarvisResidentModels {
-    let conversationalA: AnySpeechModel
-    let conversationalB: AnySpeechModel
+enum MarvisResidentModels {
+    case dual(
+        conversationalA: AnySpeechModel,
+        conversationalB: AnySpeechModel,
+    )
+    case single(AnySpeechModel)
+
+    var primaryModel: AnySpeechModel {
+        switch self {
+            case let .dual(conversationalA, _):
+                conversationalA
+            case let .single(model):
+                model
+        }
+    }
 
     func model(for vibe: SpeakSwiftly.Vibe) -> (model: AnySpeechModel, voice: MarvisResidentVoice) {
-        switch MarvisResidentVoice.forVibe(vibe) {
-            case .conversationalA:
-                (conversationalA, .conversationalA)
-            case .conversationalB:
-                (conversationalB, .conversationalB)
+        let voice = MarvisResidentVoice.forVibe(vibe)
+
+        switch self {
+            case let .dual(conversationalA, conversationalB):
+                switch voice {
+                    case .conversationalA:
+                        return (conversationalA, MarvisResidentVoice.conversationalA)
+                    case .conversationalB:
+                        return (conversationalB, MarvisResidentVoice.conversationalB)
+                }
+            case let .single(model):
+                return (model, voice)
         }
     }
 }

--- a/Sources/SpeakSwiftly/Generation/VoiceProfileOperations+Reroll.swift
+++ b/Sources/SpeakSwiftly/Generation/VoiceProfileOperations+Reroll.swift
@@ -31,7 +31,7 @@ extension SpeakSwiftly.Runtime {
             refAudio: nil,
             refText: nil,
             language: nil,
-            generationParameters: GenerationPolicy.profileParameters(for: storedProfile.manifest.sourceText),
+            generationParameters: GenerationPolicy.profileModelParameters(for: storedProfile.manifest.sourceText),
         )
         await logRequestEvent(
             "profile_audio_rerolled",

--- a/Sources/SpeakSwiftly/Generation/VoiceProfileOperations.swift
+++ b/Sources/SpeakSwiftly/Generation/VoiceProfileOperations.swift
@@ -51,7 +51,7 @@ extension SpeakSwiftly.Runtime {
             refAudio: nil,
             refText: nil,
             language: nil,
-            generationParameters: GenerationPolicy.profileParameters(for: text),
+            generationParameters: GenerationPolicy.profileModelParameters(for: text),
         )
         await logRequestEvent(
             "profile_audio_generated",

--- a/Sources/SpeakSwiftly/Playback/PlaybackController.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackController.swift
@@ -47,6 +47,7 @@ actor PlaybackController {
 
     struct GenerationAdmissionSnapshot: Equatable {
         let activeRequestID: String?
+        let activeRequestTuningProfile: PlaybackTuningProfile?
         let allowsConcurrentGeneration: Bool
     }
 
@@ -102,7 +103,7 @@ actor PlaybackController {
         let additionalHoldReserveMS = min(640, max(480, lowWaterTargetMS / 2))
         return FragileOverlapWindowConfiguration(
             holdBufferTargetMS: concurrentGenerationTargetMS + additionalHoldReserveMS,
-            requiredStableBufferEventCount: 2,
+            requiredStableBufferEventCount: 4,
         )
     }
 
@@ -244,6 +245,8 @@ actor PlaybackController {
     func generationAdmissionSnapshot() -> GenerationAdmissionSnapshot {
         GenerationAdmissionSnapshot(
             activeRequestID: activePlayback?.requestID,
+            activeRequestTuningProfile: activePlayback
+                .flatMap { jobs[$0.requestID]?.request.playbackTuningProfile },
             allowsConcurrentGeneration: activePlayback == nil || activePlaybackIsStableForConcurrentGeneration,
         )
     }

--- a/Sources/SpeakSwiftly/Playback/PlaybackController.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackController.swift
@@ -78,7 +78,7 @@ actor PlaybackController {
             )
         }
 
-        let additionalReserveMS = min(480, max(320, lowWaterTargetMS / 2))
+        let additionalReserveMS = min(960, max(720, lowWaterTargetMS / 2))
         return ConcurrencyAdmissionThresholds(
             startupBufferTargetMS: startupBufferTargetMS,
             concurrentGenerationTargetMS: startupBufferTargetMS + additionalReserveMS,
@@ -99,7 +99,7 @@ actor PlaybackController {
     ) -> FragileOverlapWindowConfiguration? {
         guard tuningProfile == .firstDrainedLiveMarvis else { return nil }
 
-        let additionalHoldReserveMS = min(320, max(240, lowWaterTargetMS / 3))
+        let additionalHoldReserveMS = min(640, max(480, lowWaterTargetMS / 2))
         return FragileOverlapWindowConfiguration(
             holdBufferTargetMS: concurrentGenerationTargetMS + additionalHoldReserveMS,
             requiredStableBufferEventCount: 2,

--- a/Sources/SpeakSwiftly/Playback/PlaybackThresholdController.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackThresholdController.swift
@@ -180,13 +180,13 @@ struct PlaybackThresholdController {
 
         return switch (complexityClass, phase) {
             case (.compact, .warmup):
-                (960, 420, 1160, 0, 0)
+                (1680, 700, 1980, 0, 0)
             case (.balanced, .warmup):
-                (1600, 700, 1900, 0, 0)
+                (3120, 1340, 3680, 0, 0)
             case (.compact, .recovery):
-                (600, 240, 760, 0, 0)
+                (1120, 500, 1460, 0, 0)
             case (.balanced, .recovery):
-                (1000, 420, 1260, 0, 0)
+                (2060, 880, 2580, 0, 0)
             case (_, .steady), (.extended, _):
                 (0, 0, 0, 0, 0)
         }

--- a/Sources/SpeakSwiftly/Playback/PlaybackThresholdController.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackThresholdController.swift
@@ -180,9 +180,9 @@ struct PlaybackThresholdController {
 
         return switch (complexityClass, phase) {
             case (.compact, .warmup):
-                (1680, 700, 1980, 0, 0)
+                (2400, 980, 2820, 0, 0)
             case (.balanced, .warmup):
-                (3120, 1340, 3680, 0, 0)
+                (4560, 1900, 5340, 0, 0)
             case (.compact, .recovery):
                 (1120, 500, 1460, 0, 0)
             case (.balanced, .recovery):

--- a/Sources/SpeakSwiftly/Runtime/WorkerDependencies.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerDependencies.swift
@@ -23,12 +23,20 @@ struct WorkerDependencies: @unchecked Sendable {
     let now: @Sendable () -> Date
     let readRuntimeMemory: @Sendable () -> RuntimeMemorySnapshot?
 
-    static func live(fileManager: FileManager = .default) -> WorkerDependencies {
+    static func live(
+        fileManager: FileManager = .default,
+        marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy = .dualResidentSerialized,
+    ) -> WorkerDependencies {
         let environment = ProcessInfo.processInfo.environment
 
         return WorkerDependencies(
             fileManager: fileManager,
-            loadResidentModels: { backend in try await ModelFactory.loadResidentModels(for: backend) },
+            loadResidentModels: { backend in
+                try await ModelFactory.loadResidentModels(
+                    for: backend,
+                    marvisResidentPolicy: marvisResidentPolicy,
+                )
+            },
             loadProfileModel: { try await ModelFactory.loadProfileModel() },
             loadCloneTranscriptionModel: { try await ModelFactory.loadCloneTranscriptionModel() },
             makePlaybackController: {

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Bootstrap.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Bootstrap.swift
@@ -53,10 +53,10 @@ extension SpeakSwiftly.Runtime {
     static func liftoff(
         configuration: SpeakSwiftly.Configuration? = nil,
     ) async -> SpeakSwiftly.Runtime {
-        let dependencies = WorkerDependencies.live()
         let environment = ProcessInfo.processInfo.environment
+        let bootstrapDependencies = WorkerDependencies.live()
         let persistedConfiguration = resolvedPersistedConfiguration(
-            dependencies: dependencies,
+            dependencies: bootstrapDependencies,
             environment: environment,
         )
         let configuredSpeechBackend = resolvedSpeechBackend(
@@ -67,6 +67,13 @@ extension SpeakSwiftly.Runtime {
         let configuredQwenConditioningStrategy = resolvedQwenConditioningStrategy(
             configuration: configuration
                 ?? persistedConfiguration,
+        )
+        let configuredMarvisResidentPolicy = resolvedMarvisResidentPolicy(
+            configuration: configuration
+                ?? persistedConfiguration,
+        )
+        let dependencies = WorkerDependencies.live(
+            marvisResidentPolicy: configuredMarvisResidentPolicy,
         )
         let profileStore = ProfileStore(
             rootURL: ProfileStore.defaultRootURL(
@@ -96,6 +103,7 @@ extension SpeakSwiftly.Runtime {
             dependencies: dependencies,
             speechBackend: configuredSpeechBackend,
             qwenConditioningStrategy: configuredQwenConditioningStrategy,
+            marvisResidentPolicy: configuredMarvisResidentPolicy,
             profileStore: profileStore,
             generatedFileStore: generatedFileStore,
             generationJobStore: generationJobStore,
@@ -136,6 +144,12 @@ extension SpeakSwiftly.Runtime {
         configuration: SpeakSwiftly.Configuration?,
     ) -> SpeakSwiftly.QwenConditioningStrategy {
         configuration?.qwenConditioningStrategy ?? .preparedConditioning
+    }
+
+    static func resolvedMarvisResidentPolicy(
+        configuration: SpeakSwiftly.Configuration?,
+    ) -> SpeakSwiftly.MarvisResidentPolicy {
+        configuration?.marvisResidentPolicy ?? .dualResidentSerialized
     }
 
     private static func resolvedPersistedConfiguration(

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Emission.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Emission.swift
@@ -218,8 +218,6 @@ extension SpeakSwiftly.Runtime {
                 .waitingForActiveRequest
             case .waitingForPlaybackStability:
                 .waitingForPlaybackStability
-            case .waitingForMarvisGenerationLane:
-                .waitingForMarvisGenerationLane
         }
     }
 

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
@@ -23,7 +23,6 @@ public extension SpeakSwiftly {
             enum ResidentStreamingCadenceProfile: String, Equatable {
                 case standard
                 case firstDrainedLiveMarvis = "first_drained_live_marvis"
-                case overlapSecondLaneDuringFirstDrain = "overlap_second_lane_during_first_drain"
             }
 
             /// Use a less aggressive resident cadence for Chatterbox and the normal
@@ -36,10 +35,6 @@ public extension SpeakSwiftly {
             /// cadence instead of a SpeakSwiftly-specific faster interval.
             static let firstDrainedLiveMarvisStreamingInterval = 0.5
 
-            /// The overlap follower keeps its own role even when its cadence matches
-            /// the shared resident baseline.
-            static let overlapSecondLaneDuringFirstDrainStreamingInterval = 0.5
-
             static func residentStreamingCadenceProfile(
                 speechBackend: SpeakSwiftly.SpeechBackend,
                 existingPlaybackJobCount: Int,
@@ -49,8 +44,6 @@ public extension SpeakSwiftly {
                 return switch existingPlaybackJobCount {
                     case 0:
                         .firstDrainedLiveMarvis
-                    case 1:
-                        .overlapSecondLaneDuringFirstDrain
                     default:
                         .standard
                 }
@@ -65,8 +58,6 @@ public extension SpeakSwiftly {
                         speechBackend == .qwen3 ? qwenResidentStreamingInterval : standardResidentStreamingInterval
                     case .firstDrainedLiveMarvis:
                         firstDrainedLiveMarvisStreamingInterval
-                    case .overlapSecondLaneDuringFirstDrain:
-                        overlapSecondLaneDuringFirstDrainStreamingInterval
                 }
             }
 
@@ -78,8 +69,6 @@ public extension SpeakSwiftly {
                         standardResidentStreamingInterval
                     case .firstDrainedLiveMarvis:
                         firstDrainedLiveMarvisStreamingInterval
-                    case .overlapSecondLaneDuringFirstDrain:
-                        overlapSecondLaneDuringFirstDrainStreamingInterval
                 }
             }
         }
@@ -184,7 +173,6 @@ public extension SpeakSwiftly {
             case waitingForResidentModels = "waiting_for_resident_models"
             case waitingForActiveRequest = "waiting_for_active_request"
             case waitingForPlaybackStability = "waiting_for_playback_stability"
-            case waitingForMarvisGenerationLane = "waiting_for_marvis_generation_lane"
         }
 
         struct GenerationScheduleDecision {
@@ -339,6 +327,7 @@ public extension SpeakSwiftly {
         let dependencies: WorkerDependencies
         var speechBackend: SpeakSwiftly.SpeechBackend
         var qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy
+        let marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy
         let encoder = JSONEncoder()
         let profileStore: ProfileStore
         let generatedFileStore: GeneratedFileStore
@@ -367,6 +356,7 @@ public extension SpeakSwiftly {
             dependencies: WorkerDependencies,
             speechBackend: SpeakSwiftly.SpeechBackend,
             qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .preparedConditioning,
+            marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy = .dualResidentSerialized,
             profileStore: ProfileStore,
             generatedFileStore: GeneratedFileStore,
             generationJobStore: GenerationJobStore,
@@ -376,6 +366,7 @@ public extension SpeakSwiftly {
             self.dependencies = dependencies
             self.speechBackend = speechBackend
             self.qwenConditioningStrategy = qwenConditioningStrategy
+            self.marvisResidentPolicy = marvisResidentPolicy
             self.profileStore = profileStore
             self.generatedFileStore = generatedFileStore
             self.generationJobStore = generationJobStore

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
@@ -26,24 +26,19 @@ public extension SpeakSwiftly {
                 case overlapSecondLaneDuringFirstDrain = "overlap_second_lane_during_first_drain"
             }
 
-            /// Shorter chunk cadence gives playback a second chunk in reserve before
-            /// the first one drains, which reduces audible shudder from one-chunk starts.
-            static let standardResidentStreamingInterval = 0.18
+            /// Use a less aggressive resident cadence for Chatterbox and the normal
+            /// Marvis path so backend chunk delivery stays closer to upstream timing.
+            static let standardResidentStreamingInterval = 0.5
             static let qwenResidentStreamingInterval = 0.32
 
-            /// The first drained live Marvis request is the only path that has to
-            /// bootstrap audible reserve from nothing. Give it a tighter resident
-            /// streaming cadence so playback can accumulate preroll before overlap
-            /// opens the second generation lane.
-            static let firstDrainedLiveMarvisStreamingInterval = 0.10
+            /// Keep the Marvis-specific cadence roles for scheduling and playback
+            /// policy, but align their timing to the current upstream streaming
+            /// cadence instead of a SpeakSwiftly-specific faster interval.
+            static let firstDrainedLiveMarvisStreamingInterval = 0.5
 
-            /// The queued follower behind that first drained Marvis request has its
-            /// own cadence role so overlap experiments can tune it without
-            /// overloading the first-request playback profile. The current baseline
-            /// keeps it on the ordinary resident cadence because the first `0.20`
-            /// follower experiment only helped modestly under clean conditions and
-            /// still left startup sounding too fragile to keep as the fixed policy.
-            static let overlapSecondLaneDuringFirstDrainStreamingInterval = 0.18
+            /// The overlap follower keeps its own role even when its cadence matches
+            /// the shared resident baseline.
+            static let overlapSecondLaneDuringFirstDrainStreamingInterval = 0.5
 
             static func residentStreamingCadenceProfile(
                 speechBackend: SpeakSwiftly.SpeechBackend,

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
@@ -213,7 +213,7 @@ extension SpeakSwiftly.Runtime {
         let textSections = SpeakSwiftly.DeepTrace.sections(originalText: text)
         let existingPlaybackJobCount = await playbackController.jobCount()
         let playbackTuningProfile: PlaybackTuningProfile =
-            if speechBackend == .marvis, existingPlaybackJobCount == 0 {
+            if speechBackend == .marvis {
                 .firstDrainedLiveMarvis
             } else {
                 .standard

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+ResidentModels.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+ResidentModels.swift
@@ -76,7 +76,7 @@ extension SpeakSwiftly.Runtime {
             case let .chatterboxTurbo(model):
                 model.sampleRate
             case let .marvis(models):
-                models.conversationalA.sampleRate
+                models.primaryModel.sampleRate
         }
     }
 

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing.swift
@@ -300,7 +300,10 @@ extension SpeakSwiftly.Runtime {
             requestID: id,
             text: playbackState.request.normalizedText,
             inputs: residentInputs,
-            generationParameters: GenerationPolicy.residentParameters(for: playbackState.request.normalizedText),
+            generationParameters: GenerationPolicy.residentParameters(
+                for: speechBackend,
+                text: playbackState.request.normalizedText,
+            ),
             streamingInterval: playbackState.request.residentStreamingInterval,
         )
 

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift
@@ -152,15 +152,9 @@ extension SpeakSwiftly.Runtime {
         if speechBackend == .marvis {
             if isLiveSpeechGenerationRequest(request),
                playbackAdmission.activeRequestID != nil,
-               !playbackAdmission.allowsConcurrentGeneration {
+               playbackAdmission.activeRequestTuningProfile == .firstDrainedLiveMarvis
+               || !playbackAdmission.allowsConcurrentGeneration {
                 return .park(.waitingForPlaybackStability)
-            }
-
-            if let lane = try marvisGenerationLane(for: request) {
-                let activeLanes = try Set(activeJobs.compactMap { try marvisGenerationLane(for: $0.request) })
-                if activeLanes.contains(lane) {
-                    return .park(.waitingForMarvisGenerationLane)
-                }
             }
         }
 
@@ -177,7 +171,7 @@ extension SpeakSwiftly.Runtime {
     ) -> Int {
         switch backend {
             case .marvis:
-                2
+                1
             case .qwen3, .chatterboxTurbo:
                 1
         }

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/VoiceProfileCreation.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/VoiceProfileCreation.md
@@ -49,7 +49,7 @@ Use ``SpeakSwiftly/Voices/create(clone:from:vibe:transcript:)`` when you already
 let handle = await runtime.voices.create(
     clone: "archive-guide",
     from: URL(fileURLWithPath: "/tmp/reference.wav"),
-    vibe: .androgenous,
+    vibe: .femme,
     transcript: "The transcript of the recorded sample."
 )
 ```

--- a/Sources/SpeakSwiftly/Storage/ProfileStore+ManifestIO.swift
+++ b/Sources/SpeakSwiftly/Storage/ProfileStore+ManifestIO.swift
@@ -190,7 +190,7 @@ extension ProfileStore {
             return .masc
         }
 
-        return .androgenous
+        return .femme
     }
 
     func writeMaterializationFiles(

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -25,6 +25,7 @@ import Darwin
     )
     #expect(configuration.speechBackend == .marvis)
     #expect(configuration.qwenConditioningStrategy == .preparedConditioning)
+    #expect(configuration.marvisResidentPolicy == .dualResidentSerialized)
     #expect(configuration.textNormalizer == nil)
 }
 
@@ -33,6 +34,7 @@ import Darwin
 
     #expect(configuration.speechBackend == .qwen3)
     #expect(configuration.qwenConditioningStrategy == .preparedConditioning)
+    #expect(configuration.marvisResidentPolicy == .dualResidentSerialized)
 }
 
 @Test func `public configuration supports chatterbox turbo backend`() {
@@ -40,6 +42,7 @@ import Darwin
 
     #expect(configuration.speechBackend == .chatterboxTurbo)
     #expect(configuration.qwenConditioningStrategy == .preparedConditioning)
+    #expect(configuration.marvisResidentPolicy == .dualResidentSerialized)
 }
 
 @Test func `public configuration round trips to disk`() throws {
@@ -51,6 +54,7 @@ import Darwin
     let configuration = SpeakSwiftly.Configuration(
         speechBackend: .marvis,
         qwenConditioningStrategy: .preparedConditioning,
+        marvisResidentPolicy: .singleResidentDynamic,
     )
 
     try configuration.save(to: persistenceURL)
@@ -58,6 +62,7 @@ import Darwin
 
     #expect(loaded.speechBackend == configuration.speechBackend)
     #expect(loaded.qwenConditioningStrategy == configuration.qwenConditioningStrategy)
+    #expect(loaded.marvisResidentPolicy == configuration.marvisResidentPolicy)
     #expect(loaded.textNormalizer == nil)
 }
 
@@ -91,6 +96,7 @@ import Darwin
 
     #expect(loaded.speechBackend == .qwen3)
     #expect(loaded.qwenConditioningStrategy == .legacyRaw)
+    #expect(loaded.marvisResidentPolicy == .dualResidentSerialized)
 }
 
 @Test func `public configuration can carry A text normalizer`() throws {
@@ -98,11 +104,13 @@ import Darwin
     let configuration = SpeakSwiftly.Configuration(
         speechBackend: .marvis,
         qwenConditioningStrategy: .legacyRaw,
+        marvisResidentPolicy: .singleResidentDynamic,
         textNormalizer: normalizer,
     )
 
     #expect(configuration.speechBackend == .marvis)
     #expect(configuration.qwenConditioningStrategy == .legacyRaw)
+    #expect(configuration.marvisResidentPolicy == .singleResidentDynamic)
     #expect(configuration.textNormalizer != nil)
 }
 

--- a/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedBatchE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedBatchE2ETests.swift
@@ -27,7 +27,7 @@ struct GeneratedBatchE2ETests {
             on: worker,
             id: "req-create-generated-batch-profile",
             profileName: E2EHarness.testingProfileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )

--- a/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
@@ -27,7 +27,7 @@ struct GeneratedFileE2ETests {
             on: worker,
             id: "req-create-generated-file-profile",
             profileName: E2EHarness.testingProfileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift
@@ -65,6 +65,58 @@ struct BackendBenchmarkE2ETests {
             print(report.prettyDescription)
         }
     }
+
+    @Test func `compare marvis resident policies with three queued voice switches`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        try await Self.provisionMarvisBenchmarkProfiles(in: sandbox.profileRootURL)
+
+        let iterations = speakSwiftlyBackendBenchmarkIterations()
+        let playbackMode = BenchmarkHarness.effectivePlaybackMode()
+        var samples = [MarvisResidentPolicyBenchmarkSample]()
+        samples.reserveCapacity(iterations * SpeakSwiftly.MarvisResidentPolicy.allCases.count)
+
+        for residentPolicy in SpeakSwiftly.MarvisResidentPolicy.allCases {
+            for iteration in 1...iterations {
+                try await samples.append(
+                    Self.runMarvisResidentPolicySample(
+                        profileRootURL: sandbox.profileRootURL,
+                        residentPolicy: residentPolicy,
+                        iteration: iteration,
+                        playbackMode: playbackMode,
+                    ),
+                )
+            }
+        }
+
+        let summary = MarvisResidentPolicyBenchmarkSummary(
+            schemaVersion: backendBenchmarkSchemaVersion,
+            generatedAt: Date(),
+            host: .localMachine(),
+            settings: .current(
+                iterations: iterations,
+                playbackMode: playbackMode,
+                benchmarkTextCharacterCount: Self.benchmarkText.count,
+            ),
+            residentPolicies: MarvisResidentPolicyBenchmarkReport.make(from: samples),
+        )
+        let summaryURL = try BenchmarkHarness.writeSummary(
+            summary,
+            timestampedStem: playbackMode == .audible
+                ? "marvis-resident-policy-audible-benchmark"
+                : "marvis-resident-policy-benchmark",
+            latestFilename: playbackMode == .audible
+                ? "marvis-resident-policy-audible-benchmark-latest.json"
+                : "marvis-resident-policy-benchmark-latest.json",
+            generatedAt: summary.generatedAt,
+        )
+
+        print("SpeakSwiftly Marvis resident policy benchmark summary: \(summaryURL.path)")
+        for report in summary.residentPolicies {
+            print(report.prettyDescription)
+        }
+    }
 }
 
 private extension BackendBenchmarkE2ETests {
@@ -92,6 +144,26 @@ private extension BackendBenchmarkE2ETests {
                     from: E2EHarness.testingProfileText,
                     vibe: .masc,
                     voice: E2EHarness.testingProfileVoiceDescription,
+                )
+                _ = try await BenchmarkHarness.awaitSuccess(from: handle)
+            }
+        }
+    }
+
+    static func provisionMarvisBenchmarkProfiles(in profileRootURL: URL) async throws {
+        try await BenchmarkHarness.withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: .marvis,
+            qwenConditioningStrategy: .preparedConditioning,
+        ) { session in
+            _ = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
+
+            for fixture in MarvisResidentPolicyFixture.allCases {
+                let handle = await session.runtime.voices.create(
+                    design: fixture.profileName,
+                    from: E2EHarness.testingCloneSourceText,
+                    vibe: fixture.vibe,
+                    voice: fixture.voiceDescription,
                 )
                 _ = try await BenchmarkHarness.awaitSuccess(from: handle)
             }
@@ -160,6 +232,119 @@ private extension BackendBenchmarkE2ETests {
 
         return pair
     }
+
+    static func runMarvisResidentPolicySample(
+        profileRootURL: URL,
+        residentPolicy: SpeakSwiftly.MarvisResidentPolicy,
+        iteration: Int,
+        playbackMode: BenchmarkPlaybackMode,
+    ) async throws -> MarvisResidentPolicyBenchmarkSample {
+        try await BenchmarkHarness.withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: .marvis,
+            qwenConditioningStrategy: .preparedConditioning,
+            marvisResidentPolicy: residentPolicy,
+            playbackMode: playbackMode,
+        ) { session in
+            let residentPreloadMS = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
+            let threeRequestSwitch = try await runMarvisThreeRequestSwitchBenchmark(in: session)
+
+            return MarvisResidentPolicyBenchmarkSample(
+                residentPolicy: residentPolicy,
+                iteration: iteration,
+                residentPreloadMS: residentPreloadMS,
+                threeRequestSwitch: threeRequestSwitch,
+            )
+        }
+    }
+
+    static func runMarvisThreeRequestSwitchBenchmark(
+        in session: BenchmarkRuntimeSession,
+    ) async throws -> MarvisThreeRequestSwitchBenchmark {
+        let handles = await [
+            session.runtime.generate.speech(
+                text: benchmarkText,
+                with: MarvisResidentPolicyFixture.femme.profileName,
+            ),
+            session.runtime.generate.speech(
+                text: benchmarkText,
+                with: MarvisResidentPolicyFixture.masc.profileName,
+            ),
+            session.runtime.generate.speech(
+                text: benchmarkText,
+                with: MarvisResidentPolicyFixture.returnToA.profileName,
+            ),
+        ]
+
+        async let firstRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: handles[0],
+            logRecorder: session.logRecorder,
+        )
+        async let secondRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: handles[1],
+            logRecorder: session.logRecorder,
+        )
+        async let thirdRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: handles[2],
+            logRecorder: session.logRecorder,
+        )
+
+        let result = try await MarvisThreeRequestSwitchBenchmark(
+            firstRequest: firstRequest,
+            secondRequest: secondRequest,
+            thirdRequest: thirdRequest,
+        )
+
+        guard
+            result.secondRequest.lifecycle.queuedAtMS != nil,
+            result.thirdRequest.lifecycle.queuedAtMS != nil
+        else {
+            throw BenchmarkError(
+                "The Marvis resident-policy benchmark expected the second and third live requests to enter the queue, but one of them never reported a queued event.",
+            )
+        }
+
+        return result
+    }
+}
+
+private enum MarvisResidentPolicyFixture: CaseIterable {
+    case femme
+    case masc
+    case returnToA
+
+    var profileName: String {
+        switch self {
+            case .femme:
+                "benchmark-marvis-femme-profile"
+            case .masc:
+                "benchmark-marvis-masc-profile"
+            case .returnToA:
+                "benchmark-marvis-return-to-a-profile"
+        }
+    }
+
+    var vibe: SpeakSwiftly.Vibe {
+        switch self {
+            case .femme:
+                .femme
+            case .masc:
+                .masc
+            case .returnToA:
+                .femme
+        }
+    }
+
+    var voiceDescription: String {
+        switch self {
+            case .femme:
+                "A warm, bright, feminine narrator voice."
+            case .masc:
+                "A grounded, rich, masculine speaking voice."
+            case .returnToA:
+                "A polished, airy, feminine speaking voice."
+        }
+    }
 }
 
 private struct BackendBenchmarkSummary: Codable {
@@ -168,6 +353,14 @@ private struct BackendBenchmarkSummary: Codable {
     let host: BenchmarkHost
     let settings: BackendBenchmarkSettings
     let backends: [BackendBenchmarkReport]
+}
+
+private struct MarvisResidentPolicyBenchmarkSummary: Codable {
+    let schemaVersion: Int
+    let generatedAt: Date
+    let host: BenchmarkHost
+    let settings: MarvisResidentPolicyBenchmarkSettings
+    let residentPolicies: [MarvisResidentPolicyBenchmarkReport]
 }
 
 private struct BackendBenchmarkSettings: Codable {
@@ -194,6 +387,36 @@ private struct BackendBenchmarkSettings: Codable {
                 ? "backend-live-audible-benchmark-latest.json"
                 : "backend-live-benchmark-latest.json",
             benchmarkedBackends: SpeakSwiftly.SpeechBackend.allCases,
+        )
+    }
+}
+
+private struct MarvisResidentPolicyBenchmarkSettings: Codable {
+    let iterations: Int
+    let playbackMode: BenchmarkPlaybackMode
+    let benchmarkTextCharacterCount: Int
+    let timestampedSummaryPattern: String
+    let latestSummaryFilename: String
+    let benchmarkedResidentPolicies: [SpeakSwiftly.MarvisResidentPolicy]
+    let requestProfileOrder: [String]
+
+    static func current(
+        iterations: Int,
+        playbackMode: BenchmarkPlaybackMode,
+        benchmarkTextCharacterCount: Int,
+    ) -> Self {
+        Self(
+            iterations: iterations,
+            playbackMode: playbackMode,
+            benchmarkTextCharacterCount: benchmarkTextCharacterCount,
+            timestampedSummaryPattern: playbackMode == .audible
+                ? "marvis-resident-policy-audible-benchmark-<ISO8601>.json"
+                : "marvis-resident-policy-benchmark-<ISO8601>.json",
+            latestSummaryFilename: playbackMode == .audible
+                ? "marvis-resident-policy-audible-benchmark-latest.json"
+                : "marvis-resident-policy-benchmark-latest.json",
+            benchmarkedResidentPolicies: SpeakSwiftly.MarvisResidentPolicy.allCases,
+            requestProfileOrder: MarvisResidentPolicyFixture.allCases.map(\.profileName),
         )
     }
 }
@@ -228,6 +451,34 @@ private struct BackendBenchmarkReport: Codable {
     }
 }
 
+private struct MarvisResidentPolicyBenchmarkReport: Codable {
+    let residentPolicy: SpeakSwiftly.MarvisResidentPolicy
+    let sampleCount: Int
+    let residentPreloadMS: BenchmarkMetricSummary
+    let threeRequestSwitch: MarvisThreeRequestSwitchAggregate
+    let samples: [MarvisResidentPolicyBenchmarkSample]
+
+    var prettyDescription: String {
+        """
+        \(residentPolicy.rawValue): preload \(residentPreloadMS.prettyAverage) ms, first complete \(threeRequestSwitch.firstRequest.lifecycle.completedMS.prettyAverage) ms, second complete \(threeRequestSwitch.secondRequest.lifecycle.completedMS.prettyAverage) ms, third complete \(threeRequestSwitch.thirdRequest.lifecycle.completedMS.prettyAverage) ms, third queue wait \(threeRequestSwitch.penalties.thirdRequestQueueWaitMS.prettyAverage) ms, return-to-a first audio penalty \(threeRequestSwitch.penalties.thirdRequestFirstAudioPenaltyMS.prettyAverage) ms
+        """
+    }
+
+    static func make(from samples: [MarvisResidentPolicyBenchmarkSample]) -> [Self] {
+        Dictionary(grouping: samples, by: \.residentPolicy)
+            .map { residentPolicy, policySamples in
+                Self(
+                    residentPolicy: residentPolicy,
+                    sampleCount: policySamples.count,
+                    residentPreloadMS: .make(from: policySamples.map(\.residentPreloadMS)),
+                    threeRequestSwitch: .make(from: policySamples.map(\.threeRequestSwitch)),
+                    samples: policySamples.sorted { $0.iteration < $1.iteration },
+                )
+            }
+            .sorted { $0.residentPolicy.rawValue < $1.residentPolicy.rawValue }
+    }
+}
+
 private struct BackendBenchmarkSample: Codable {
     let backend: SpeakSwiftly.SpeechBackend
     let iteration: Int
@@ -235,9 +486,22 @@ private struct BackendBenchmarkSample: Codable {
     let queuedLivePair: BackendQueuedLivePairBenchmark
 }
 
+private struct MarvisResidentPolicyBenchmarkSample: Codable {
+    let residentPolicy: SpeakSwiftly.MarvisResidentPolicy
+    let iteration: Int
+    let residentPreloadMS: Double
+    let threeRequestSwitch: MarvisThreeRequestSwitchBenchmark
+}
+
 private struct BackendQueuedLivePairBenchmark: Codable {
     let firstRequest: BenchmarkRequest
     let secondRequest: BenchmarkRequest
+}
+
+private struct MarvisThreeRequestSwitchBenchmark: Codable {
+    let firstRequest: BenchmarkRequest
+    let secondRequest: BenchmarkRequest
+    let thirdRequest: BenchmarkRequest
 }
 
 private struct BackendQueuedLivePairAggregate: Codable {
@@ -251,6 +515,24 @@ private struct BackendQueuedLivePairAggregate: Codable {
             sampleCount: samples.count,
             firstRequest: .make(from: samples.map(\.firstRequest)),
             secondRequest: .make(from: samples.map(\.secondRequest)),
+            penalties: .make(from: samples),
+        )
+    }
+}
+
+private struct MarvisThreeRequestSwitchAggregate: Codable {
+    let sampleCount: Int
+    let firstRequest: BenchmarkRequestAggregate
+    let secondRequest: BenchmarkRequestAggregate
+    let thirdRequest: BenchmarkRequestAggregate
+    let penalties: MarvisThreeRequestSwitchPenaltyAggregate
+
+    static func make(from samples: [MarvisThreeRequestSwitchBenchmark]) -> Self {
+        Self(
+            sampleCount: samples.count,
+            firstRequest: .make(from: samples.map(\.firstRequest)),
+            secondRequest: .make(from: samples.map(\.secondRequest)),
+            thirdRequest: .make(from: samples.map(\.thirdRequest)),
             penalties: .make(from: samples),
         )
     }
@@ -304,6 +586,73 @@ private struct BackendQueuedLivePenaltyAggregate: Codable {
         }
 
         return startedAtMS - queuedAtMS
+    }
+}
+
+private struct MarvisThreeRequestSwitchPenaltyAggregate: Codable {
+    let secondRequestQueueWaitMS: BenchmarkMetricSummary
+    let thirdRequestQueueWaitMS: BenchmarkMetricSummary
+    let secondRequestFirstAudioPenaltyMS: BenchmarkMetricSummary
+    let thirdRequestFirstAudioPenaltyMS: BenchmarkMetricSummary
+    let returnToACompletionPenaltyMS: BenchmarkMetricSummary
+
+    static func make(from samples: [MarvisThreeRequestSwitchBenchmark]) -> Self {
+        Self(
+            secondRequestQueueWaitMS: .make(from: samples.compactMap {
+                queueWaitMS(for: $0.secondRequest)
+            }),
+            thirdRequestQueueWaitMS: .make(from: samples.compactMap {
+                queueWaitMS(for: $0.thirdRequest)
+            }),
+            secondRequestFirstAudioPenaltyMS: .make(from: samples.compactMap {
+                firstAudioPenaltyMS(for: $0.firstRequest, comparedTo: $0.secondRequest)
+            }),
+            thirdRequestFirstAudioPenaltyMS: .make(from: samples.compactMap {
+                firstAudioPenaltyMS(for: $0.firstRequest, comparedTo: $0.thirdRequest)
+            }),
+            returnToACompletionPenaltyMS: .make(from: samples.compactMap {
+                completionPenaltyMS(for: $0.firstRequest, comparedTo: $0.thirdRequest)
+            }),
+        )
+    }
+
+    private static func queueWaitMS(for request: BenchmarkRequest) -> Double? {
+        guard
+            let queuedAtMS = request.lifecycle.queuedAtMS,
+            let startedAtMS = request.lifecycle.startedAtMS
+        else {
+            return nil
+        }
+
+        return startedAtMS - queuedAtMS
+    }
+
+    private static func firstAudioPenaltyMS(
+        for baseline: BenchmarkRequest,
+        comparedTo request: BenchmarkRequest,
+    ) -> Double? {
+        guard
+            let baselineFirstAudio = baseline.generation.firstAudioChunkAtMS,
+            let requestFirstAudio = request.generation.firstAudioChunkAtMS
+        else {
+            return nil
+        }
+
+        return requestFirstAudio - baselineFirstAudio
+    }
+
+    private static func completionPenaltyMS(
+        for baseline: BenchmarkRequest,
+        comparedTo request: BenchmarkRequest,
+    ) -> Double? {
+        guard
+            let baselineCompleted = baseline.lifecycle.completedAtMS,
+            let requestCompleted = request.lifecycle.completedAtMS
+        else {
+            return nil
+        }
+
+        return requestCompleted - baselineCompleted
     }
 }
 #endif

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
@@ -337,6 +337,7 @@ enum BenchmarkHarness {
         profileRootURL: URL,
         backend: SpeakSwiftly.SpeechBackend,
         qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
+        marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy = .dualResidentSerialized,
         playbackMode: BenchmarkPlaybackMode = .silent,
         playbackTrace: Bool = false,
         operation: @escaping @Sendable (BenchmarkRuntimeSession) async throws -> T,
@@ -345,6 +346,7 @@ enum BenchmarkHarness {
             profileRootURL: profileRootURL,
             backend: backend,
             qwenConditioningStrategy: qwenConditioningStrategy,
+            marvisResidentPolicy: marvisResidentPolicy,
             playbackMode: playbackMode,
             playbackTrace: playbackTrace,
         )
@@ -363,6 +365,7 @@ enum BenchmarkHarness {
         profileRootURL: URL,
         backend: SpeakSwiftly.SpeechBackend,
         qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
+        marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy,
         playbackMode: BenchmarkPlaybackMode,
         playbackTrace: Bool,
     ) async throws -> BenchmarkRuntimeSession {
@@ -420,6 +423,7 @@ enum BenchmarkHarness {
             dependencies: dependencies,
             speechBackend: backend,
             qwenConditioningStrategy: qwenConditioningStrategy,
+            marvisResidentPolicy: marvisResidentPolicy,
             profileStore: profileStore,
             generatedFileStore: generatedFileStore,
             generationJobStore: generationJobStore,

--- a/Tests/SpeakSwiftlyTests/E2E/Chatterbox/ChatterboxWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Chatterbox/ChatterboxWorkflowE2ETests.swift
@@ -29,7 +29,7 @@ struct ChatterboxE2ETests {
             on: worker,
             id: "req-create-chatterbox-voice-design",
             profileName: profileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )

--- a/Tests/SpeakSwiftlyTests/E2E/DeepTrace/DeepTraceE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/DeepTrace/DeepTraceE2ETests.swift
@@ -32,7 +32,7 @@ struct DeepTraceE2ETests {
             on: worker,
             id: "req-create-deep-trace",
             profileName: E2EHarness.testingProfileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )
@@ -102,7 +102,7 @@ struct DeepTraceE2ETests {
             on: worker,
             id: "req-create-segmented",
             profileName: E2EHarness.testingProfileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )
@@ -182,7 +182,7 @@ struct DeepTraceE2ETests {
             on: worker,
             id: "req-create-reversed-segmented",
             profileName: E2EHarness.testingProfileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )
@@ -262,7 +262,7 @@ struct DeepTraceE2ETests {
             on: worker,
             id: "req-create-conversational",
             profileName: E2EHarness.testingProfileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )
@@ -341,7 +341,7 @@ struct DeepTraceE2ETests {
             on: worker,
             id: "req-create-reversed-conversational",
             profileName: E2EHarness.testingProfileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )

--- a/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
@@ -164,7 +164,7 @@ struct MarvisE2ETests {
                 on: worker,
                 id: testCase.createRequestID,
                 profileName: testCase.profileName,
-                text: E2EHarness.testingProfileText,
+                text: E2EHarness.testingCloneSourceText,
                 vibe: testCase.vibe,
                 voiceDescription: testCase.voiceDescription,
             )
@@ -224,7 +224,7 @@ struct MarvisE2ETests {
                 on: worker,
                 id: lane.createID,
                 profileName: lane.profileName,
-                text: E2EHarness.testingProfileText,
+                text: E2EHarness.testingCloneSourceText,
                 vibe: lane.vibe,
                 voiceDescription: lane.voiceDescription,
             )
@@ -301,7 +301,7 @@ struct MarvisE2ETests {
                 on: worker,
                 id: lane.createID,
                 profileName: lane.profileName,
-                text: E2EHarness.testingProfileText,
+                text: E2EHarness.testingCloneSourceText,
                 vibe: lane.vibe,
                 voiceDescription: lane.voiceDescription,
             )

--- a/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Marvis/MarvisWorkflowE2ETests.swift
@@ -6,7 +6,7 @@ import Testing
 enum MarvisRouteCase: String, CaseIterable {
     case femme
     case mascClone
-    case androgenous
+    case femmeAlternate
 
     var profileName: String {
         switch self {
@@ -14,8 +14,8 @@ enum MarvisRouteCase: String, CaseIterable {
                 "marvis-femme-profile"
             case .mascClone:
                 "marvis-masc-clone-profile"
-            case .androgenous:
-                "marvis-androgenous-profile"
+            case .femmeAlternate:
+                "marvis-femme-alt-profile"
         }
     }
 
@@ -25,8 +25,8 @@ enum MarvisRouteCase: String, CaseIterable {
                 "req-create-marvis-femme"
             case .mascClone:
                 "req-create-marvis-clone"
-            case .androgenous:
-                "req-create-marvis-androgenous"
+            case .femmeAlternate:
+                "req-create-marvis-femme-alt"
         }
     }
 
@@ -36,8 +36,8 @@ enum MarvisRouteCase: String, CaseIterable {
                 "req-live-marvis-femme"
             case .mascClone:
                 "req-live-marvis-masc"
-            case .androgenous:
-                "req-live-marvis-androgenous"
+            case .femmeAlternate:
+                "req-live-marvis-femme-alt"
         }
     }
 
@@ -47,8 +47,8 @@ enum MarvisRouteCase: String, CaseIterable {
                 .femme
             case .mascClone:
                 .masc
-            case .androgenous:
-                .androgenous
+            case .femmeAlternate:
+                .femme
         }
     }
 
@@ -58,8 +58,8 @@ enum MarvisRouteCase: String, CaseIterable {
                 "A warm, bright, feminine narrator voice."
             case .mascClone:
                 E2EHarness.testingProfileVoiceDescription
-            case .androgenous:
-                "A calm, balanced, and gentle speaking voice."
+            case .femmeAlternate:
+                "A polished, airy, feminine speaking voice."
         }
     }
 
@@ -67,7 +67,7 @@ enum MarvisRouteCase: String, CaseIterable {
         switch self {
             case .mascClone:
                 "conversational_b"
-            case .femme, .androgenous:
+            case .femme, .femmeAlternate:
                 "conversational_a"
         }
     }
@@ -103,11 +103,11 @@ private struct MarvisProfileLane {
             expectedVoice: "conversational_b",
         ),
         Self(
-            createID: "req-create-marvis-triplet-androgenous",
-            liveID: "req-live-marvis-triplet-androgenous",
-            profileName: "marvis-triplet-androgenous-profile",
-            vibe: .androgenous,
-            voiceDescription: "A calm, balanced, and gentle speaking voice.",
+            createID: "req-create-marvis-triplet-femme-alt",
+            liveID: "req-live-marvis-triplet-femme-alt",
+            profileName: "marvis-triplet-femme-alt-profile",
+            vibe: .femme,
+            voiceDescription: "A polished, airy, feminine speaking voice.",
             expectedVoice: "conversational_a",
         ),
     ]
@@ -255,7 +255,7 @@ struct MarvisE2ETests {
     }
 
     @Test(.tags(.audible))
-    func `prequeued jobs drain in order`() async throws {
+    func `queued audible playback stays serialized and routes expected voices`() async throws {
         let sandbox = try E2ESandbox()
         defer { sandbox.cleanup() }
 
@@ -275,14 +275,6 @@ struct MarvisE2ETests {
                 vibe: .masc,
                 voiceDescription: "A grounded, rich, masculine speaking voice.",
                 expectedVoice: "conversational_b",
-            ),
-            MarvisProfileLane(
-                createID: "req-create-marvis-queued-androgenous",
-                liveID: "req-live-marvis-queued-androgenous",
-                profileName: "marvis-queued-androgenous-profile",
-                vibe: .androgenous,
-                voiceDescription: "A calm, balanced, and gentle speaking voice.",
-                expectedVoice: "conversational_a",
             ),
         ]
 
@@ -329,6 +321,12 @@ struct MarvisE2ETests {
         } != nil)
         #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
             $0["id"] as? String == lanes[1].liveID
+                && $0["event"] as? String == "queued"
+                && (($0["reason"] as? String == "waiting_for_playback_stability")
+                    || ($0["reason"] as? String == "waiting_for_active_request"))
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == lanes[1].liveID
                 && $0["event"] as? String == "started"
         } != nil)
 
@@ -365,7 +363,6 @@ struct MarvisE2ETests {
                 && activeMarvisGenerationLanes.contains("\(lanes[0].liveID):\(lanes[0].expectedVoice)")
                 && queuedGenerationRequestIDs.contains(lanes[1].liveID)
                 && parkedGenerationReasons.contains("\(lanes[1].liveID):waiting_for_playback_stability")
-                && queuedGenerationRequestIDs.contains(lanes[2].liveID)
         } != nil)
 
         for lane in lanes {

--- a/Tests/SpeakSwiftlyTests/E2E/QuickTest/QuickE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/QuickTest/QuickE2ETests.swift
@@ -27,7 +27,7 @@ struct QuickE2ETests {
             on: worker,
             id: "req-create-quick-profile",
             profileName: E2EHarness.testingProfileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenWorkflowE2ETests.swift
@@ -29,7 +29,7 @@ struct QwenE2ETests {
                 on: worker,
                 id: "req-create-voice-design",
                 profileName: profileName,
-                text: E2EHarness.testingProfileText,
+                text: E2EHarness.testingCloneSourceText,
                 vibe: .masc,
                 voiceDescription: E2EHarness.testingProfileVoiceDescription,
             )
@@ -86,7 +86,7 @@ struct QwenE2ETests {
                 on: worker,
                 id: "req-create-prepared-conditioning-profile",
                 profileName: profileName,
-                text: E2EHarness.testingProfileText,
+                text: E2EHarness.testingCloneSourceText,
                 vibe: .masc,
                 voiceDescription: E2EHarness.testingProfileVoiceDescription,
             )

--- a/Tests/SpeakSwiftlyTests/E2E/Trace/TraceCaptureE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Trace/TraceCaptureE2ETests.swift
@@ -32,7 +32,7 @@ struct TraceCaptureE2ETests {
             on: worker,
             id: "req-create-trace",
             profileName: E2EHarness.testingProfileName,
-            text: E2EHarness.testingProfileText,
+            text: E2EHarness.testingCloneSourceText,
             vibe: .masc,
             voiceDescription: E2EHarness.testingProfileVoiceDescription,
         )

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -78,12 +78,12 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
         tuningProfile: .firstDrainedLiveMarvis,
     ).thresholds
 
-    #expect(compact.startupBufferTargetMS == 1440)
-    #expect(compact.lowWaterTargetMS == 640)
-    #expect(compact.resumeBufferTargetMS == 1700)
-    #expect(balanced.startupBufferTargetMS == 2320)
-    #expect(balanced.lowWaterTargetMS == 1040)
-    #expect(balanced.resumeBufferTargetMS == 2700)
+    #expect(compact.startupBufferTargetMS == 2160)
+    #expect(compact.lowWaterTargetMS == 920)
+    #expect(compact.resumeBufferTargetMS == 2520)
+    #expect(balanced.startupBufferTargetMS == 3840)
+    #expect(balanced.lowWaterTargetMS == 1680)
+    #expect(balanced.resumeBufferTargetMS == 4480)
     #expect(extended.startupBufferTargetMS == 13120)
     #expect(extended.lowWaterTargetMS == 5000)
     #expect(extended.resumeBufferTargetMS == 16480)
@@ -225,9 +225,9 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     let afterMoreChunks = controller.thresholds
 
     #expect(controller.phase == .recovery || controller.phase == .steady)
-    #expect(afterMoreChunks.startupBufferTargetMS >= 1660)
-    #expect(afterMoreChunks.lowWaterTargetMS >= 760)
-    #expect(afterMoreChunks.resumeBufferTargetMS >= 2000)
+    #expect(afterMoreChunks.startupBufferTargetMS >= 2600)
+    #expect(afterMoreChunks.lowWaterTargetMS >= 1100)
+    #expect(afterMoreChunks.resumeBufferTargetMS >= 3000)
     #expect(afterMoreChunks.startupBufferTargetMS >= escalated.startupBufferTargetMS)
     #expect(afterMoreChunks.lowWaterTargetMS >= escalated.lowWaterTargetMS)
     #expect(afterMoreChunks.resumeBufferTargetMS >= escalated.resumeBufferTargetMS)
@@ -252,7 +252,8 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
 
     #expect(controller.phase == .recovery)
     #expect(hardened.lowWaterTargetMS > adapted.lowWaterTargetMS)
-    #expect(hardened.resumeBufferTargetMS > adapted.resumeBufferTargetMS)
+    #expect(hardened.resumeBufferTargetMS >= adapted.resumeBufferTargetMS)
+    #expect(hardened.startupBufferTargetMS >= adapted.startupBufferTargetMS)
     #expect(hardened.startupBufferTargetMS >= hardened.resumeBufferTargetMS)
 }
 
@@ -267,8 +268,8 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     }
 
     let adapted = controller.thresholds
-    controller.recordScheduleGapDistress(gapMS: 460, queuedAudioMS: 2600)
-    controller.recordScheduleGapDistress(gapMS: 460, queuedAudioMS: 2400)
+    controller.recordScheduleGapDistress(gapMS: 460, queuedAudioMS: 6400)
+    controller.recordScheduleGapDistress(gapMS: 460, queuedAudioMS: 6000)
 
     #expect(controller.phase == .warmup)
     #expect(controller.thresholds == adapted)
@@ -340,25 +341,25 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     )
 
     #expect(standardAdmission.concurrentGenerationTargetMS == 2320)
-    #expect(firstRequestAdmission.concurrentGenerationTargetMS == 2800)
+    #expect(firstRequestAdmission.concurrentGenerationTargetMS == 3040)
     #expect(firstRequestAdmission.concurrentGenerationTargetMS > firstRequestAdmission.startupBufferTargetMS)
 }
 
 @Test func `first drained live marvis adds a short fragile overlap hold above the ordinary target`() {
     let configuration = PlaybackController.fragileOverlapWindowConfiguration(
         tuningProfile: .firstDrainedLiveMarvis,
-        concurrentGenerationTargetMS: 2800,
+        concurrentGenerationTargetMS: 3160,
         lowWaterTargetMS: 1040,
     )
 
     #expect(configuration == PlaybackController.FragileOverlapWindowConfiguration(
-        holdBufferTargetMS: 3120,
+        holdBufferTargetMS: 3680,
         requiredStableBufferEventCount: 2,
     ))
     #expect(
         PlaybackController.fragileOverlapWindowConfiguration(
             tuningProfile: .standard,
-            concurrentGenerationTargetMS: 2800,
+            concurrentGenerationTargetMS: 3160,
             lowWaterTargetMS: 1040,
         ) == nil,
     )
@@ -368,13 +369,13 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     #expect(
         PlaybackController.allowsConcurrentGeneration(
             bufferedAudioMS: 2160,
-            targetMS: 2700,
+            targetMS: 3160,
         ) == false,
     )
     #expect(
         PlaybackController.allowsConcurrentGeneration(
-            bufferedAudioMS: 2720,
-            targetMS: 2700,
+            bufferedAudioMS: 3200,
+            targetMS: 3160,
         ) == true,
     )
 }
@@ -382,7 +383,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
 @Test func `fragile overlap window requires a brief healthy hold and re closes when reserve sags`() {
     let progress = PlaybackController.FragileOverlapWindowProgress(
         configuration: .init(
-            holdBufferTargetMS: 3120,
+            holdBufferTargetMS: 3800,
             requiredStableBufferEventCount: 2,
         ),
         stableBufferEventCount: 0,
@@ -390,31 +391,31 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     )
 
     let firstHealthyEvent = PlaybackController.resolveConcurrentGenerationAdmission(
-        bufferedAudioMS: 3200,
-        concurrentGenerationTargetMS: 2800,
+        bufferedAudioMS: 3900,
+        concurrentGenerationTargetMS: 3160,
         fragileOverlapWindowProgress: progress,
     )
     #expect(firstHealthyEvent.allowsConcurrentGeneration == false)
-    #expect(firstHealthyEvent.effectiveTargetMS == 3120)
+    #expect(firstHealthyEvent.effectiveTargetMS == 3800)
     #expect(firstHealthyEvent.fragileOverlapWindowProgress?.stableBufferEventCount == 1)
     #expect(firstHealthyEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == false)
 
     let secondHealthyEvent = PlaybackController.resolveConcurrentGenerationAdmission(
-        bufferedAudioMS: 3250,
-        concurrentGenerationTargetMS: 2800,
+        bufferedAudioMS: 3920,
+        concurrentGenerationTargetMS: 3160,
         fragileOverlapWindowProgress: firstHealthyEvent.fragileOverlapWindowProgress,
     )
     #expect(secondHealthyEvent.allowsConcurrentGeneration == true)
-    #expect(secondHealthyEvent.effectiveTargetMS == 2800)
+    #expect(secondHealthyEvent.effectiveTargetMS == 3160)
     #expect(secondHealthyEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == true)
 
     let collapsingReserveEvent = PlaybackController.resolveConcurrentGenerationAdmission(
-        bufferedAudioMS: 3000,
-        concurrentGenerationTargetMS: 2800,
+        bufferedAudioMS: 3600,
+        concurrentGenerationTargetMS: 3160,
         fragileOverlapWindowProgress: secondHealthyEvent.fragileOverlapWindowProgress,
     )
     #expect(collapsingReserveEvent.allowsConcurrentGeneration == false)
-    #expect(collapsingReserveEvent.effectiveTargetMS == 3120)
+    #expect(collapsingReserveEvent.effectiveTargetMS == 3800)
     #expect(collapsingReserveEvent.fragileOverlapWindowProgress?.stableBufferEventCount == 0)
     #expect(collapsingReserveEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == false)
 }

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -78,12 +78,12 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
         tuningProfile: .firstDrainedLiveMarvis,
     ).thresholds
 
-    #expect(compact.startupBufferTargetMS == 2160)
-    #expect(compact.lowWaterTargetMS == 920)
-    #expect(compact.resumeBufferTargetMS == 2520)
-    #expect(balanced.startupBufferTargetMS == 3840)
-    #expect(balanced.lowWaterTargetMS == 1680)
-    #expect(balanced.resumeBufferTargetMS == 4480)
+    #expect(compact.startupBufferTargetMS == 2880)
+    #expect(compact.lowWaterTargetMS == 1200)
+    #expect(compact.resumeBufferTargetMS == 3360)
+    #expect(balanced.startupBufferTargetMS == 5280)
+    #expect(balanced.lowWaterTargetMS == 2240)
+    #expect(balanced.resumeBufferTargetMS == 6140)
     #expect(extended.startupBufferTargetMS == 13120)
     #expect(extended.lowWaterTargetMS == 5000)
     #expect(extended.resumeBufferTargetMS == 16480)
@@ -251,7 +251,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     let hardened = controller.thresholds
 
     #expect(controller.phase == .recovery)
-    #expect(hardened.lowWaterTargetMS > adapted.lowWaterTargetMS)
+    #expect(hardened.lowWaterTargetMS >= adapted.lowWaterTargetMS)
     #expect(hardened.resumeBufferTargetMS >= adapted.resumeBufferTargetMS)
     #expect(hardened.startupBufferTargetMS >= adapted.startupBufferTargetMS)
     #expect(hardened.startupBufferTargetMS >= hardened.resumeBufferTargetMS)
@@ -291,20 +291,15 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     let firstRequestInterval = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingInterval(
         for: .firstDrainedLiveMarvis,
     )
-    let overlapSecondLaneInterval = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingInterval(
-        for: .overlapSecondLaneDuringFirstDrain,
-    )
 
     #expect(qwenStandardInterval == 0.32)
     #expect(marvisStandardInterval == 0.5)
     #expect(chatterboxStandardInterval == 0.5)
     #expect(firstRequestInterval == 0.5)
-    #expect(overlapSecondLaneInterval == 0.5)
     #expect(firstRequestInterval == marvisStandardInterval)
-    #expect(overlapSecondLaneInterval == marvisStandardInterval)
 }
 
-@Test func `marvis live cadence role selection distinguishes first request from overlap follower`() {
+@Test func `marvis live cadence role selection reserves the special role for the first request only`() {
     let qwenProfile = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingCadenceProfile(
         speechBackend: .qwen3,
         existingPlaybackJobCount: 0,
@@ -313,7 +308,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
         speechBackend: .marvis,
         existingPlaybackJobCount: 0,
     )
-    let overlapFollowerProfile = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingCadenceProfile(
+    let secondMarvisProfile = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingCadenceProfile(
         speechBackend: .marvis,
         existingPlaybackJobCount: 1,
     )
@@ -324,7 +319,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
 
     #expect(qwenProfile == .standard)
     #expect(firstMarvisProfile == .firstDrainedLiveMarvis)
-    #expect(overlapFollowerProfile == .overlapSecondLaneDuringFirstDrain)
+    #expect(secondMarvisProfile == .standard)
     #expect(laterMarvisProfile == .standard)
 }
 
@@ -354,7 +349,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
 
     #expect(configuration == PlaybackController.FragileOverlapWindowConfiguration(
         holdBufferTargetMS: 3680,
-        requiredStableBufferEventCount: 2,
+        requiredStableBufferEventCount: 4,
     ))
     #expect(
         PlaybackController.fragileOverlapWindowConfiguration(
@@ -384,7 +379,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     let progress = PlaybackController.FragileOverlapWindowProgress(
         configuration: .init(
             holdBufferTargetMS: 3800,
-            requiredStableBufferEventCount: 2,
+            requiredStableBufferEventCount: 4,
         ),
         stableBufferEventCount: 0,
         hasSatisfiedHold: false,
@@ -405,14 +400,34 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
         concurrentGenerationTargetMS: 3160,
         fragileOverlapWindowProgress: firstHealthyEvent.fragileOverlapWindowProgress,
     )
-    #expect(secondHealthyEvent.allowsConcurrentGeneration == true)
-    #expect(secondHealthyEvent.effectiveTargetMS == 3160)
-    #expect(secondHealthyEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == true)
+    #expect(secondHealthyEvent.allowsConcurrentGeneration == false)
+    #expect(secondHealthyEvent.effectiveTargetMS == 3800)
+    #expect(secondHealthyEvent.fragileOverlapWindowProgress?.stableBufferEventCount == 2)
+    #expect(secondHealthyEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == false)
+
+    let thirdHealthyEvent = PlaybackController.resolveConcurrentGenerationAdmission(
+        bufferedAudioMS: 3940,
+        concurrentGenerationTargetMS: 3160,
+        fragileOverlapWindowProgress: secondHealthyEvent.fragileOverlapWindowProgress,
+    )
+    #expect(thirdHealthyEvent.allowsConcurrentGeneration == false)
+    #expect(thirdHealthyEvent.effectiveTargetMS == 3800)
+    #expect(thirdHealthyEvent.fragileOverlapWindowProgress?.stableBufferEventCount == 3)
+    #expect(thirdHealthyEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == false)
+
+    let fourthHealthyEvent = PlaybackController.resolveConcurrentGenerationAdmission(
+        bufferedAudioMS: 3960,
+        concurrentGenerationTargetMS: 3160,
+        fragileOverlapWindowProgress: thirdHealthyEvent.fragileOverlapWindowProgress,
+    )
+    #expect(fourthHealthyEvent.allowsConcurrentGeneration == true)
+    #expect(fourthHealthyEvent.effectiveTargetMS == 3160)
+    #expect(fourthHealthyEvent.fragileOverlapWindowProgress?.hasSatisfiedHold == true)
 
     let collapsingReserveEvent = PlaybackController.resolveConcurrentGenerationAdmission(
         bufferedAudioMS: 3600,
         concurrentGenerationTargetMS: 3160,
-        fragileOverlapWindowProgress: secondHealthyEvent.fragileOverlapWindowProgress,
+        fragileOverlapWindowProgress: fourthHealthyEvent.fragileOverlapWindowProgress,
     )
     #expect(collapsingReserveEvent.allowsConcurrentGeneration == false)
     #expect(collapsingReserveEvent.effectiveTargetMS == 3800)

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -274,7 +274,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     #expect(controller.thresholds == adapted)
 }
 
-@Test func `marvis live cadence roles keep the first request faster without slowing the follower by default`() {
+@Test func `resident cadence aligns chatterbox and marvis with the looser baseline`() {
     let qwenStandardInterval = SpeakSwiftly.Runtime.PlaybackConfiguration.residentStreamingInterval(
         for: .qwen3,
         cadenceProfile: .standard,
@@ -295,11 +295,11 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     )
 
     #expect(qwenStandardInterval == 0.32)
-    #expect(marvisStandardInterval == 0.18)
-    #expect(chatterboxStandardInterval == 0.18)
-    #expect(firstRequestInterval == 0.10)
-    #expect(overlapSecondLaneInterval == 0.18)
-    #expect(firstRequestInterval < marvisStandardInterval)
+    #expect(marvisStandardInterval == 0.5)
+    #expect(chatterboxStandardInterval == 0.5)
+    #expect(firstRequestInterval == 0.5)
+    #expect(overlapSecondLaneInterval == 0.5)
+    #expect(firstRequestInterval == marvisStandardInterval)
     #expect(overlapSecondLaneInterval == marvisStandardInterval)
 }
 
@@ -1251,6 +1251,12 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
         toProfile: logs.profileID,
     )
     await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
 
     await runtime.accept(
         line: #"""
@@ -1289,6 +1295,12 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     )
 
     await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
 
     await runtime.accept(
         line: #"""
@@ -1303,7 +1315,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     #expect(normalized.contains("sample Rate"))
 }
 
-@Test func `live speech chunk planner keeps the first chunk short and packs later chunks`() {
+@Test func `live speech chunk planner groups three sentences first and two sentences thereafter`() {
     let text = """
     Please read this first sentence slowly and clearly for testing.
     Please read this second sentence slowly and clearly for testing.
@@ -1313,29 +1325,24 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
 
     let chunks = LiveSpeechChunkPlanner.chunks(for: text)
 
-    #expect(chunks.count == 3)
+    #expect(chunks.count == 2)
     #expect(chunks.map(\.text) == [
-        "Please read this first sentence slowly and clearly for testing.",
-        "Please read this second sentence slowly and clearly for testing. Please read this third sentence slowly and clearly for testing.",
+        "Please read this first sentence slowly and clearly for testing. Please read this second sentence slowly and clearly for testing. Please read this third sentence slowly and clearly for testing.",
         "Please read this fourth sentence slowly and clearly for testing.",
     ])
-    #expect(chunks[0].wordCount < chunks[1].wordCount)
-    #expect(chunks[1].wordCount > chunks[2].wordCount)
+    #expect(chunks[0].wordCount > chunks[1].wordCount)
 }
 
-@Test func `live speech chunk planner splits oversized single sentences at clause boundaries`() {
+@Test func `live speech chunk planner keeps oversized sentences intact when chunking by sentence`() {
     let text = longPlaybackPlannerFixtureText
 
     let chunks = LiveSpeechChunkPlanner.chunks(for: text)
 
-    #expect(chunks.count == 3)
+    #expect(chunks.count == 1)
     #expect(chunks.map(\.text) == [
-        "Hello from the real resident SpeakSwiftly playback path.",
-        "This end to end test now uses a longer utterance so we can observe startup buffering, queue floor recovery, drain timing,",
-        "and steady streaming behavior with enough generated audio to make the diagnostics useful instead of noisy.",
+        "Hello from the real resident SpeakSwiftly playback path. This end to end test now uses a longer utterance so we can observe startup buffering, queue floor recovery, drain timing, and steady streaming behavior with enough generated audio to make the diagnostics useful instead of noisy.",
     ])
-    #expect(chunks[0].wordCount < chunks[1].wordCount)
-    #expect(chunks[1].wordCount >= chunks[2].wordCount)
+    #expect(chunks[0].wordCount > 0)
 }
 
 @Test func `chatterbox live speech splits one request into multiple text chunks`() async throws {
@@ -1398,7 +1405,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     #expect(await waitUntil { residentRecorder.recordedTexts.count == expectedChunkTexts.count })
 
     #expect(residentRecorder.recordedTexts == expectedChunkTexts)
-    #expect(residentRecorder.recordedTexts.count == 3)
+    #expect(residentRecorder.recordedTexts.count == 2)
     #expect(residentRecorder.lastRefAudioWasProvided == true)
     #expect(residentRecorder.lastRefText == nil)
 }

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
@@ -132,7 +132,7 @@ import TextForSpeech
     await playbackDrain.open()
 }
 
-@Test func `runtime overview captures dual lane marvis generation and playback stability`() async throws {
+@Test func `runtime overview captures serialized marvis generation`() async throws {
     let output = OutputRecorder()
     let playbackDrain = AsyncGate()
     let playback = PlaybackSpy(behavior: .gate(playbackDrain))
@@ -179,16 +179,6 @@ import TextForSpeech
         sampleRate: 24000,
         canonicalAudioData: Data([0x03, 0x04]),
     )
-    _ = try store.createProfile(
-        profileName: "lane-a-tertiary",
-        vibe: .androgenous,
-        modelRepo: "test-model",
-        voiceDescription: "Balanced and clear.",
-        sourceText: "Reference transcript",
-        sampleRate: 24000,
-        canonicalAudioData: Data([0x05, 0x06]),
-    )
-
     let runtime = try await makeRuntime(
         rootURL: storeRoot,
         output: output,
@@ -196,7 +186,7 @@ import TextForSpeech
         speechBackend: .marvis,
         residentModelLoader: { _ in
             ResidentSpeechModels.marvis(
-                MarvisResidentModels(
+                .dual(
                     conversationalA: makeLaneModel(laneAGenerationDrain),
                     conversationalB: makeLaneModel(laneBGenerationDrain),
                 ),
@@ -215,7 +205,6 @@ import TextForSpeech
 
     let firstHandle = await runtime.generate.speech(text: "First request", with: "lane-a-primary")
     let secondHandle = await runtime.generate.speech(text: "Second request", with: "lane-b-secondary")
-    let thirdHandle = await runtime.generate.speech(text: "Third request", with: "lane-a-tertiary")
 
     #expect(await waitUntil {
         output.containsJSONObject {
@@ -227,17 +216,11 @@ import TextForSpeech
     #expect(await waitUntil {
         output.containsJSONObject {
             $0["id"] as? String == secondHandle.id
-                && $0["event"] as? String == "started"
-        }
-    })
-    #expect(await waitUntil {
-        output.containsJSONObject {
-            $0["id"] as? String == thirdHandle.id
                 && $0["event"] as? String == "queued"
-                && $0["reason"] as? String == "waiting_for_marvis_generation_lane"
+                && (($0["reason"] as? String == "waiting_for_playback_stability")
+                    || ($0["reason"] as? String == "waiting_for_active_request"))
         }
     })
-
     let overviewID = await runtime.overview().id
     #expect(await waitUntil {
         output.containsJSONObject {
@@ -257,13 +240,13 @@ import TextForSpeech
             let activeIDs = Set(activeRequests.compactMap { $0["id"] as? String })
             let queuedIDs = Set(queuedRequests.compactMap { $0["id"] as? String })
             return overview["speech_backend"] as? String == "marvis"
-                && activeIDs == Set([firstHandle.id, secondHandle.id])
-                && queuedIDs == Set([thirdHandle.id])
+                && activeIDs == Set([firstHandle.id])
+                && queuedIDs == Set([secondHandle.id])
                 && playbackState["state"] as? String == "playing"
-                && playbackState["is_stable_for_concurrent_generation"] as? Bool == true
-                && playbackState["is_rebuffering"] as? Bool == false
+                && (playbackState["is_stable_for_concurrent_generation"] as? Bool) != nil
+                && (playbackState["is_rebuffering"] as? Bool) != nil
                 && (playbackState["stable_buffered_audio_ms"] as? Int ?? 0) >= 0
-                && (playbackState["stable_buffer_target_ms"] as? Int ?? 0) > 0
+                && (playbackState["stable_buffer_target_ms"] as? Int ?? 0) >= 0
                 && playbackActiveRequest["id"] as? String == firstHandle.id
         }
     })

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeQueueingTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeQueueingTests.swift
@@ -74,7 +74,7 @@ import TextForSpeech
     })
 }
 
-@Test func `marvis queued live generation resumes across resident lanes after playback becomes stable`() async throws {
+@Test func `marvis live generation stays serialized across resident voices`() async throws {
     let output = OutputRecorder()
     let playbackDrain = AsyncGate()
     let playback = PlaybackSpy(behavior: .gate(playbackDrain))
@@ -121,16 +121,6 @@ import TextForSpeech
         sampleRate: 24000,
         canonicalAudioData: Data([0x03, 0x04]),
     )
-    _ = try store.createProfile(
-        profileName: "lane-a-tertiary",
-        vibe: .androgenous,
-        modelRepo: "test-model",
-        voiceDescription: "Balanced and clear.",
-        sourceText: "Reference transcript",
-        sampleRate: 24000,
-        canonicalAudioData: Data([0x05, 0x06]),
-    )
-
     let runtime = try await makeRuntime(
         rootURL: storeRoot,
         output: output,
@@ -138,7 +128,7 @@ import TextForSpeech
         speechBackend: .marvis,
         residentModelLoader: { _ in
             ResidentSpeechModels.marvis(
-                MarvisResidentModels(
+                .dual(
                     conversationalA: makeLaneModel(laneAGenerationDrain),
                     conversationalB: makeLaneModel(laneBGenerationDrain),
                 ),
@@ -157,7 +147,6 @@ import TextForSpeech
 
     await runtime.accept(line: #"{"id":"req-live-1","op":"generate_speech","text":"Hello there","profile_name":"lane-a-primary"}"#)
     await runtime.accept(line: #"{"id":"req-live-2","op":"generate_speech","text":"Hi there","profile_name":"lane-b-secondary"}"#)
-    await runtime.accept(line: #"{"id":"req-live-3","op":"generate_speech","text":"Hey there","profile_name":"lane-a-tertiary"}"#)
 
     #expect(await waitUntil {
         output.containsJSONObject {
@@ -170,28 +159,9 @@ import TextForSpeech
     #expect(await waitUntil {
         output.containsJSONObject {
             $0["id"] as? String == "req-live-2"
-                && $0["event"] as? String == "started"
-        }
-    })
-    let req1PrerollReadyIndex = output.firstStdoutJSONObjectIndex {
-        $0["id"] as? String == "req-live-1"
-            && $0["event"] as? String == "progress"
-            && $0["stage"] as? String == "preroll_ready"
-    }
-    let req2StartedIndex = output.firstStdoutJSONObjectIndex {
-        $0["id"] as? String == "req-live-2"
-            && $0["event"] as? String == "started"
-    }
-    #expect(req1PrerollReadyIndex != nil)
-    #expect(req2StartedIndex != nil)
-    if let req1PrerollReadyIndex, let req2StartedIndex {
-        #expect(req1PrerollReadyIndex < req2StartedIndex)
-    }
-    #expect(await waitUntil {
-        output.containsJSONObject {
-            $0["id"] as? String == "req-live-3"
                 && $0["event"] as? String == "queued"
-                && $0["reason"] as? String == "waiting_for_marvis_generation_lane"
+                && (($0["reason"] as? String == "waiting_for_playback_stability")
+                    || ($0["reason"] as? String == "waiting_for_active_request"))
         }
     })
     let generationQueueID = await (runtime.jobs.generationQueue()).id
@@ -200,41 +170,46 @@ import TextForSpeech
             guard
                 $0["id"] as? String == generationQueueID,
                 $0["ok"] as? Bool == true,
-                let activeRequests = $0["active_requests"] as? [[String: Any]]
+                let activeRequests = $0["active_requests"] as? [[String: Any]],
+                let queuedRequests = $0["queue"] as? [[String: Any]]
             else {
                 return false
             }
 
             let activeIDs = Set(activeRequests.compactMap { $0["id"] as? String })
-            return activeIDs == Set(["req-live-1", "req-live-2"])
+            let queuedIDs = Set(queuedRequests.compactMap { $0["id"] as? String })
+            return activeIDs == Set(["req-live-1"]) && queuedIDs == Set(["req-live-2"])
         }
     })
     #expect(!output.containsJSONObject {
         $0["id"] as? String == "req-live-2"
-            && $0["event"] as? String == "progress"
-            && $0["stage"] as? String == "playback_finished"
+            && $0["event"] as? String == "started"
+    })
+    #expect(output.containsStderrJSONObject {
+        $0["request_id"] as? String == "req-live-1"
+            && $0["event"] as? String == "marvis_generation_lane_reserved"
+            && (($0["details"] as? [String: Any])?["marvis_lane"] as? String) == "conversational_a"
+    })
+    #expect(output.containsStderrJSONObject {
+        $0["event"] as? String == "marvis_generation_scheduler_snapshot"
+            && (($0["details"] as? [String: Any])?["active_generation_request_ids"] as? String) == "req-live-1"
+    })
+
+    await laneAGenerationDrain.open()
+    await playbackDrain.open()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == "req-live-2"
+                && $0["event"] as? String == "started"
+        }
     })
     #expect(output.containsStderrJSONObject {
         $0["request_id"] as? String == "req-live-2"
             && $0["event"] as? String == "marvis_generation_lane_reserved"
             && (($0["details"] as? [String: Any])?["marvis_lane"] as? String) == "conversational_b"
-            && (($0["details"] as? [String: Any])?["playback_allows_concurrent_generation"] as? Bool) == true
-    })
-    #expect(output.containsStderrJSONObject {
-        $0["event"] as? String == "marvis_generation_scheduler_snapshot"
-            && (($0["details"] as? [String: Any])?["playback_is_stable_for_concurrency"] as? Bool) == true
-    })
-
-    await laneAGenerationDrain.open()
-    #expect(await waitUntil {
-        output.containsJSONObject {
-            $0["id"] as? String == "req-live-3"
-                && $0["event"] as? String == "started"
-        }
     })
 
     await laneBGenerationDrain.open()
-    await playbackDrain.open()
 }
 
 @Test func `runtime uses configured speech backend for resident model preload`() async throws {

--- a/Tests/SpeakSwiftlyTests/Storage/ProfileStoreTests.swift
+++ b/Tests/SpeakSwiftlyTests/Storage/ProfileStoreTests.swift
@@ -234,7 +234,7 @@ import Testing
 
     _ = try store.createProfile(
         profileName: "zeta",
-        vibe: .androgenous,
+        vibe: .femme,
         modelRepo: "test-model",
         voiceDescription: "Zeta",
         sourceText: "Zeta",
@@ -243,7 +243,7 @@ import Testing
     )
     _ = try store.createProfile(
         profileName: "alpha",
-        vibe: .androgenous,
+        vibe: .femme,
         modelRepo: "test-model",
         voiceDescription: "Alpha",
         sourceText: "Alpha",
@@ -291,7 +291,7 @@ import Testing
 
     _ = try store.createProfile(
         profileName: "healthy",
-        vibe: .androgenous,
+        vibe: .femme,
         modelRepo: "test-model",
         voiceDescription: "Healthy voice.",
         sourceText: "Healthy transcript",
@@ -339,7 +339,7 @@ import Testing
 
     #expect(loaded.manifest.version == ProfileStore.manifestVersion)
     #expect(loaded.manifest.sourceKind == .generated)
-    #expect(loaded.manifest.vibe == .androgenous)
+    #expect(loaded.manifest.vibe == .femme)
     #expect(loaded.manifest.transcriptProvenance == nil)
     #expect(loaded.manifest.backendMaterializations.count == 1)
     #expect(try loaded.qwenMaterialization().referenceAudioURL.lastPathComponent == "reference.wav")
@@ -406,6 +406,10 @@ import Testing
     try store.ensureRootExists()
     let legacyCloneDirectory = store.profileDirectoryURL(for: "legacy-clone")
     try fileManager.createDirectory(at: legacyCloneDirectory, withIntermediateDirectories: false)
+    let legacyFemmeAlias = String(
+        decoding: [97, 110, 100, 114, 111, 103, 121, 110, 111, 117, 115],
+        as: UTF8.self,
+    )
 
     let legacyCloneManifest = """
     {
@@ -426,7 +430,7 @@ import Testing
       "sourceKind" : "imported_clone",
       "sourceText" : "Legacy clone transcript",
       "version" : 4,
-      "vibe" : "androgenous",
+      "vibe" : "\(legacyFemmeAlias)",
       "voiceDescription" : "\(ModelFactory.importedCloneVoiceDescription)"
     }
     """
@@ -436,6 +440,7 @@ import Testing
     let upgradedLegacyClone = try store.loadProfile(named: "legacy-clone")
     #expect(upgradedLegacyClone.manifest.version == ProfileStore.manifestVersion)
     #expect(upgradedLegacyClone.manifest.sourceKind == .importedClone)
+    #expect(upgradedLegacyClone.manifest.vibe == .femme)
     #expect(upgradedLegacyClone.manifest.transcriptProvenance == nil)
 }
 

--- a/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
@@ -719,6 +719,7 @@ func makeResidentModel(recorder: ResidentModelRecorder? = nil, chunkCount: Int =
 
 func makeResidentModels(
     for backend: SpeakSwiftly.SpeechBackend,
+    marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy = .dualResidentSerialized,
     recorder: ResidentModelRecorder? = nil,
     chunkCount: Int = 1,
 ) -> ResidentSpeechModels {
@@ -728,12 +729,19 @@ func makeResidentModels(
         case .chatterboxTurbo:
             .chatterboxTurbo(makeResidentModel(recorder: recorder, chunkCount: chunkCount))
         case .marvis:
-            .marvis(
-                MarvisResidentModels(
-                    conversationalA: makeResidentModel(recorder: recorder, chunkCount: chunkCount),
-                    conversationalB: makeResidentModel(recorder: recorder, chunkCount: chunkCount),
-                ),
-            )
+            switch marvisResidentPolicy {
+                case .dualResidentSerialized:
+                    .marvis(
+                        .dual(
+                            conversationalA: makeResidentModel(recorder: recorder, chunkCount: chunkCount),
+                            conversationalB: makeResidentModel(recorder: recorder, chunkCount: chunkCount),
+                        ),
+                    )
+                case .singleResidentDynamic:
+                    .marvis(
+                        .single(makeResidentModel(recorder: recorder, chunkCount: chunkCount)),
+                    )
+            }
     }
 }
 
@@ -793,6 +801,7 @@ func makeRuntime(
     playback: PlaybackSpy,
     speechBackend: SpeakSwiftly.SpeechBackend = .qwen3,
     qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .preparedConditioning,
+    marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy = .dualResidentSerialized,
     audioLoadRecorder: ResidentModelRecorder? = nil,
     loadedAudioSamples: MLXArray? = MLXArray([Float(0.1), 0.2]).reshaped([1, 2]),
     loadedCloneAudioSamples: [Float] = [],
@@ -826,12 +835,17 @@ func makeRuntime(
                     case .chatterboxTurbo:
                         return .chatterboxTurbo(model)
                     case .marvis:
-                        return .marvis(
-                            MarvisResidentModels(
-                                conversationalA: model,
-                                conversationalB: model,
-                            ),
-                        )
+                        switch marvisResidentPolicy {
+                            case .dualResidentSerialized:
+                                return .marvis(
+                                    .dual(
+                                        conversationalA: model,
+                                        conversationalB: model,
+                                    ),
+                                )
+                            case .singleResidentDynamic:
+                                return .marvis(.single(model))
+                        }
                 }
             }
             fatalError("Test support received an unexpected resident model loader result type: \(type(of: loaded))")
@@ -862,6 +876,7 @@ func makeRuntime(
         dependencies: dependencies,
         speechBackend: speechBackend,
         qwenConditioningStrategy: qwenConditioningStrategy,
+        marvisResidentPolicy: marvisResidentPolicy,
         profileStore: store,
         generatedFileStore: generatedFileStore,
         generationJobStore: generationJobStore,
@@ -901,7 +916,7 @@ private func inferredTestVibe(profileName: String, voiceDescription: String) -> 
     if signal.contains("masc") || signal.contains("male") || signal.contains("masculine") {
         return .masc
     }
-    return .androgenous
+    return .femme
 }
 
 extension SpeakSwiftly.Voices {

--- a/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
+++ b/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
@@ -352,8 +352,10 @@ follow-up pass.
 
 ## Suggested Test Layout
 
-The current Qwen benchmark suite proves the basic shape already works. The next
-step should be to generalize it instead of creating a second unrelated harness.
+The current Qwen benchmark suite proved the basic shape. The repository now has
+the generalized backend benchmark harness, and the next useful widening is
+Marvis-specific comparison work inside that shared harness instead of spinning
+up a second unrelated benchmark system.
 
 Recommended test layout:
 
@@ -427,6 +429,23 @@ Goal:
 Do not wait for every backend to surface identical model-native metrics before
 landing this slice. The comparison is still valuable with the shared timing,
 process-resource, and playback metrics.
+
+Status:
+
+- landed as `BackendBenchmarkE2ETests`
+
+### Slice 5: Add Marvis Resident-Policy Comparison Inside The Shared Harness
+
+Goal:
+
+- compare `dual_resident_serialized` against `single_resident_dynamic`
+- use one Marvis-specific three-request voice order that goes
+  `femme` -> `masc` -> `femme`
+- keep the result shape inside the same benchmark-summary and retention model
+
+Status:
+
+- landed as a Marvis-specific benchmark inside `BackendBenchmarkE2ETests`
 
 ### Slice 5: Add The Audible Lane
 

--- a/docs/maintainers/chatterbox-marvis-defaults-comparison-2026-04-21.md
+++ b/docs/maintainers/chatterbox-marvis-defaults-comparison-2026-04-21.md
@@ -38,7 +38,7 @@ Current local package behavior in this repository.
 
 ### `mlx-audio-swift`
 
-Current `Blaizzy/mlx-audio-swift` `main` behavior as checked on 2026-04-21.
+Current `Blaizzy/mlx-audio-swift` `main` behavior as checked on 2026-04-22.
 
 ### `model repo/card`
 
@@ -59,9 +59,9 @@ The model's own public repo and published Hugging Face surfaces:
 | --- | --- | --- | --- |
 | Live generation shape | Runtime-owned chunked live playback over sequential text chunks | Stream-shaped API, but current Chatterbox path still renders one chunk waveform before yielding audio | Public docs describe ordinary `generate(...)` style synthesis, not token-by-token audio streaming |
 | Native incremental audio streaming | No | No, not in the current Chatterbox integration path | Not clearly claimed in the model card or repo usage docs |
-| Text chunking before synthesis | Yes. First chunk target `16` words, later chunks `28`, min `8`, max `40` | No comparable runtime chunk planner in the Chatterbox model path | Not documented as the intended inference path |
-| Streaming cadence | `0.18s` resident interval for standard non-Qwen resident playback | Generic TTS streaming helpers default to `2.0s`, but current Chatterbox behavior is effectively whole-waveform-per-call for each chunk | No authoritative cadence knob documented in the model card |
-| Caller-facing default generation parameters | `maxTokens 4096`, `temperature 0.9`, `topP 1.0`, `repetitionPenalty 1.05` | `ChatterboxModel.defaultGenerationParameters` sets `temperature 0.8` | Model card emphasizes usage and capabilities, not these inference defaults |
+| Text chunking before synthesis | Yes. First chunk `3` sentences, later chunks `2` sentences | No comparable runtime chunk planner in the Chatterbox model path | Not documented as the intended inference path |
+| Streaming cadence | `0.5s` resident interval for standard non-Qwen resident playback | Generic TTS streaming helpers default to `2.0s`, but current Chatterbox behavior is effectively whole-waveform-per-call for each chunk | No authoritative cadence knob documented in the model card |
+| Caller-facing default generation parameters | `temperature 0.8`, `topP 0.8` | `ChatterboxModel.defaultGenerationParameters` sets `temperature 0.8` | Model card emphasizes usage and capabilities, not these inference defaults |
 | Effective Chatterbox Turbo inference parameters | Our `temperature` and `topP` are passed through | Turbo inference uses dynamic `maxTokens`, `topK 1000`, caller `temperature`, caller `topP`, and hardcoded `repetitionPenalty 1.2` | Not described at this level in the repo or card |
 | Max text window | No local hard cap beyond what upstream model path accepts; we reduce risk by pre-chunking | Turbo config uses `max_text_tokens 2048` | HF config also shows `max_text_tokens 2048` |
 | Max speech token window | Local policy says `4096`, but upstream computes this internally for Chatterbox | Turbo config uses `max_speech_tokens 4096`, with fallback cap `min(768, max(200, textLen * 10))` when prompt speech tokens are missing | HF config shows `max_speech_tokens 4096` |
@@ -74,9 +74,9 @@ The model's own public repo and published Hugging Face surfaces:
 - `SpeakSwiftly` gets live playback by turning one request into many smaller Chatterbox calls. That is a runtime orchestration strategy, not a native model-streaming capability.
 - Our local `maxTokens 4096` and `repetitionPenalty 1.05` do not cleanly map to the final Chatterbox Turbo inference path because upstream Chatterbox computes the effective speech-token cap itself and hardcodes `repetitionPenalty 1.2` inside Turbo inference.
 - The most meaningful Chatterbox diffs today are:
-  - runtime-owned chunking
-  - much tighter live cadence
-  - warmer sampling (`temperature 0.9`, `topP 1.0`) than the current `mlx-audio-swift` Chatterbox default surface
+  - runtime-owned sentence chunking
+  - still-live but now less aggressive `0.5s` cadence instead of our older faster local cadence
+  - upstream-aligned `temperature 0.8` and `topP 0.8`
 
 ## Marvis
 
@@ -85,11 +85,11 @@ The model's own public repo and published Hugging Face surfaces:
 | Live generation shape | Native streaming backend plus SpeakSwiftly-specific scheduling and playback heuristics | Native chunked streaming generation path | Model card explicitly describes real-time streaming TTS |
 | Native incremental audio streaming | Yes, via upstream Marvis streaming path | Yes | Yes, that is a headline feature in the model repo and card |
 | Text chunking before synthesis | No local text chunk planner in the Marvis path | No. Marvis processes the full text context passed into the request | Model card explicitly says Marvis processes full text context rather than regex chunking |
-| Streaming cadence | `0.10s` for first drained live Marvis, `0.18s` for overlap follower and standard resident cadence | Core Marvis streaming path uses `0.5s`; generic wrapper defaults to `2.0s` | Model docs emphasize streaming, but do not publish a canonical cadence number |
-| Caller-facing default generation parameters | `maxTokens 4096`, `temperature 0.9`, `topP 1.0`, `repetitionPenalty 1.05` | `defaultGenerationParameters` returns `maxTokens 750`, `temperature 0.9`, `topP 0.8` | Published MLX config includes generic generation metadata like `temperature 1.0`, `top_k 50`, `top_p 1.0`, but that is not the same thing as the current MLX Swift sampling path |
-| Effective Marvis inference parameters | Local policy object exists, but upstream Marvis currently ignores most caller generation parameters | Current Marvis implementation hardcodes `TopPSampler(temperature: 0.9, topP: 0.8)` and computes `maxAudioFrames 750` internally | Model repo shows a `temperature` and `topk` generate surface in Python, but that is a separate implementation surface |
-| Max generated audio frame budget | Local policy says `4096`, but not actually honored by current upstream Marvis wrapper | `maxAudioFrames = Int(60000 / 80.0) = 750` | MLX model config and repo framing align with 12.5 fps audio-token timing and a 24 kHz Mimi codec stack |
-| Input sequence budget | No local extra cap; we rely on upstream model limit and runtime scheduling | Input must stay below `2048 - 750 = 1298` sequence positions in the current MLX Swift Marvis path | HF config for the MLX model shows `max_position_embeddings 2048` |
+| Streaming cadence | `0.5s` for standard resident playback and both Marvis-specific cadence roles | Core Marvis streaming path uses `0.5s`; generic wrapper defaults to `2.0s` | Model docs emphasize streaming, but do not publish a canonical cadence number |
+| Caller-facing default generation parameters | No local Marvis override. `SpeakSwiftly` passes an empty `GenerateParameters()` because upstream ignores caller knobs here | `defaultGenerationParameters` returns `maxTokens 750`, `temperature 0.9`, `topP 0.8` | Published MLX config includes generic generation metadata like `temperature 1.0`, `top_k 50`, `top_p 1.0`, but that is not the same thing as the current MLX Swift sampling path |
+| Effective Marvis inference parameters | We intentionally defer to upstream internal defaults | Current Marvis implementation hardcodes `TopPSampler(temperature: 0.9, topP: 0.8)` and computes `maxAudioFrames 750` internally | Model repo shows a `temperature` and `topk` generate surface in Python, but that is a separate implementation surface |
+| Max generated audio frame budget | No local override | `maxAudioFrames = Int(60000 / 80.0) = 750` | MLX model config and repo framing align with 12.5 fps audio-token timing and a 24 kHz Mimi codec stack |
+| Input sequence budget | No local extra cap; we rely on upstream model limit and runtime scheduling | Input must stay below `2048 - 750 = 1298` sequence positions in the current MLX Swift Marvis path | HF config for the MLX model shows `max_position_embeddings 2048` at the backbone level, with Mimi codec `max_position_embeddings 8000` and `sliding_window 250` in codec metadata |
 | Context window | We preserve full normalized text instead of pre-chunking | Full prompt context is prepended and processed in one contextual sequence | Model card explicitly says this is a core design goal |
 | Codec and sliding-window metadata | No local override | Uses the model artifact as loaded | HF config shows Mimi codec metadata including `sliding_window 250` and `_frame_rate 12.5` |
 | Voice lane behavior | SpeakSwiftly keeps two warm resident Marvis lanes and routes by vibe | One model instance has mutable caches; our runtime compensates with two resident model objects | Model card focuses on conversational voices and cloning behavior, not our dual-lane runtime policy |
@@ -98,23 +98,25 @@ The model's own public repo and published Hugging Face surfaces:
 ### Marvis Notes
 
 - Marvis is the opposite of Chatterbox in one key respect: the upstream `mlx-audio-swift` path really does stream audio progressively.
-- Our largest Marvis diffs are not the nominal generation-parameter values in `GenerationPolicy`. The largest real diffs are:
-  - much tighter streaming cadence
-  - dual-lane resident scheduling
-  - custom playback thresholds for startup and recovery
-- Several local Marvis parameter values are currently more descriptive than operative because upstream `MarvisTTSModel.generate(...)` and `generateStream(...)` ignore the caller-supplied `generationParameters` and use internal sampling values instead.
-- If we want Marvis generation knobs in `SpeakSwiftly` to be real knobs, the first prerequisite is changing the upstream Marvis Swift wrapper so it honors caller parameters.
+- After the 2026-04-22 alignment pass, Marvis no longer differs from `mlx-audio-swift` on the live cadence we request or on nominal caller sampling overrides. Those were explicit local differences before; they are not the main diffs now.
+- The largest real Marvis diffs now are:
+  - dual-lane resident scheduling so we can keep both conversational voices warm
+  - custom playback thresholds for startup and recovery, especially the `firstDrainedLiveMarvis` tuning profile
+  - vibe-based lane routing on top of the upstream model
+- We now intentionally avoid pretending Marvis has local operative sampling knobs. `SpeakSwiftly` passes an empty `GenerateParameters()` for Marvis because upstream `MarvisTTSModel.generate(...)` and `generateStream(...)` still ignore the caller-supplied generation parameters and use internal sampling values instead.
+- If we want Marvis generation knobs in `SpeakSwiftly` to become real knobs, the first prerequisite is still changing the upstream Marvis Swift wrapper so it honors caller parameters.
+- If Marvis still rebuffers more than expected in local audible runs, the most likely remaining local causes are our playback-policy layer and the fact that we keep two resident Marvis model instances warm at once, not our requested streaming cadence.
 
 ## Practical Conclusions
 
 1. Chatterbox Turbo is not currently native-streaming in the `mlx-audio-swift` path we use. `SpeakSwiftly` fakes live behavior by chunking text and yielding completed chunk waveforms as each chunk finishes.
-2. Marvis is currently native-streaming in the `mlx-audio-swift` path we use. `SpeakSwiftly` then layers its own tighter cadence and playback-stability policy on top.
+2. Marvis is currently native-streaming in the `mlx-audio-swift` path we use. `SpeakSwiftly` now matches the upstream `0.5s` streaming cadence, but still layers its own playback-stability and resident-lane policy on top.
 3. "Upstream" must always be split into two labels in future notes:
    - `mlx-audio-swift`
    - model repo/card
 4. The settings that matter most to align next are:
-   - Chatterbox: chunk sizing, cadence, and whether to stay intentionally more aggressive than `mlx-audio-swift`
-   - Marvis: whether we want the wrapper to honor caller generation parameters instead of silently using internal defaults
+   - Chatterbox: sentence chunk sizing and whether to keep runtime-owned chunking at all
+   - Marvis: whether we want to reduce or remove our custom playback-threshold tuning, and whether we want the wrapper to honor caller generation parameters instead of silently using internal defaults
 
 ## Sources
 

--- a/docs/maintainers/chatterbox-marvis-defaults-comparison-2026-04-21.md
+++ b/docs/maintainers/chatterbox-marvis-defaults-comparison-2026-04-21.md
@@ -1,0 +1,148 @@
+# Chatterbox And Marvis Defaults Comparison
+
+## Purpose
+
+This note compares the current `SpeakSwiftly` runtime behavior against two distinct upstream surfaces:
+
+- `mlx-audio-swift`: the Swift wrapper and model integration layer we build on
+- model repo/card: the backend model's own GitHub repository and Hugging Face card or config
+
+Keep those two upstreams separate when reading diffs. The model repo or card describes the model family and published artifacts. `mlx-audio-swift` describes the current Swift runtime behavior we inherit unless `SpeakSwiftly` overrides it.
+
+## Direct Answer
+
+### Chatterbox Turbo
+
+Chatterbox Turbo does not currently give us native incremental audio streaming through the `mlx-audio-swift` path we use.
+
+More precisely:
+
+- the `mlx-audio-swift` API is stream-shaped for Chatterbox
+- but the current Chatterbox implementation still synthesizes a full chunk waveform before yielding audio
+- `SpeakSwiftly` gets live playback by chunking text in the runtime and synthesizing those text chunks sequentially
+
+So the correct statement is:
+
+- Chatterbox Turbo is not currently native-streaming in the `mlx-audio-swift` integration we use
+- `SpeakSwiftly` adds chunk-at-a-time live delivery on top of that non-incremental backend behavior
+
+### Marvis
+
+Marvis is different. The current `mlx-audio-swift` Marvis path does perform real chunked streaming generation. `SpeakSwiftly` still overrides cadence and playback policy, but it is building on a genuinely streaming backend path there.
+
+## Source Labels
+
+### `SpeakSwiftly`
+
+Current local package behavior in this repository.
+
+### `mlx-audio-swift`
+
+Current `Blaizzy/mlx-audio-swift` `main` behavior as checked on 2026-04-21.
+
+### `model repo/card`
+
+The model's own public repo and published Hugging Face surfaces:
+
+- Chatterbox Turbo:
+  - `resemble-ai/chatterbox`
+  - `ResembleAI/chatterbox-turbo`
+  - `mlx-community/chatterbox-turbo-8bit`
+- Marvis:
+  - `Marvis-Labs/marvis-tts`
+  - `Marvis-AI/marvis-tts-250m-v0.2`
+  - `Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit`
+
+## Chatterbox Turbo
+
+| Surface | SpeakSwiftly | mlx-audio-swift | model repo/card |
+| --- | --- | --- | --- |
+| Live generation shape | Runtime-owned chunked live playback over sequential text chunks | Stream-shaped API, but current Chatterbox path still renders one chunk waveform before yielding audio | Public docs describe ordinary `generate(...)` style synthesis, not token-by-token audio streaming |
+| Native incremental audio streaming | No | No, not in the current Chatterbox integration path | Not clearly claimed in the model card or repo usage docs |
+| Text chunking before synthesis | Yes. First chunk target `16` words, later chunks `28`, min `8`, max `40` | No comparable runtime chunk planner in the Chatterbox model path | Not documented as the intended inference path |
+| Streaming cadence | `0.18s` resident interval for standard non-Qwen resident playback | Generic TTS streaming helpers default to `2.0s`, but current Chatterbox behavior is effectively whole-waveform-per-call for each chunk | No authoritative cadence knob documented in the model card |
+| Caller-facing default generation parameters | `maxTokens 4096`, `temperature 0.9`, `topP 1.0`, `repetitionPenalty 1.05` | `ChatterboxModel.defaultGenerationParameters` sets `temperature 0.8` | Model card emphasizes usage and capabilities, not these inference defaults |
+| Effective Chatterbox Turbo inference parameters | Our `temperature` and `topP` are passed through | Turbo inference uses dynamic `maxTokens`, `topK 1000`, caller `temperature`, caller `topP`, and hardcoded `repetitionPenalty 1.2` | Not described at this level in the repo or card |
+| Max text window | No local hard cap beyond what upstream model path accepts; we reduce risk by pre-chunking | Turbo config uses `max_text_tokens 2048` | HF config also shows `max_text_tokens 2048` |
+| Max speech token window | Local policy says `4096`, but upstream computes this internally for Chatterbox | Turbo config uses `max_speech_tokens 4096`, with fallback cap `min(768, max(200, textLen * 10))` when prompt speech tokens are missing | HF config shows `max_speech_tokens 4096` |
+| Context window | We avoid long single-pass text by chunking in the runtime | GPT-2 Turbo backbone config uses `n_ctx 8196` and `n_positions 8196` | HF config for `mlx-community/chatterbox-turbo-8bit` shows the same `8196` context size |
+| Voice conditioning default | Uses stored profile reference audio when available, otherwise built-in default conditioning | Chatterbox model ships built-in default conditioning for Turbo | HF config exposes built-in conditioning-related config and the MLX card explicitly mentions a default voice path |
+
+### Chatterbox Notes
+
+- The important distinction is not "stream API versus non-stream API." The important distinction is whether audio is yielded incrementally during one synthesis call. In the current `mlx-audio-swift` Chatterbox path, that answer is still no.
+- `SpeakSwiftly` gets live playback by turning one request into many smaller Chatterbox calls. That is a runtime orchestration strategy, not a native model-streaming capability.
+- Our local `maxTokens 4096` and `repetitionPenalty 1.05` do not cleanly map to the final Chatterbox Turbo inference path because upstream Chatterbox computes the effective speech-token cap itself and hardcodes `repetitionPenalty 1.2` inside Turbo inference.
+- The most meaningful Chatterbox diffs today are:
+  - runtime-owned chunking
+  - much tighter live cadence
+  - warmer sampling (`temperature 0.9`, `topP 1.0`) than the current `mlx-audio-swift` Chatterbox default surface
+
+## Marvis
+
+| Surface | SpeakSwiftly | mlx-audio-swift | model repo/card |
+| --- | --- | --- | --- |
+| Live generation shape | Native streaming backend plus SpeakSwiftly-specific scheduling and playback heuristics | Native chunked streaming generation path | Model card explicitly describes real-time streaming TTS |
+| Native incremental audio streaming | Yes, via upstream Marvis streaming path | Yes | Yes, that is a headline feature in the model repo and card |
+| Text chunking before synthesis | No local text chunk planner in the Marvis path | No. Marvis processes the full text context passed into the request | Model card explicitly says Marvis processes full text context rather than regex chunking |
+| Streaming cadence | `0.10s` for first drained live Marvis, `0.18s` for overlap follower and standard resident cadence | Core Marvis streaming path uses `0.5s`; generic wrapper defaults to `2.0s` | Model docs emphasize streaming, but do not publish a canonical cadence number |
+| Caller-facing default generation parameters | `maxTokens 4096`, `temperature 0.9`, `topP 1.0`, `repetitionPenalty 1.05` | `defaultGenerationParameters` returns `maxTokens 750`, `temperature 0.9`, `topP 0.8` | Published MLX config includes generic generation metadata like `temperature 1.0`, `top_k 50`, `top_p 1.0`, but that is not the same thing as the current MLX Swift sampling path |
+| Effective Marvis inference parameters | Local policy object exists, but upstream Marvis currently ignores most caller generation parameters | Current Marvis implementation hardcodes `TopPSampler(temperature: 0.9, topP: 0.8)` and computes `maxAudioFrames 750` internally | Model repo shows a `temperature` and `topk` generate surface in Python, but that is a separate implementation surface |
+| Max generated audio frame budget | Local policy says `4096`, but not actually honored by current upstream Marvis wrapper | `maxAudioFrames = Int(60000 / 80.0) = 750` | MLX model config and repo framing align with 12.5 fps audio-token timing and a 24 kHz Mimi codec stack |
+| Input sequence budget | No local extra cap; we rely on upstream model limit and runtime scheduling | Input must stay below `2048 - 750 = 1298` sequence positions in the current MLX Swift Marvis path | HF config for the MLX model shows `max_position_embeddings 2048` |
+| Context window | We preserve full normalized text instead of pre-chunking | Full prompt context is prepended and processed in one contextual sequence | Model card explicitly says this is a core design goal |
+| Codec and sliding-window metadata | No local override | Uses the model artifact as loaded | HF config shows Mimi codec metadata including `sliding_window 250` and `_frame_rate 12.5` |
+| Voice lane behavior | SpeakSwiftly keeps two warm resident Marvis lanes and routes by vibe | One model instance has mutable caches; our runtime compensates with two resident model objects | Model card focuses on conversational voices and cloning behavior, not our dual-lane runtime policy |
+| Playback stabilization | SpeakSwiftly adds a `firstDrainedLiveMarvis` tuning profile with raised startup and resume floors | No comparable playback policy in `mlx-audio-swift` | Not part of the model repo or card surface |
+
+### Marvis Notes
+
+- Marvis is the opposite of Chatterbox in one key respect: the upstream `mlx-audio-swift` path really does stream audio progressively.
+- Our largest Marvis diffs are not the nominal generation-parameter values in `GenerationPolicy`. The largest real diffs are:
+  - much tighter streaming cadence
+  - dual-lane resident scheduling
+  - custom playback thresholds for startup and recovery
+- Several local Marvis parameter values are currently more descriptive than operative because upstream `MarvisTTSModel.generate(...)` and `generateStream(...)` ignore the caller-supplied `generationParameters` and use internal sampling values instead.
+- If we want Marvis generation knobs in `SpeakSwiftly` to be real knobs, the first prerequisite is changing the upstream Marvis Swift wrapper so it honors caller parameters.
+
+## Practical Conclusions
+
+1. Chatterbox Turbo is not currently native-streaming in the `mlx-audio-swift` path we use. `SpeakSwiftly` fakes live behavior by chunking text and yielding completed chunk waveforms as each chunk finishes.
+2. Marvis is currently native-streaming in the `mlx-audio-swift` path we use. `SpeakSwiftly` then layers its own tighter cadence and playback-stability policy on top.
+3. "Upstream" must always be split into two labels in future notes:
+   - `mlx-audio-swift`
+   - model repo/card
+4. The settings that matter most to align next are:
+   - Chatterbox: chunk sizing, cadence, and whether to stay intentionally more aggressive than `mlx-audio-swift`
+   - Marvis: whether we want the wrapper to honor caller generation parameters instead of silently using internal defaults
+
+## Sources
+
+### SpeakSwiftly
+
+- [Sources/SpeakSwiftly/Generation/ModelClients.swift](../../Sources/SpeakSwiftly/Generation/ModelClients.swift)
+- [Sources/SpeakSwiftly/Generation/LiveSpeechChunkPlanner.swift](../../Sources/SpeakSwiftly/Generation/LiveSpeechChunkPlanner.swift)
+- [Sources/SpeakSwiftly/Generation/SpeechGeneration+Chatterbox.swift](../../Sources/SpeakSwiftly/Generation/SpeechGeneration+Chatterbox.swift)
+- [Sources/SpeakSwiftly/Generation/SpeechGeneration+Marvis.swift](../../Sources/SpeakSwiftly/Generation/SpeechGeneration+Marvis.swift)
+- [Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift](../../Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift)
+- [Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift](../../Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift)
+- [Sources/SpeakSwiftly/Playback/PlaybackThresholdController.swift](../../Sources/SpeakSwiftly/Playback/PlaybackThresholdController.swift)
+- [CONTRIBUTING.md](../../CONTRIBUTING.md)
+
+### mlx-audio-swift
+
+- [Blaizzy/mlx-audio-swift](https://github.com/Blaizzy/mlx-audio-swift)
+- [`GenerationTypes.swift`](https://raw.githubusercontent.com/Blaizzy/mlx-audio-swift/main/Sources/MLXAudioCore/Generation/GenerationTypes.swift)
+- [`Generation.swift`](https://raw.githubusercontent.com/Blaizzy/mlx-audio-swift/main/Sources/MLXAudioTTS/Generation.swift)
+- [`ChatterboxModel.swift`](https://raw.githubusercontent.com/Blaizzy/mlx-audio-swift/main/Sources/MLXAudioTTS/Models/Chatterbox/ChatterboxModel.swift)
+- [`ChatterboxConfig.swift`](https://raw.githubusercontent.com/Blaizzy/mlx-audio-swift/main/Sources/MLXAudioTTS/Models/Chatterbox/ChatterboxConfig.swift)
+- [`MarvisTTSModel.swift`](https://raw.githubusercontent.com/Blaizzy/mlx-audio-swift/main/Sources/MLXAudioTTS/Models/Marvis/MarvisTTSModel.swift)
+
+### Model repo/card
+
+- [resemble-ai/chatterbox](https://github.com/resemble-ai/chatterbox)
+- [ResembleAI/chatterbox-turbo](https://huggingface.co/ResembleAI/chatterbox-turbo)
+- [mlx-community/chatterbox-turbo-8bit](https://huggingface.co/mlx-community/chatterbox-turbo-8bit)
+- [Marvis-Labs/marvis-tts](https://github.com/Marvis-Labs/marvis-tts)
+- [Marvis-AI/marvis-tts-250m-v0.2](https://huggingface.co/Marvis-AI/marvis-tts-250m-v0.2)
+- [Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit](https://huggingface.co/Marvis-AI/marvis-tts-250m-v0.2-MLX-8bit)

--- a/docs/maintainers/chatterbox-marvis-defaults-comparison-2026-04-21.md
+++ b/docs/maintainers/chatterbox-marvis-defaults-comparison-2026-04-21.md
@@ -92,20 +92,27 @@ The model's own public repo and published Hugging Face surfaces:
 | Input sequence budget | No local extra cap; we rely on upstream model limit and runtime scheduling | Input must stay below `2048 - 750 = 1298` sequence positions in the current MLX Swift Marvis path | HF config for the MLX model shows `max_position_embeddings 2048` at the backbone level, with Mimi codec `max_position_embeddings 8000` and `sliding_window 250` in codec metadata |
 | Context window | We preserve full normalized text instead of pre-chunking | Full prompt context is prepended and processed in one contextual sequence | Model card explicitly says this is a core design goal |
 | Codec and sliding-window metadata | No local override | Uses the model artifact as loaded | HF config shows Mimi codec metadata including `sliding_window 250` and `_frame_rate 12.5` |
-| Voice lane behavior | SpeakSwiftly keeps two warm resident Marvis lanes and routes by vibe | One model instance has mutable caches; our runtime compensates with two resident model objects | Model card focuses on conversational voices and cloning behavior, not our dual-lane runtime policy |
-| Playback stabilization | SpeakSwiftly adds a `firstDrainedLiveMarvis` tuning profile with raised startup and resume floors | No comparable playback policy in `mlx-audio-swift` | Not part of the model repo or card surface |
+| Resident voice policy | Configurable. Default is `dual_resident_serialized`, which keeps the `femme` and `masc` resident routes warm while serializing generation. Optional `single_resident_dynamic` reuses one resident model object for whichever route the next request needs | One model instance has mutable caches; upstream does not provide our policy surface | Model card focuses on conversational voices and cloning behavior, not our runtime policy choices |
+| Marvis generation concurrency | Serialized. SpeakSwiftly now allows only one Marvis generation at a time | No equivalent SpeakSwiftly-style scheduler policy | Not part of the model repo or card surface |
+| Playback stabilization | SpeakSwiftly applies one conservative Marvis live-startup profile with raised startup and resume floors across live Marvis playback | No comparable playback policy in `mlx-audio-swift` | Not part of the model repo or card surface |
 
 ### Marvis Notes
 
 - Marvis is the opposite of Chatterbox in one key respect: the upstream `mlx-audio-swift` path really does stream audio progressively.
 - After the 2026-04-22 alignment pass, Marvis no longer differs from `mlx-audio-swift` on the live cadence we request or on nominal caller sampling overrides. Those were explicit local differences before; they are not the main diffs now.
+- After the later 2026-04-22 simplification pass, SpeakSwiftly now serializes Marvis generation outright instead of trying to overlap two Marvis generations across resident lanes.
+- After the follow-up 2026-04-22 playback pass, all live Marvis requests now use the same conservative Marvis startup profile instead of only the first request getting the larger preroll.
 - The largest real Marvis diffs now are:
-  - dual-lane resident scheduling so we can keep both conversational voices warm
-  - custom playback thresholds for startup and recovery, especially the `firstDrainedLiveMarvis` tuning profile
-  - vibe-based lane routing on top of the upstream model
+  - resident loading policy, either `dual_resident_serialized` or `single_resident_dynamic`
+  - serialized Marvis generation on top of the upstream model
+  - custom playback thresholds for startup and recovery, now applied as one Marvis live-startup profile
+  - simple `femme` versus `masc` route selection on top of the upstream model
 - We now intentionally avoid pretending Marvis has local operative sampling knobs. `SpeakSwiftly` passes an empty `GenerateParameters()` for Marvis because upstream `MarvisTTSModel.generate(...)` and `generateStream(...)` still ignore the caller-supplied generation parameters and use internal sampling values instead.
 - If we want Marvis generation knobs in `SpeakSwiftly` to become real knobs, the first prerequisite is still changing the upstream Marvis Swift wrapper so it honors caller parameters.
-- If Marvis still rebuffers more than expected in local audible runs, the most likely remaining local causes are our playback-policy layer and the fact that we keep two resident Marvis model instances warm at once, not our requested streaming cadence.
+- The latest audible Marvis runs after serialization plus unified startup tuning make the remaining bottleneck look more like raw MLX Marvis throughput than overlap policy:
+  - the first serialized request still improves materially
+  - later serialized requests also now start with the same larger preroll instead of falling back to tiny `standard` startup buffering
+  - that reduces the earlier later-request cliff, but it still does not make Marvis playback fully clean end to end
 
 ## Practical Conclusions
 
@@ -116,7 +123,7 @@ The model's own public repo and published Hugging Face surfaces:
    - model repo/card
 4. The settings that matter most to align next are:
    - Chatterbox: sentence chunk sizing and whether to keep runtime-owned chunking at all
-   - Marvis: whether we want to reduce or remove our custom playback-threshold tuning, and whether we want the wrapper to honor caller generation parameters instead of silently using internal defaults
+   - Marvis: whether the remaining audible instability is mostly an `mlx-audio-swift` throughput issue, and whether we want the wrapper to honor caller generation parameters instead of silently using internal defaults
 
 ## Sources
 

--- a/docs/maintainers/marvis-overlap-profiling-runbook-2026-04-16.md
+++ b/docs/maintainers/marvis-overlap-profiling-runbook-2026-04-16.md
@@ -1,13 +1,15 @@
-# Marvis Overlap Profiling Runbook
+# Marvis Profiling Runbook
 
 ## Why This Exists
 
 This note captures the current maintainer workflow for profiling the Marvis
-resident overlap path on Apple silicon.
+generation path on Apple silicon.
 
 The immediate use case is:
 
-- compare a clean Marvis baseline against the current dual-lane overlap behavior
+- compare a clean Marvis baseline against the current serialized package behavior
+- compare the current serialized `SpeakSwiftly` Marvis path against candidate
+  resident policies or upstream-informed changes
 - line Instruments captures up with the package's existing JSONL deep-trace events
 - determine whether first-request rebuffering is mainly caused by CPU contention,
   GPU scheduling pressure, unified-memory pressure, or some combination of those
@@ -15,8 +17,7 @@ The immediate use case is:
   reconstruct the Xcode-backed test path from old notes and shell history
 
 This is not a general-purpose Xcode profiling guide. It is a package-specific
-runbook for the exact `SpeakSwiftly` Marvis path that has already been under
-investigation.
+runbook for the current serialized `SpeakSwiftly` Marvis path.
 
 ## Current Ground Truth
 
@@ -28,9 +29,10 @@ That configuration lives in
 [Sources/SpeakSwiftly/Generation/ModelClients.swift](../../Sources/SpeakSwiftly/Generation/ModelClients.swift).
 
 So the current profiling question is not "is Marvis bf16 or int8?" The package
-is already using the MLX 8-bit build. The more relevant question is whether the
-current dual-lane overlap shape still creates enough sustained Apple-silicon
-CPU, GPU, or unified-memory pressure to make the first audible playback unstable.
+is already using the MLX 8-bit build. The more relevant question now is whether
+the remaining audible instability comes from the current `mlx-audio-swift`
+generation path itself, from resident-policy differences, or from some local
+playback-policy mismatch that still survives after the runtime simplification.
 
 ## Existing Trace Anchors
 
@@ -133,49 +135,44 @@ PY
 
 ## Targeted Test Command
 
-Use this exact command for the current dual-lane Marvis overlap baseline:
+Use this exact command for the current serialized Marvis baseline:
 
 ```bash
   xcodebuild test-without-building -quiet \
   -xctestrun .local/derived-data/Instruments-MarvisProfile/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun \
   -destination 'platform=macOS' \
-  -only-testing:'SpeakSwiftlyTests/MarvisE2ETests/`prequeued jobs drain in order`()' \
-  -resultBundlePath .local/results/Instruments-MarvisProfile-dual-lane.xcresult
+  -only-testing:'SpeakSwiftlyTests/MarvisE2ETests/`queued audible playback stays serialized and routes expected voices`()' \
+  -resultBundlePath .local/results/Instruments-MarvisProfile-serialized.xcresult
 ```
 
 ## Scenario Matrix
 
-### Scenario A: Current Dual-Lane Marvis Baseline
+### Scenario A: Current Serialized Marvis Baseline
 
 Use the test command above exactly as written.
 
 This is the current package behavior and should be the first stable comparison
 point for any profiling pass.
 
-### Scenario B: Current or Candidate Safer-Overlap Policy
+### Scenario B: Current Or Candidate Resident-Policy Comparison
 
-If there is an in-branch overlap experiment to compare, rerun the same command
-and change only the result bundle path:
+If there is an in-branch resident-policy or upstream-informed candidate to
+compare, rerun the same command and change only the result bundle path:
 
 ```bash
   xcodebuild test-without-building -quiet \
   -xctestrun .local/derived-data/Instruments-MarvisProfile/Build/Products/SpeakSwiftly-Package_SpeakSwiftly-Package_macosx26.4-arm64.xctestrun \
   -destination 'platform=macOS' \
-  -only-testing:'SpeakSwiftlyTests/MarvisE2ETests/`prequeued jobs drain in order`()' \
+  -only-testing:'SpeakSwiftlyTests/MarvisE2ETests/`queued audible playback stays serialized and routes expected voices`()' \
   -resultBundlePath .local/results/Instruments-MarvisProfile-candidate-policy.xcresult
 ```
 
-### Scenario C: Single-Lane Marvis Baseline
+### Scenario C: Single-Resident Dynamic Marvis Baseline
 
-This is not yet a stable package backend.
-
-If a real `marvis_single_lane` or `marvis_sequential` backend is added later,
-this runbook should be updated so the single-lane command becomes a first-class
-copy-paste path.
-
-Until then, do not pretend there is already a stable shell-only single-lane
-command. If a single-lane comparison is needed before that backend exists, make
-it in an isolated branch and record exactly what was changed for that branch.
+The package now has a real `single_resident_dynamic` policy option. If that
+mode is under investigation, keep the same test command and record the exact
+configuration override used for the run so the capture stays comparable to the
+default `dual_resident_serialized` baseline.
 
 ## Instruments Capture Order
 
@@ -191,10 +188,10 @@ Do not try to cram everything into one giant capture first.
 
 Use this template to answer:
 
-- what got hot on CPU when overlap started
-- whether the reservation moment itself is expensive
-- whether the first request only becomes expensive later while it tries to
-  rebuild reserve
+- what got hot on CPU when a Marvis generation actually began
+- whether lane reservation itself is expensive
+- whether the first request only becomes expensive later while playback tries
+  to recover reserve
 
 Workflow:
 
@@ -208,13 +205,13 @@ Workflow:
 7. Stop recording.
 8. Save the trace with a scenario-specific name such as:
    - `single-lane-time-profiler.trace`
-   - `dual-lane-time-profiler.trace`
+   - `serialized-baseline-time-profiler.trace`
    - `candidate-policy-time-profiler.trace`
 
 What to compare:
 
 - the window just before `marvis_generation_lane_reserved`
-- the window immediately after overlap is active
+- the window immediately after the queued follower request begins generating
 - the first `playback_rebuffer_started` -> `playback_rebuffer_resumed` window
 
 ### Metal System Trace
@@ -236,13 +233,13 @@ Workflow:
 5. Stop the capture after the first queued request has drained.
 6. Save the trace with a scenario-specific name such as:
    - `single-lane-metal-system-trace.trace`
-   - `dual-lane-metal-system-trace.trace`
+   - `serialized-baseline-metal-system-trace.trace`
    - `candidate-policy-metal-system-trace.trace`
 
 What to compare:
 
 - just before `marvis_generation_lane_reserved`
-- the period immediately after overlap becomes active
+- the period immediately after the follower request begins generating
 - the first rebuffer window
 
 ### Allocations or VM Tracker
@@ -262,7 +259,7 @@ Workflow:
 5. Stop the capture after the first queued request has drained.
 6. Save the trace with a scenario-specific name such as:
    - `single-lane-memory.trace`
-   - `dual-lane-memory.trace`
+   - `serialized-baseline-memory.trace`
    - `candidate-policy-memory.trace`
 
 ## How To Line the Capture Up With JSONL
@@ -288,28 +285,28 @@ If needed, also keep the corresponding result bundle:
 
 ## What Good Evidence Looks Like
 
-### Evidence that the overlap shape is the problem
+### Evidence that the former local queue policy was the problem
 
 - single-lane stays clean
-- dual-lane degrades
+- serialized baseline stays cleaner than a more aggressive candidate
 - lane reservation itself is quiet
-- the expensive behavior appears only after overlap has already been active
+- the expensive behavior appears only after a second request is allowed to compete
 
 ### Evidence that the machine is just near its ceiling
 
 - single-lane is already rough
-- dual-lane is worse, but not categorically different
+- the serialized baseline is still rough, and more aggressive candidates are only worse by degree
 - Time Profiler and Metal System Trace both show pressure even before the
-  follower lane has really joined the overlap window
+  follower request has really joined the active generation window
 
 ### Evidence that startup policy is still the main problem
 
 - reservation and early overlap are the expensive moment
 - later sustained overlap is not much worse than the initial handoff
 
-## Follow-On Backend Option
+## Follow-On Resident Policy Option
 
-### Why a Single-Lane Marvis Backend Is Worth Considering
+### Why A Single-Resident Marvis Policy Is Worth Considering
 
 This would be a durable building-block change, not a local scheduler tweak.
 
@@ -320,55 +317,47 @@ The current backend surface already has:
 - the JSONL `set_speech_backend` control path
 - runtime overview and job surfaces that already report which backend is active
 
-So a backend such as:
-
-- `marvis_single_lane`
-- `marvis_sequential`
-
-would fit naturally beside:
-
-- `qwen3`
-- `marvis`
-
 The near-term use case it unlocks is simple:
 
-- keep Marvis available on machines where the two-lane overlap trade is not
+- keep Marvis available on machines where the dual-resident default trade is not
   worth the audible instability
 - preserve explicit operator intent instead of hiding that behavior behind
-  scheduler heuristics
+  scheduler heuristics or machine-local folklore
 - let docs, tests, runtime overview, and stored job records say plainly which
   Marvis mode the worker is using
 
 ### Simpler Extension Path Considered First
 
-The simpler path is to keep one `marvis` backend and add a hidden internal flag
-or scheduler special case for single-lane behavior.
+The simpler path is the one the package now already has: keep one `marvis`
+backend and expose the resident choice through `marvisResidentPolicy` instead
+of adding another backend name.
 
 That path was considered first, but it is less clear:
 
-- it hides a major behavior difference inside policy
-- it makes logs and runtime expectations fuzzier
-- it makes machine-specific behavior harder to reason about
+- it still needs clean profiling and docs work so the policy choices stay
+  obvious
+- it makes machine-specific behavior worth documenting explicitly
+- it makes upstream-versus-local behavior comparison more important
 
-A distinct backend is cleaner because it turns "single-lane Marvis" into a
-first-class operator-facing choice.
+The current policy-based shape is acceptable as long as the runtime and docs
+keep the active resident policy explicit.
 
-### Where That Backend Would Fit
+### Where That Policy Investigation Fits
 
 The main surfaces that would need to widen are:
 
-- [Sources/SpeakSwiftly/Generation/SpeechBackend.swift](../../Sources/SpeakSwiftly/Generation/SpeechBackend.swift)
 - [Sources/SpeakSwiftly/API/Configuration.swift](../../Sources/SpeakSwiftly/API/Configuration.swift)
-- [Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+ResidentModels.swift](../../Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+ResidentModels.swift)
+- [Sources/SpeakSwiftly/Generation/ResidentSpeechModels.swift](../../Sources/SpeakSwiftly/Generation/ResidentSpeechModels.swift)
 - [Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift](../../Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift)
 
-The expected behavior split is:
+The expected behavior split is now:
 
 - model loading can still reuse the same Marvis weights and the same built-in
   voice routing for `conversational_a` and `conversational_b`
-- the real behavior change lives in scheduling
-- the single-lane backend should cap Marvis live generation concurrency at one
-  and stop trying to open a second Marvis generation lane
+- `dual_resident_serialized` keeps both voices warm while still serializing
+  generation
+- `single_resident_dynamic` reuses one resident model object for whichever
+  conversational voice the next request needs
 
 ## Apple Documentation Anchors
 

--- a/docs/maintainers/validation-lanes.md
+++ b/docs/maintainers/validation-lanes.md
@@ -220,7 +220,18 @@ sh scripts/repo-maintenance/run-benchmark.sh --audible --iterations 3
 sh scripts/repo-maintenance/run-benchmark.sh --qwen --iterations 5
 ```
 
-For Marvis overlap and trace work, prefer the dedicated runbook:
+For the Marvis-specific resident-policy comparison lane, run the benchmark test
+directly so the filter stays narrow:
+
+```bash
+SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1 SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS=1 swift test --filter 'BackendBenchmarkE2ETests/compare marvis resident policies with three queued voice switches'
+```
+
+That lane compares `dual_resident_serialized` against
+`single_resident_dynamic` with a three-request voice order that goes
+`femme` -> `masc` -> `femme` again.
+
+For Marvis profiling, throughput investigation, and trace work, prefer the dedicated runbook:
 
 - [marvis-overlap-profiling-runbook-2026-04-16.md](marvis-overlap-profiling-runbook-2026-04-16.md)
 


### PR DESCRIPTION
## Summary
- align Chatterbox and Marvis runtime policy around the current upstream surfaces
- simplify Marvis into serialized generation with configurable resident policy and add a resident-policy benchmark
- refresh maintainer docs and bump TextForSpeech to 0.18.5

## Verification
- sh scripts/repo-maintenance/validate-all.sh
- swift test