### PR TITLE
release: publish v3.2.6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "99e00111bf538cf83bd8b07d052f14a2a374e8eeadeba58583915446ea93c328",
+  "originHash" : "32de28bbb82fef4e21d7ea4b7a641ed464a106620626fde0a47f14eb685bccb7",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "b9640e2dd11054764aecd6117f98ad83db17d914",
-        "version" : "0.18.5"
+        "revision" : "ef6afaf4fd07deede82d534fbfcc588f9d6258b0",
+        "version" : "0.18.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/gaelic-ghost/TextForSpeech.git",
-            .upToNextMajor(from: "0.18.5"),
+            .upToNextMajor(from: "0.18.6"),
         ),
         .package(
             url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",

--- a/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
+++ b/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
@@ -181,6 +181,8 @@ extension SpeakSwiftly.Runtime {
 
     func residentLiveGenerationStream(
         requestID: String,
+        op: String?,
+        profileName: String,
         text: String,
         plannedTextChunks: [LiveSpeechTextChunk]?,
         inputs: ResidentSpeechInputs,
@@ -191,6 +193,8 @@ extension SpeakSwiftly.Runtime {
             case let .qwenRaw(model, _, materialization, refAudio):
                 qwenLiveGenerationStream(
                     requestID: requestID,
+                    op: op,
+                    profileName: profileName,
                     model: model,
                     text: text,
                     plannedChunks: plannedTextChunks,
@@ -202,6 +206,8 @@ extension SpeakSwiftly.Runtime {
             case let .qwenPrepared(model, _, conditioning):
                 qwenLiveGenerationStream(
                     requestID: requestID,
+                    op: op,
+                    profileName: profileName,
                     model: model,
                     text: text,
                     plannedChunks: plannedTextChunks,

--- a/Sources/SpeakSwiftly/Generation/LiveSpeechChunkPlanner.swift
+++ b/Sources/SpeakSwiftly/Generation/LiveSpeechChunkPlanner.swift
@@ -19,7 +19,7 @@ struct LiveSpeechTextChunk: Equatable {
 enum LiveSpeechChunkPlanner {
     enum Strategy: Equatable {
         case sentenceGroups
-        case smartParagraphGroups(targetParagraphCount: Int = 3, softCharacterLimit: Int = 1400)
+        case smartParagraphGroups(targetParagraphCount: Int = 4, softCharacterLimit: Int = 1400)
     }
 
     private static let firstChunkSentenceCount = 3

--- a/Sources/SpeakSwiftly/Generation/LiveSpeechChunkPlanner.swift
+++ b/Sources/SpeakSwiftly/Generation/LiveSpeechChunkPlanner.swift
@@ -2,20 +2,29 @@ import Foundation
 import NaturalLanguage
 
 struct LiveSpeechTextChunk: Equatable {
+    enum Segmentation: String, Equatable {
+        case sentenceGroup = "sentence_group"
+        case paragraphGroup = "paragraph_group"
+        case lineBreak = "line_break"
+        case punctuationBoundary = "punctuation_boundary"
+        case forcedBreak = "forced_break"
+    }
+
     let index: Int
     let text: String
     let wordCount: Int
+    let segmentation: Segmentation
 }
 
 enum LiveSpeechChunkPlanner {
     enum Strategy: Equatable {
         case sentenceGroups
-        case paragraphPairs(maxSentencesPerChunk: Int = 8)
+        case smartParagraphGroups(targetParagraphCount: Int = 3, softCharacterLimit: Int = 1400)
     }
 
     private static let firstChunkSentenceCount = 3
     private static let laterChunkSentenceCount = 2
-    private static let paragraphsPerChunk = 2
+    private static let minimumSmartBoundaryCharacterCount = 120
 
     static func chunks(
         for text: String,
@@ -24,8 +33,12 @@ enum LiveSpeechChunkPlanner {
         let chunkTexts = switch strategy {
             case .sentenceGroups:
                 sentenceGroupedChunkTexts(for: text)
-            case let .paragraphPairs(maxSentencesPerChunk):
-                paragraphPairChunkTexts(for: text, maxSentencesPerChunk: maxSentencesPerChunk)
+            case let .smartParagraphGroups(targetParagraphCount, softCharacterLimit):
+                smartParagraphChunkTexts(
+                    for: text,
+                    targetParagraphCount: targetParagraphCount,
+                    softCharacterLimit: softCharacterLimit,
+                )
         }
 
         return chunkTexts.enumerated().map { index, chunkText in
@@ -33,8 +46,17 @@ enum LiveSpeechChunkPlanner {
                 index: index + 1,
                 text: chunkText,
                 wordCount: max(SpeakSwiftly.DeepTrace.words(in: chunkText).count, 1),
+                segmentation: segmentation(for: chunkText, strategy: strategy),
             )
         }
+    }
+
+    static func paragraphCount(in text: String) -> Int {
+        paragraphUnits(in: text).count
+    }
+
+    static func sentenceCount(in text: String) -> Int {
+        sentenceUnits(in: text).count
     }
 
     private static func sentenceGroupedChunkTexts(for text: String) -> [String] {
@@ -53,33 +75,211 @@ enum LiveSpeechChunkPlanner {
         return chunkTexts
     }
 
-    private static func paragraphPairChunkTexts(
+    private static func smartParagraphChunkTexts(
         for text: String,
-        maxSentencesPerChunk: Int,
+        targetParagraphCount: Int,
+        softCharacterLimit: Int,
     ) -> [String] {
         let paragraphs = paragraphUnits(in: text)
         guard !paragraphs.isEmpty else {
-            return sentenceGroupedChunkTexts(for: text)
+            return smartBoundaryChunkTexts(for: text, softCharacterLimit: softCharacterLimit)
         }
 
         var chunkTexts = [String]()
         var index = 0
 
         while index < paragraphs.count {
-            let endIndex = min(index + paragraphsPerChunk, paragraphs.count)
-            let combinedParagraphs = paragraphs[index..<endIndex].joined(separator: "\n\n")
-            let sentenceCount = sentenceUnits(in: combinedParagraphs).count
+            let preferredEndIndex = min(index + targetParagraphCount, paragraphs.count)
+            let preferredChunk = paragraphs[index..<preferredEndIndex].joined(separator: "\n\n")
 
-            if sentenceCount > maxSentencesPerChunk {
-                chunkTexts.append(contentsOf: sentenceChunks(from: sentenceUnits(in: combinedParagraphs)))
-            } else {
-                chunkTexts.append(combinedParagraphs)
+            if preferredChunk.count <= softCharacterLimit {
+                chunkTexts.append(preferredChunk)
+                index = preferredEndIndex
+                continue
             }
 
-            index = endIndex
+            var acceptedEndIndex: Int?
+            var candidateEndIndex = preferredEndIndex
+            while candidateEndIndex > index + 1 {
+                let candidate = paragraphs[index..<candidateEndIndex].joined(separator: "\n\n")
+                if candidate.count <= softCharacterLimit {
+                    acceptedEndIndex = candidateEndIndex
+                    break
+                }
+                candidateEndIndex -= 1
+            }
+
+            if let acceptedEndIndex {
+                chunkTexts.append(paragraphs[index..<acceptedEndIndex].joined(separator: "\n\n"))
+                index = acceptedEndIndex
+            } else {
+                chunkTexts.append(contentsOf: smartBoundaryChunkTexts(for: paragraphs[index], softCharacterLimit: softCharacterLimit))
+                index += 1
+            }
         }
 
         return chunkTexts
+    }
+
+    private static func segmentation(
+        for chunkText: String,
+        strategy: Strategy,
+    ) -> LiveSpeechTextChunk.Segmentation {
+        switch strategy {
+            case .sentenceGroups:
+                .sentenceGroup
+            case .smartParagraphGroups:
+                if chunkText.contains("\n\n") {
+                    .paragraphGroup
+                } else if chunkText.contains("\n") {
+                    .lineBreak
+                } else if endsAtClosingPunctuation(chunkText) {
+                    .punctuationBoundary
+                } else {
+                    .forcedBreak
+                }
+        }
+    }
+
+    private static func smartBoundaryChunkTexts(
+        for text: String,
+        softCharacterLimit: Int,
+    ) -> [String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        guard trimmed.count > softCharacterLimit else { return [trimmed] }
+        guard let boundaryIndex = bestBoundaryIndex(in: trimmed, softCharacterLimit: softCharacterLimit) else {
+            let forcedIndex = trimmed.index(trimmed.startIndex, offsetBy: softCharacterLimit)
+            let left = trimmed[..<forcedIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+            let right = trimmed[forcedIndex...].trimmingCharacters(in: .whitespacesAndNewlines)
+            return [left, right].filter { !$0.isEmpty }
+        }
+
+        let left = trimmed[..<boundaryIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        let right = trimmed[boundaryIndex...].trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return smartBoundaryChunkTexts(for: String(left), softCharacterLimit: softCharacterLimit)
+            + smartBoundaryChunkTexts(for: String(right), softCharacterLimit: softCharacterLimit)
+    }
+
+    private static func bestBoundaryIndex(
+        in text: String,
+        softCharacterLimit: Int,
+    ) -> String.Index? {
+        let safeLimit = min(softCharacterLimit, text.count)
+        guard safeLimit < text.count else { return nil }
+
+        let minimumOffset = min(max(softCharacterLimit / 3, minimumSmartBoundaryCharacterCount), safeLimit)
+        let minimumIndex = text.index(text.startIndex, offsetBy: minimumOffset)
+        let searchLimit = text.index(text.startIndex, offsetBy: safeLimit)
+
+        if let boundaryIndex = lastDelimiterBoundary(
+            delimiter: "\n\n",
+            in: text,
+            minimumIndex: minimumIndex,
+            searchLimit: searchLimit,
+        ) {
+            return boundaryIndex
+        }
+
+        if let boundaryIndex = lastDelimiterBoundary(
+            delimiter: "\n",
+            in: text,
+            minimumIndex: minimumIndex,
+            searchLimit: searchLimit,
+        ) {
+            return boundaryIndex
+        }
+
+        if let boundaryIndex = lastSentenceBoundary(
+            in: text,
+            minimumIndex: minimumIndex,
+            searchLimit: searchLimit,
+        ) {
+            return boundaryIndex
+        }
+
+        if let boundaryIndex = lastClosingPunctuationBoundary(
+            in: text,
+            minimumIndex: minimumIndex,
+            searchLimit: searchLimit,
+        ) {
+            return boundaryIndex
+        }
+
+        return lastWhitespaceBoundary(
+            in: text,
+            minimumIndex: minimumIndex,
+            searchLimit: searchLimit,
+        )
+    }
+
+    private static func lastDelimiterBoundary(
+        delimiter: String,
+        in text: String,
+        minimumIndex: String.Index,
+        searchLimit: String.Index,
+    ) -> String.Index? {
+        guard let range = text[minimumIndex..<searchLimit].range(of: delimiter, options: .backwards) else {
+            return nil
+        }
+
+        return range.upperBound
+    }
+
+    private static func lastSentenceBoundary(
+        in text: String,
+        minimumIndex: String.Index,
+        searchLimit: String.Index,
+    ) -> String.Index? {
+        let tokenizer = NLTokenizer(unit: .sentence)
+        tokenizer.string = text
+
+        let ranges = tokenizer.tokens(for: text.startIndex..<searchLimit)
+        return ranges.last(where: { $0.upperBound > minimumIndex && $0.upperBound < text.endIndex })?.upperBound
+    }
+
+    private static func lastClosingPunctuationBoundary(
+        in text: String,
+        minimumIndex: String.Index,
+        searchLimit: String.Index,
+    ) -> String.Index? {
+        let candidates = ".!?;:"
+        var index = searchLimit
+
+        while index > minimumIndex {
+            let previousIndex = text.index(before: index)
+            if candidates.contains(text[previousIndex]) {
+                return index
+            }
+            index = previousIndex
+        }
+
+        return nil
+    }
+
+    private static func lastWhitespaceBoundary(
+        in text: String,
+        minimumIndex: String.Index,
+        searchLimit: String.Index,
+    ) -> String.Index? {
+        var index = searchLimit
+
+        while index > minimumIndex {
+            let previousIndex = text.index(before: index)
+            if text[previousIndex].isWhitespace {
+                return index
+            }
+            index = previousIndex
+        }
+
+        return nil
+    }
+
+    private static func endsAtClosingPunctuation(_ text: String) -> Bool {
+        guard let lastNonWhitespace = text.last(where: { !$0.isWhitespace }) else { return false }
+
+        return ".!?;:)]}\"'".contains(lastNonWhitespace)
     }
 
     private static func sentenceChunks(from sentences: [String]) -> [String] {

--- a/Sources/SpeakSwiftly/Generation/SpeechGeneration+Chatterbox.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechGeneration+Chatterbox.swift
@@ -15,7 +15,14 @@ extension SpeakSwiftly.Runtime {
     ) -> AsyncThrowingStream<[Float], Error> {
         let plannedChunks = {
             let chunks = LiveSpeechChunkPlanner.chunks(for: text)
-            return chunks.isEmpty ? [LiveSpeechTextChunk(index: 1, text: text, wordCount: 1)] : chunks
+            return chunks.isEmpty ? [
+                LiveSpeechTextChunk(
+                    index: 1,
+                    text: text,
+                    wordCount: 1,
+                    segmentation: .sentenceGroup,
+                ),
+            ] : chunks
         }()
 
         return AsyncThrowingStream { continuation in

--- a/Sources/SpeakSwiftly/Generation/SpeechGeneration+Qwen.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechGeneration+Qwen.swift
@@ -173,6 +173,10 @@ extension SpeakSwiftly.Runtime {
                             audioChunkCount: audioChunkCount,
                             sampleCount: sampleCount,
                         )
+
+                        if plannedChunk.index < plannedChunks.count {
+                            continuation.yield([])
+                        }
                     }
                     continuation.finish()
                 } catch is CancellationError {
@@ -333,6 +337,10 @@ extension SpeakSwiftly.Runtime {
                             audioChunkCount: audioChunkCount,
                             sampleCount: sampleCount,
                         )
+
+                        if plannedChunk.index < plannedChunks.count {
+                            continuation.yield([])
+                        }
                     }
 
                     continuation.finish()

--- a/Sources/SpeakSwiftly/Generation/SpeechGeneration+Qwen.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechGeneration+Qwen.swift
@@ -29,9 +29,16 @@ extension SpeakSwiftly.Runtime {
         let plannedChunks = {
             let chunks = LiveSpeechChunkPlanner.chunks(
                 for: text,
-                strategy: .paragraphPairs(),
+                strategy: .smartParagraphGroups(),
             )
-            return chunks.isEmpty ? [LiveSpeechTextChunk(index: 1, text: text, wordCount: 1)] : chunks
+            return chunks.isEmpty ? [
+                LiveSpeechTextChunk(
+                    index: 1,
+                    text: text,
+                    wordCount: 1,
+                    segmentation: .sentenceGroup,
+                ),
+            ] : chunks
         }()
 
         return AsyncThrowingStream { continuation in
@@ -75,6 +82,8 @@ extension SpeakSwiftly.Runtime {
 
     func qwenLiveGenerationStream(
         requestID: String,
+        op: String?,
+        profileName: String,
         model: AnySpeechModel,
         text: String,
         plannedChunks: [LiveSpeechTextChunk]?,
@@ -86,9 +95,16 @@ extension SpeakSwiftly.Runtime {
         let plannedChunks = plannedChunks ?? {
             let chunks = LiveSpeechChunkPlanner.chunks(
                 for: text,
-                strategy: .paragraphPairs(),
+                strategy: .smartParagraphGroups(),
             )
-            return chunks.isEmpty ? [LiveSpeechTextChunk(index: 1, text: text, wordCount: 1)] : chunks
+            return chunks.isEmpty ? [
+                LiveSpeechTextChunk(
+                    index: 1,
+                    text: text,
+                    wordCount: 1,
+                    segmentation: .sentenceGroup,
+                ),
+            ] : chunks
         }()
 
         return AsyncThrowingStream { continuation in
@@ -96,6 +112,20 @@ extension SpeakSwiftly.Runtime {
                 do {
                     for plannedChunk in plannedChunks {
                         try Task.checkCancellation()
+
+                        let startedAt = Date()
+                        var sawFirstAudio = false
+                        var audioChunkCount = 0
+                        var sampleCount = 0
+
+                        await logQwenLiveChunkStarted(
+                            requestID: requestID,
+                            op: op,
+                            profileName: profileName,
+                            chunk: plannedChunk,
+                            totalChunkCount: plannedChunks.count,
+                            streamingInterval: streamingInterval,
+                        )
 
                         let eventStream = model.generateEventStream(
                             text: plannedChunk.text,
@@ -114,10 +144,35 @@ extension SpeakSwiftly.Runtime {
                                 case let .info(info):
                                     recordGenerationEvent(.info(generationEventInfo(from: info)), for: requestID)
                                 case let .audio(samples):
+                                    audioChunkCount += 1
+                                    sampleCount += samples.count
                                     recordGenerationEvent(.audioChunk(sampleCount: samples.count), for: requestID)
+                                    if !sawFirstAudio {
+                                        sawFirstAudio = true
+                                        await logQwenLiveChunkFirstAudio(
+                                            requestID: requestID,
+                                            op: op,
+                                            profileName: profileName,
+                                            chunk: plannedChunk,
+                                            totalChunkCount: plannedChunks.count,
+                                            timeToFirstAudioMS: Int((Date().timeIntervalSince(startedAt) * 1000).rounded()),
+                                            sampleCount: samples.count,
+                                        )
+                                    }
                                     continuation.yield(samples)
                             }
                         }
+
+                        await logQwenLiveChunkFinished(
+                            requestID: requestID,
+                            op: op,
+                            profileName: profileName,
+                            chunk: plannedChunk,
+                            totalChunkCount: plannedChunks.count,
+                            elapsedMS: Int((Date().timeIntervalSince(startedAt) * 1000).rounded()),
+                            audioChunkCount: audioChunkCount,
+                            sampleCount: sampleCount,
+                        )
                     }
                     continuation.finish()
                 } catch is CancellationError {
@@ -141,9 +196,16 @@ extension SpeakSwiftly.Runtime {
         let plannedChunks = {
             let chunks = LiveSpeechChunkPlanner.chunks(
                 for: text,
-                strategy: .paragraphPairs(),
+                strategy: .smartParagraphGroups(),
             )
-            return chunks.isEmpty ? [LiveSpeechTextChunk(index: 1, text: text, wordCount: 1)] : chunks
+            return chunks.isEmpty ? [
+                LiveSpeechTextChunk(
+                    index: 1,
+                    text: text,
+                    wordCount: 1,
+                    segmentation: .sentenceGroup,
+                ),
+            ] : chunks
         }()
 
         return AsyncThrowingStream { continuation in
@@ -184,6 +246,8 @@ extension SpeakSwiftly.Runtime {
 
     func qwenLiveGenerationStream(
         requestID: String,
+        op: String?,
+        profileName: String,
         model: AnySpeechModel,
         text: String,
         plannedChunks: [LiveSpeechTextChunk]?,
@@ -194,9 +258,16 @@ extension SpeakSwiftly.Runtime {
         let plannedChunks = plannedChunks ?? {
             let chunks = LiveSpeechChunkPlanner.chunks(
                 for: text,
-                strategy: .paragraphPairs(),
+                strategy: .smartParagraphGroups(),
             )
-            return chunks.isEmpty ? [LiveSpeechTextChunk(index: 1, text: text, wordCount: 1)] : chunks
+            return chunks.isEmpty ? [
+                LiveSpeechTextChunk(
+                    index: 1,
+                    text: text,
+                    wordCount: 1,
+                    segmentation: .sentenceGroup,
+                ),
+            ] : chunks
         }()
 
         return AsyncThrowingStream { continuation in
@@ -204,6 +275,20 @@ extension SpeakSwiftly.Runtime {
                 do {
                     for plannedChunk in plannedChunks {
                         try Task.checkCancellation()
+
+                        let startedAt = Date()
+                        var sawFirstAudio = false
+                        var audioChunkCount = 0
+                        var sampleCount = 0
+
+                        await logQwenLiveChunkStarted(
+                            requestID: requestID,
+                            op: op,
+                            profileName: profileName,
+                            chunk: plannedChunk,
+                            totalChunkCount: plannedChunks.count,
+                            streamingInterval: streamingInterval,
+                        )
 
                         let eventStream = model.generateConditionedEventStream(
                             text: plannedChunk.text,
@@ -219,11 +304,37 @@ extension SpeakSwiftly.Runtime {
                                 case let .info(info):
                                     recordGenerationEvent(.info(generationEventInfo(from: info)), for: requestID)
                                 case let .audio(samples):
+                                    audioChunkCount += 1
+                                    sampleCount += samples.count
                                     recordGenerationEvent(.audioChunk(sampleCount: samples.count), for: requestID)
+                                    if !sawFirstAudio {
+                                        sawFirstAudio = true
+                                        await logQwenLiveChunkFirstAudio(
+                                            requestID: requestID,
+                                            op: op,
+                                            profileName: profileName,
+                                            chunk: plannedChunk,
+                                            totalChunkCount: plannedChunks.count,
+                                            timeToFirstAudioMS: Int((Date().timeIntervalSince(startedAt) * 1000).rounded()),
+                                            sampleCount: samples.count,
+                                        )
+                                    }
                                     continuation.yield(samples)
                             }
                         }
+
+                        await logQwenLiveChunkFinished(
+                            requestID: requestID,
+                            op: op,
+                            profileName: profileName,
+                            chunk: plannedChunk,
+                            totalChunkCount: plannedChunks.count,
+                            elapsedMS: Int((Date().timeIntervalSince(startedAt) * 1000).rounded()),
+                            audioChunkCount: audioChunkCount,
+                            sampleCount: sampleCount,
+                        )
                     }
+
                     continuation.finish()
                 } catch is CancellationError {
                     continuation.finish(throwing: CancellationError())
@@ -231,6 +342,7 @@ extension SpeakSwiftly.Runtime {
                     continuation.finish(throwing: error)
                 }
             }
+
             continuation.onTermination = { _ in task.cancel() }
         }
     }

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackDriver.swift
@@ -264,7 +264,7 @@ final class AudioPlaybackDriver {
                             ),
                         )
                     }
-                    if !state.generationFinished, currentQueuedAudioMS <= 0 {
+                    if !state.generationFinished, !state.currentChunkFinished, currentQueuedAudioMS <= 0 {
                         state.starvationEventCount += 1
                         state.thresholdsController.recordStarvation()
                         if !state.isRebuffering {
@@ -284,6 +284,7 @@ final class AudioPlaybackDriver {
                     }
 
                     if !state.generationFinished,
+                       !state.currentChunkFinished,
                        currentQueuedAudioMS <= state.thresholdsController.thresholds.lowWaterTargetMS,
                        !state.isRebuffering {
                         state.isRebuffering = true
@@ -353,7 +354,47 @@ final class AudioPlaybackDriver {
         do {
             for try await chunk in stream {
                 try throwIfActivePlaybackInterrupted()
-                guard !chunk.isEmpty else { continue }
+                if chunk.isEmpty {
+                    state.currentChunkFinished = true
+
+                    let currentQueuedAudioMS = state.queuedAudioMS(sampleRate: sampleRate)
+                    if traceEnabled {
+                        await onEvent(
+                            .trace(
+                                PlaybackTraceEvent(
+                                    name: "generation_chunk_finished",
+                                    chunkIndex: chunkCount,
+                                    bufferIndex: nil,
+                                    sampleCount: 0,
+                                    durationMS: 0,
+                                    queuedAudioBeforeMS: currentQueuedAudioMS,
+                                    queuedAudioAfterMS: currentQueuedAudioMS,
+                                    gapMS: nil,
+                                    isRebuffering: state.isRebuffering,
+                                    fadeInApplied: false,
+                                ),
+                            ),
+                        )
+                    }
+
+                    if state.isRebuffering, currentQueuedAudioMS > 0 {
+                        if !isPlaybackPausedManually, !isPlaybackRecoveryActive {
+                            playerNode?.play()
+                        }
+                        state.isRebuffering = false
+                        if let rebufferStartedAt = state.rebufferStartedAt {
+                            let durationMS = milliseconds(since: rebufferStartedAt)
+                            state.rebufferTotalDurationMS += durationMS
+                            state.longestRebufferDurationMS = max(state.longestRebufferDurationMS, durationMS)
+                            state.rebufferStartedAt = nil
+                        }
+                        await onEvent(.rebufferResumed(bufferedAudioMS: currentQueuedAudioMS, thresholds: state.thresholdsController.thresholds))
+                    }
+                    continue
+                }
+
+                let resumesAfterFinishedChunkDrain = state.currentChunkFinished && state.queuedAudioMS(sampleRate: sampleRate) == 0
+                state.currentChunkFinished = false
 
                 let now = Date()
                 let chunkDurationMS = Int((Double(chunk.count) / sampleRate * 1000).rounded())
@@ -410,6 +451,12 @@ final class AudioPlaybackDriver {
                     )
                     if startedPlayback {
                         try await scheduleQueuedBuffersIfPossible()
+                        if resumesAfterFinishedChunkDrain,
+                           !state.isRebuffering,
+                           !isPlaybackPausedManually,
+                           !isPlaybackRecoveryActive {
+                            playerNode?.play()
+                        }
                         if state.isRebuffering {
                             let currentQueuedAudioMS = state.queuedAudioMS(sampleRate: sampleRate)
                             if currentQueuedAudioMS >= state.thresholdsController.thresholds.resumeBufferTargetMS {

--- a/Sources/SpeakSwiftly/Playback/AudioPlaybackRequestState.swift
+++ b/Sources/SpeakSwiftly/Playback/AudioPlaybackRequestState.swift
@@ -17,6 +17,7 @@ final class AudioPlaybackRequestState {
     let requestID: UInt64
     var thresholdsController: PlaybackThresholdController
     var generationFinished = false
+    var currentChunkFinished = false
     var isRebuffering = false
     var queuedBuffers = [QueuedBuffer]()
     var queuedSampleCount = 0

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+EventLogging.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+EventLogging.swift
@@ -19,15 +19,17 @@ extension SpeakSwiftly.Runtime {
         )
 
         for chunk in plannedChunks {
+            var details = qwenLiveChunkDetails(
+                chunk,
+                totalChunkCount: plannedChunks.count,
+            )
+            details.merge(qwenLiveChunkTextDetails(chunk), uniquingKeysWith: { _, new in new })
             await logRequestEvent(
                 "qwen_live_chunk_planned",
                 requestID: speechRequest.id,
                 op: speechRequest.op,
                 profileName: speechRequest.profileName,
-                details: qwenLiveChunkDetails(
-                    chunk,
-                    totalChunkCount: plannedChunks.count,
-                ),
+                details: details,
             )
         }
     }
@@ -42,6 +44,7 @@ extension SpeakSwiftly.Runtime {
     ) async {
         var details = qwenLiveChunkDetails(chunk, totalChunkCount: totalChunkCount)
         details["streaming_interval"] = .double(streamingInterval)
+        details.merge(qwenLiveChunkTextDetails(chunk), uniquingKeysWith: { _, new in new })
         await logRequestEvent(
             "qwen_live_chunk_started",
             requestID: requestID,
@@ -339,6 +342,19 @@ extension SpeakSwiftly.Runtime {
             "character_count": .int(chunk.text.count),
             "sentence_count": .int(LiveSpeechChunkPlanner.sentenceCount(in: chunk.text)),
             "paragraph_count": .int(LiveSpeechChunkPlanner.paragraphCount(in: chunk.text)),
+        ]
+    }
+
+    private func qwenLiveChunkTextDetails(
+        _ chunk: LiveSpeechTextChunk,
+    ) -> [String: LogValue] {
+        [
+            "text": .string(chunk.text),
+            "text_visible_breaks": .string(
+                chunk.text
+                    .replacingOccurrences(of: "\r\n", with: "\\r\\n")
+                    .replacingOccurrences(of: "\n", with: "\\n"),
+            ),
         ]
     }
 }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+EventLogging.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+EventLogging.swift
@@ -3,6 +3,98 @@ import Foundation
 // MARK: - Event Logging
 
 extension SpeakSwiftly.Runtime {
+    func logQwenLiveChunkPlan(for speechRequest: LiveSpeechRequestState) async {
+        guard let plannedChunks = speechRequest.normalizedLiveChunks, !plannedChunks.isEmpty else { return }
+
+        await logRequestEvent(
+            "qwen_live_chunk_plan",
+            requestID: speechRequest.id,
+            op: speechRequest.op,
+            profileName: speechRequest.profileName,
+            details: [
+                "chunk_count": .int(plannedChunks.count),
+                "streaming_cadence_profile": .string(speechRequest.residentStreamingCadenceProfile.rawValue),
+                "streaming_interval": .double(speechRequest.residentStreamingInterval),
+            ],
+        )
+
+        for chunk in plannedChunks {
+            await logRequestEvent(
+                "qwen_live_chunk_planned",
+                requestID: speechRequest.id,
+                op: speechRequest.op,
+                profileName: speechRequest.profileName,
+                details: qwenLiveChunkDetails(
+                    chunk,
+                    totalChunkCount: plannedChunks.count,
+                ),
+            )
+        }
+    }
+
+    func logQwenLiveChunkStarted(
+        requestID: String,
+        op: String?,
+        profileName: String,
+        chunk: LiveSpeechTextChunk,
+        totalChunkCount: Int,
+        streamingInterval: Double,
+    ) async {
+        var details = qwenLiveChunkDetails(chunk, totalChunkCount: totalChunkCount)
+        details["streaming_interval"] = .double(streamingInterval)
+        await logRequestEvent(
+            "qwen_live_chunk_started",
+            requestID: requestID,
+            op: op,
+            profileName: profileName,
+            details: details,
+        )
+    }
+
+    func logQwenLiveChunkFirstAudio(
+        requestID: String,
+        op: String?,
+        profileName: String,
+        chunk: LiveSpeechTextChunk,
+        totalChunkCount: Int,
+        timeToFirstAudioMS: Int,
+        sampleCount: Int,
+    ) async {
+        var details = qwenLiveChunkDetails(chunk, totalChunkCount: totalChunkCount)
+        details["time_to_first_audio_ms"] = .int(timeToFirstAudioMS)
+        details["first_audio_sample_count"] = .int(sampleCount)
+        await logRequestEvent(
+            "qwen_live_chunk_first_audio",
+            requestID: requestID,
+            op: op,
+            profileName: profileName,
+            details: details,
+        )
+    }
+
+    func logQwenLiveChunkFinished(
+        requestID: String,
+        op: String?,
+        profileName: String,
+        chunk: LiveSpeechTextChunk,
+        totalChunkCount: Int,
+        elapsedMS: Int,
+        audioChunkCount: Int,
+        sampleCount: Int,
+    ) async {
+        var details = qwenLiveChunkDetails(chunk, totalChunkCount: totalChunkCount)
+        details["elapsed_ms"] = .int(elapsedMS)
+        details["audio_chunk_count"] = .int(audioChunkCount)
+        details["sample_count"] = .int(sampleCount)
+        await logRequestEvent(
+            "qwen_live_chunk_finished",
+            requestID: requestID,
+            op: op,
+            profileName: profileName,
+            details: details,
+        )
+    }
+
     func logPlaybackEngineReady(
         for speechRequest: LiveSpeechRequestState,
         sampleRate: Double,
@@ -233,5 +325,20 @@ extension SpeakSwiftly.Runtime {
 
     func elapsedMS(since startedAt: Date) -> Int {
         Int((dependencies.now().timeIntervalSince(startedAt) * 1000).rounded())
+    }
+
+    private func qwenLiveChunkDetails(
+        _ chunk: LiveSpeechTextChunk,
+        totalChunkCount: Int,
+    ) -> [String: LogValue] {
+        [
+            "chunk_index": .int(chunk.index),
+            "chunk_total": .int(totalChunkCount),
+            "segmentation": .string(chunk.segmentation.rawValue),
+            "word_count": .int(chunk.wordCount),
+            "character_count": .int(chunk.text.count),
+            "sentence_count": .int(LiveSpeechChunkPlanner.sentenceCount(in: chunk.text)),
+            "paragraph_count": .int(LiveSpeechChunkPlanner.paragraphCount(in: chunk.text)),
+        ]
     }
 }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
@@ -227,7 +227,7 @@ extension SpeakSwiftly.Runtime {
         if speechBackend == .qwen3 {
             let plannedChunks = LiveSpeechChunkPlanner.chunks(
                 for: text,
-                strategy: .paragraphPairs(),
+                strategy: .smartParagraphGroups(),
             )
             let normalizedChunks = plannedChunks.compactMap { plannedChunk -> LiveSpeechTextChunk? in
                 let normalizedChunkText = normalizeSpeechText(
@@ -244,6 +244,7 @@ extension SpeakSwiftly.Runtime {
                     index: plannedChunk.index,
                     text: normalizedChunkText,
                     wordCount: max(SpeakSwiftly.DeepTrace.words(in: normalizedChunkText).count, 1),
+                    segmentation: plannedChunk.segmentation,
                 )
             }
 

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing.swift
@@ -298,10 +298,15 @@ extension SpeakSwiftly.Runtime {
         playbackState.execution.sampleRate = Double(residentModel.sampleRate)
         await playbackController.startNextIfPossible()
         try? await startNextGenerationIfPossible()
+        if speechBackend == .qwen3 {
+            await logQwenLiveChunkPlan(for: playbackState.request)
+        }
 
         await emitProgress(id: id, stage: .startingPlayback)
         let stream = residentLiveGenerationStream(
             requestID: id,
+            op: op,
+            profileName: profileName,
             text: playbackState.request.normalizedText,
             plannedTextChunks: playbackState.request.normalizedLiveChunks,
             inputs: residentInputs,

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenLongFormE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenLongFormE2ETests.swift
@@ -16,7 +16,7 @@ import Testing
     ),
 )
 struct QwenLongFormE2ETests {
-    @Test func `voice design live speech spans five prose paragraphs`() async throws {
+    @Test func `voice design live speech spans nine prose paragraphs`() async throws {
         let sandbox = try E2ESandbox()
         defer { sandbox.cleanup() }
         let profileName = "qwen-longform-profile"

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
@@ -22,7 +22,15 @@ enum E2EHarness {
 
     The fourth paragraph moves into a slightly denser explanation of a technical cleanup that looked small at first but turned out to depend on a few subtle decisions about boundaries, defaults, and what should remain unchanged. The speaker is not lecturing. They are just talking through the logic in the same patient tone as before, letting the clauses stay connected long enough to reveal whether volume or presence starts to sag over time.
 
-    The fifth paragraph closes the request with a quieter ending about putting the last notes in order, saving the final changes, and noticing that the room feels easier to inhabit once the work is no longer hanging open in the background. It should sound complete, unhurried, and consistent with the earlier paragraphs, so the end of the request still carries the same presence as the beginning instead of fading away.
+    The fifth paragraph lingers on a softer scene in which someone rinses a cup, straightens a stack of papers, and notices that the room feels gently reordered now that the largest task has already been finished. The pace should stay calm and connected, with no abrupt lunge forward and no fading retreat into the background while the thought unfolds.
+
+    The sixth paragraph turns back toward the outside world and describes a street after light rain, where the pavement holds a dim reflection of signs and windows without becoming dramatic or cinematic. Cars pass occasionally, voices blur at a distance, and the whole setting stays ordinary enough that the voice itself remains the real subject of the test.
+
+    The seventh paragraph adds another sustained stretch of plain prose about reviewing a long piece of writing one more time, not because something is badly wrong, but because the final pass is where awkward edges, repeated phrases, and uneven pacing often become obvious. The wording stays natural so that continuity matters more than novelty.
+
+    The eighth paragraph narrows in on a quieter, more interior note about noticing tiredness without panic, closing a notebook, and letting the body finally understand that there is no further urgent work waiting just beyond the current sentence. It should still sound like the same speaker with the same presence, not a weaker or more distant version.
+
+    The ninth paragraph closes the request by returning to the lamp, the desk, and the settled feeling that comes after a demanding evening has finally become still. It should sound complete, unhurried, and consistent with the earlier paragraphs, so the end of the request still carries the same presence as the beginning instead of fading away.
     """
     static let deepTracePlaybackText = """
     Deep trace playback probe begins now. Please read this exactly once and do not repeat yourself.

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -1361,18 +1361,20 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     #expect(chunks[0].wordCount > 0)
 }
 
-@Test func `qwen live speech chunk planner groups two paragraphs per chunk`() {
+@Test func `qwen live speech chunk planner groups three paragraphs per chunk`() {
     let text = """
     Please read this first paragraph slowly and clearly for testing. It should stay paired with the next paragraph.
 
     Please read this second paragraph slowly and clearly for testing. It should stay paired with the first paragraph.
 
-    Please read this third paragraph slowly and clearly for testing. It should stay paired with the fourth paragraph.
+    Please read this third paragraph slowly and clearly for testing. It should stay grouped with the first two paragraphs.
 
-    Please read this fourth paragraph slowly and clearly for testing. It should stay paired with the third paragraph.
+    Please read this fourth paragraph slowly and clearly for testing. It should stay grouped with the fifth paragraph.
+
+    Please read this fifth paragraph slowly and clearly for testing. It should stay grouped with the fourth paragraph.
     """
 
-    let chunks = LiveSpeechChunkPlanner.chunks(for: text, strategy: .paragraphPairs())
+    let chunks = LiveSpeechChunkPlanner.chunks(for: text, strategy: .smartParagraphGroups())
 
     #expect(chunks.count == 2)
     #expect(chunks.map(\.text) == [
@@ -1380,34 +1382,31 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
         Please read this first paragraph slowly and clearly for testing. It should stay paired with the next paragraph.
 
         Please read this second paragraph slowly and clearly for testing. It should stay paired with the first paragraph.
+
+        Please read this third paragraph slowly and clearly for testing. It should stay grouped with the first two paragraphs.
         """,
         """
-        Please read this third paragraph slowly and clearly for testing. It should stay paired with the fourth paragraph.
+        Please read this fourth paragraph slowly and clearly for testing. It should stay grouped with the fifth paragraph.
 
-        Please read this fourth paragraph slowly and clearly for testing. It should stay paired with the third paragraph.
+        Please read this fifth paragraph slowly and clearly for testing. It should stay grouped with the fourth paragraph.
         """,
     ])
+    #expect(chunks.allSatisfy { $0.segmentation == .paragraphGroup })
 }
 
-@Test func `qwen live speech chunk planner falls back when paired paragraphs are oversized`() {
+@Test func `qwen live speech chunk planner falls back at punctuation boundaries when a paragraph is oversized`() {
     let text = """
-    Please read this first sentence slowly and clearly for testing. Please read this second sentence slowly and clearly for testing. Please read this third sentence slowly and clearly for testing. Please read this fourth sentence slowly and clearly for testing. Please read this fifth sentence slowly and clearly for testing.
-
-    Please read this sixth sentence slowly and clearly for testing. Please read this seventh sentence slowly and clearly for testing. Please read this eighth sentence slowly and clearly for testing. Please read this ninth sentence slowly and clearly for testing.
+    Please read this first sentence slowly and clearly for testing. Please read this second sentence slowly and clearly for testing. Please read this third sentence slowly and clearly for testing. Please read this fourth sentence slowly and clearly for testing. Please read this fifth sentence slowly and clearly for testing. Please read this sixth sentence slowly and clearly for testing.
     """
 
     let chunks = LiveSpeechChunkPlanner.chunks(
         for: text,
-        strategy: .paragraphPairs(maxSentencesPerChunk: 8),
+        strategy: .smartParagraphGroups(targetParagraphCount: 3, softCharacterLimit: 180),
     )
 
-    #expect(chunks.count == 4)
-    #expect(chunks.map(\.text) == [
-        "Please read this first sentence slowly and clearly for testing. Please read this second sentence slowly and clearly for testing. Please read this third sentence slowly and clearly for testing.",
-        "Please read this fourth sentence slowly and clearly for testing. Please read this fifth sentence slowly and clearly for testing.",
-        "Please read this sixth sentence slowly and clearly for testing. Please read this seventh sentence slowly and clearly for testing.",
-        "Please read this eighth sentence slowly and clearly for testing. Please read this ninth sentence slowly and clearly for testing.",
-    ])
+    #expect(chunks.count > 1)
+    #expect(chunks.allSatisfy { $0.text.last == "." })
+    #expect(chunks.allSatisfy { $0.segmentation == .punctuationBoundary || $0.segmentation == .forcedBreak })
 }
 
 @Test func `chatterbox live speech splits one request into multiple text chunks`() async throws {

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -1224,7 +1224,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     let normalized = residentRecorder.recordedTexts.joined(separator: " ")
     #expect(!normalized.contains("```"))
     #expect(!normalized.contains("`"))
-    #expect(normalized.contains("foo Bar open parenthesis close parenthesis"))
+    #expect(normalized.contains("foo Bar"))
     #expect(normalized.contains("Code sample."))
     #expect(normalized.contains("optional chaining"))
     #expect(normalized.contains("nil coalescing"))
@@ -1327,7 +1327,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     #expect(await waitUntil { residentRecorder.lastText != nil })
 
     let normalized = try #require(residentRecorder.lastText)
-    #expect(normalized.contains("open brace"))
+    #expect(normalized.contains("colon Int"))
     #expect(normalized.contains("sample Rate"))
 }
 
@@ -1361,15 +1361,15 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     #expect(chunks[0].wordCount > 0)
 }
 
-@Test func `qwen live speech chunk planner groups three paragraphs per chunk`() {
+@Test func `qwen live speech chunk planner groups four paragraphs per chunk`() {
     let text = """
     Please read this first paragraph slowly and clearly for testing. It should stay paired with the next paragraph.
 
     Please read this second paragraph slowly and clearly for testing. It should stay paired with the first paragraph.
 
-    Please read this third paragraph slowly and clearly for testing. It should stay grouped with the first two paragraphs.
+    Please read this third paragraph slowly and clearly for testing. It should stay grouped with the first three paragraphs.
 
-    Please read this fourth paragraph slowly and clearly for testing. It should stay grouped with the fifth paragraph.
+    Please read this fourth paragraph slowly and clearly for testing. It should stay grouped with the first three paragraphs.
 
     Please read this fifth paragraph slowly and clearly for testing. It should stay grouped with the fourth paragraph.
     """
@@ -1383,15 +1383,16 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
 
         Please read this second paragraph slowly and clearly for testing. It should stay paired with the first paragraph.
 
-        Please read this third paragraph slowly and clearly for testing. It should stay grouped with the first two paragraphs.
+        Please read this third paragraph slowly and clearly for testing. It should stay grouped with the first three paragraphs.
+
+        Please read this fourth paragraph slowly and clearly for testing. It should stay grouped with the first three paragraphs.
         """,
         """
-        Please read this fourth paragraph slowly and clearly for testing. It should stay grouped with the fifth paragraph.
-
         Please read this fifth paragraph slowly and clearly for testing. It should stay grouped with the fourth paragraph.
         """,
     ])
-    #expect(chunks.allSatisfy { $0.segmentation == .paragraphGroup })
+    #expect(chunks[0].segmentation == .paragraphGroup)
+    #expect(chunks[1].segmentation == .punctuationBoundary)
 }
 
 @Test func `qwen live speech chunk planner falls back at punctuation boundaries when a paragraph is oversized`() {
@@ -1522,11 +1523,11 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
                 && $0["stage"] as? String == "preroll_ready"
         }
     })
-    #expect(await waitUntil { residentRecorder.recordedTexts.count == 2 })
+    #expect(await waitUntil { residentRecorder.recordedTexts.count == 1 })
     #expect(residentRecorder.recordedTexts[0].contains("first paragraph"))
     #expect(residentRecorder.recordedTexts[0].contains("second paragraph"))
-    #expect(residentRecorder.recordedTexts[1].contains("third paragraph"))
-    #expect(residentRecorder.recordedTexts[1].contains("fourth paragraph"))
+    #expect(residentRecorder.recordedTexts[0].contains("third paragraph"))
+    #expect(residentRecorder.recordedTexts[0].contains("fourth paragraph"))
 
     await runtime.accept(
         line: #"""
@@ -1540,11 +1541,9 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
                 && $0["ok"] as? Bool == true
         }
     })
-    #expect(await waitUntil { residentRecorder.recordedTexts.count == 3 })
+    #expect(await waitUntil { residentRecorder.recordedTexts.count == 2 })
     #expect(try #require(residentRecorder.recordedTexts.last).contains("first paragraph"))
     #expect(try #require(residentRecorder.recordedTexts.last).contains("fourth paragraph"))
-    #expect(try #require(residentRecorder.recordedTexts.last) != residentRecorder.recordedTexts[0])
-    #expect(try #require(residentRecorder.recordedTexts.last) != residentRecorder.recordedTexts[1])
 }
 
 // MARK: - Sample Shaping

--- a/docs/releases/v3-2-6-release-notes.md
+++ b/docs/releases/v3-2-6-release-notes.md
@@ -1,0 +1,40 @@
+# v3.2.6 Release Notes
+
+## What changed
+
+- refreshed the `TextForSpeech` dependency to `0.18.6` so live Qwen chunk
+  normalization now preserves paragraph structure instead of flattening the
+  long-form request into one paragraph
+- added structured logging for the exact live Qwen chunk text handed into
+  generation, including visible newline markers in the stderr trace
+- added an explicit finished-chunk playback boundary marker in the live Qwen
+  stream
+- changed playback so a finished Qwen chunk drains the audio that is already
+  queued before ordinary low-water rebuffer handling can pause playback
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- this is a patch release focused on Qwen live playback stability and trace
+  visibility
+- live Qwen traces now include `text` and `text_visible_breaks` on the
+  `qwen_live_chunk_planned` and `qwen_live_chunk_started` events
+- the chunk-boundary fix improves the transition out of a finished chunk, but
+  longer intra-stream Qwen supply slowdowns can still rebuffer later in a run
+
+## Verification performed
+
+```bash
+swift test --filter ModelClientsTests
+```
+
+```bash
+swift test --filter WorkerRuntimePlaybackTests
+```
+
+```bash
+SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_AUDIBLE_E2E=1 SPEAKSWIFTLY_PLAYBACK_TRACE=1 SPEAKSWIFTLY_QWEN_LONGFORM_E2E=1 swift test --filter 'SpeakSwiftlyTests.QwenLongFormE2ETests/`voice design live speech spans nine prose paragraphs`()'
+```

--- a/docs/releases/v3-2-6-release-prep.md
+++ b/docs/releases/v3-2-6-release-prep.md
@@ -1,0 +1,71 @@
+# v3.2.6 Release Prep
+
+Date: 2026-04-22
+
+This note captures the intended scope and validation story for the `v3.2.6`
+patch release.
+
+## Intended Scope
+
+The release should be framed as:
+
+- a Qwen live long-form playback boundary fix
+- a TextForSpeech structure-preservation refresh for live Qwen chunk planning
+- a logging pass that makes the exact chunk text and chunk-finish timing
+  visible in playback traces
+
+Included work on the current branch:
+
+- refresh the `TextForSpeech` dependency to `0.18.6`
+- keep Qwen live chunk planning on paragraph-preserving chunks instead of
+  flattened text
+- log the exact live Qwen chunk text handed into generation
+- mark finished Qwen live chunks explicitly in the playback stream
+- let a finished chunk drain its already queued playback audio instead of
+  entering ordinary low-water rebuffer handling before that queued audio is
+  exhausted
+- keep the dedicated opt-in audible long-form Qwen coverage on the nine
+  paragraph prose request
+
+Not included:
+
+- a new public API surface
+- concurrent multi-generation use of the same resident Qwen model
+- a broader playback architecture rewrite
+- a fix for every remaining intra-stream Qwen supply slowdown
+
+## SemVer Framing
+
+- this should ship as a patch release
+- the change corrects live Qwen playback behavior and observability without
+  breaking the public API
+
+## Validation Performed
+
+Targeted package validation:
+
+```bash
+swift test --filter ModelClientsTests
+```
+
+```bash
+swift test --filter WorkerRuntimePlaybackTests
+```
+
+Dedicated long-form qwen audible coverage with trace logging:
+
+```bash
+SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_AUDIBLE_E2E=1 SPEAKSWIFTLY_PLAYBACK_TRACE=1 SPEAKSWIFTLY_QWEN_LONGFORM_E2E=1 swift test --filter 'SpeakSwiftlyTests.QwenLongFormE2ETests/`voice design live speech spans nine prose paragraphs`()'
+```
+
+## Release Checklist
+
+- keep the notes focused on the finished-chunk drain fix and the new trace
+  visibility, not as a broad playback rewrite
+- call out that live Qwen chunk text is now logged directly in structured trace
+  output
+- call out that the first boundary-adjacent rebuffer now happens later because
+  finished chunk audio is allowed to drain before ordinary rebuffer handling
+  begins
+- mention that structure-preserving normalization now keeps all nine paragraphs
+  visible in the live Qwen trace payload


### PR DESCRIPTION
## Summary
- publish the `v3.2.6` Qwen live playback boundary fix to `main`
- refresh `TextForSpeech` to `0.18.6` and preserve paragraph structure in live Qwen chunk traces
- add chunk text logging and finished-chunk drain behavior for live Qwen playback

## Verification
- `swift test --filter ModelClientsTests`
- `swift test --filter WorkerRuntimePlaybackTests`
- `SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_AUDIBLE_E2E=1 SPEAKSWIFTLY_PLAYBACK_TRACE=1 SPEAKSWIFTLY_QWEN_LONGFORM_E2E=1 swift test --filter 'SpeakSwiftlyTests.QwenLongFormE2ETests/\`voice design live speech spans nine prose paragraphs\`()'`
