### PR TITLE
release: prepare v4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ let requestHandle = await runtime.generate.audio(
 ```
 
 The typed Swift surface uses `voiceProfile`, `textProfile`, `inputTextContext`, and `requestContext`.
+`SpeakSwiftly.RequestContext` is the shared `TextForSpeech.RequestContext` model, so the same request-origin metadata shape can move unchanged between normalization, generation, and downstream packages that import `SpeakSwiftly`.
 The JSONL worker now uses those same generation concepts with snake_case keys such as `voice_profile`, `text_profile`, `input_text_context`, and `request_context`. Older generation-request aliases like `profile_name` and `text_profile_id` are still accepted for compatibility.
 
 The runtime is organized around stored concern handles that callers can keep and reuse:

--- a/Sources/SpeakSwiftly/SpeakSwiftly.swift
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.swift
@@ -30,49 +30,10 @@ public enum SpeakSwiftly {
     }
 
     /// Describes where a generation request came from and what it is related to.
-    public struct RequestContext: Codable, Sendable, Equatable {
-        enum CodingKeys: String, CodingKey {
-            case source
-            case app
-            case agent
-            case project
-            case topic
-            case attributes
-        }
-
-        public let source: String?
-        public let app: String?
-        public let agent: String?
-        public let project: String?
-        public let topic: String?
-        public let attributes: [String: String]
-
-        public init(
-            source: String? = nil,
-            app: String? = nil,
-            agent: String? = nil,
-            project: String? = nil,
-            topic: String? = nil,
-            attributes: [String: String] = [:],
-        ) {
-            self.source = source
-            self.app = app
-            self.agent = agent
-            self.project = project
-            self.topic = topic
-            self.attributes = attributes
-        }
-
-        public init(from decoder: any Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            source = try container.decodeIfPresent(String.self, forKey: .source)
-            app = try container.decodeIfPresent(String.self, forKey: .app)
-            agent = try container.decodeIfPresent(String.self, forKey: .agent)
-            project = try container.decodeIfPresent(String.self, forKey: .project)
-            topic = try container.decodeIfPresent(String.self, forKey: .topic)
-            attributes = try container.decodeIfPresent([String: String].self, forKey: .attributes) ?? [:]
-        }
-    }
+    ///
+    /// `TextForSpeech` owns the concrete model so request metadata stays identical
+    /// across normalization, generation, and downstream server surfaces.
+    public typealias RequestContext = TextForSpeech.RequestContext
 
     /// Describes the current playback state of the live audio player.
     public enum PlaybackState: String, Codable, Sendable, Equatable {

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -18,6 +18,20 @@ import Darwin
     _ = normalizer
 }
 
+@Test func `public request context aliases the TextForSpeech model`() throws {
+    let requestContext = SpeakSwiftly.RequestContext(
+        source: "codex",
+        app: "SpeakSwiftlyServer",
+        project: "SpeakSwiftly",
+        attributes: ["surface": "mcp"],
+    )
+    let encoded = try JSONEncoder().encode(requestContext)
+    let decoded = try JSONDecoder().decode(TextForSpeech.RequestContext.self, from: encoded)
+
+    #expect(decoded == requestContext)
+    #expect(decoded.attributes == ["surface": "mcp"])
+}
+
 @Test func `public library surface constructs configuration`() {
     let configuration = SpeakSwiftly.Configuration(
         speechBackend: .marvis,

--- a/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedBatchE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedBatchE2ETests.swift
@@ -45,7 +45,7 @@ struct GeneratedBatchE2ETests {
         )
 
         #expect(generatedBatch["batch_id"] as? String == "req-generated-batch-e2e")
-        #expect(generatedBatch["profile_name"] as? String == E2EHarness.testingProfileName)
+        #expect(generatedBatch["voice_profile"] as? String == E2EHarness.testingProfileName)
         #expect(generatedBatch["state"] as? String == "completed")
 
         let artifacts = try #require(generatedBatch["artifacts"] as? [[String: Any]])

--- a/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
@@ -40,7 +40,7 @@ struct GeneratedFileE2ETests {
         )
         let artifactID = "req-generated-file-e2e-artifact-1"
         #expect(generatedFile["artifact_id"] as? String == artifactID)
-        #expect(generatedFile["profile_name"] as? String == E2EHarness.testingProfileName)
+        #expect(generatedFile["voice_profile"] as? String == E2EHarness.testingProfileName)
 
         let generatedFilePath = try #require(generatedFile["file_path"] as? String)
         #expect(FileManager.default.fileExists(atPath: generatedFilePath))

--- a/Tests/SpeakSwiftlyTests/E2E/Chatterbox/ChatterboxWorkflowE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Chatterbox/ChatterboxWorkflowE2ETests.swift
@@ -45,7 +45,7 @@ struct ChatterboxE2ETests {
             text: E2EHarness.testingPlaybackText,
             profileName: profileName,
         )
-        #expect(generatedFile["profile_name"] as? String == profileName)
+        #expect(generatedFile["voice_profile"] as? String == profileName)
         try worker.closeInput()
         try await worker.waitForExit(timeout: .seconds(30))
     }

--- a/Tests/SpeakSwiftlyTests/E2E/QuickTest/QuickE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/QuickTest/QuickE2ETests.swift
@@ -40,7 +40,7 @@ struct QuickE2ETests {
         )
 
         #expect(generatedFile["artifact_id"] as? String == "req-quick-generated-file-artifact-1")
-        #expect(generatedFile["profile_name"] as? String == E2EHarness.testingProfileName)
+        #expect(generatedFile["voice_profile"] as? String == E2EHarness.testingProfileName)
 
         let generatedFilePath = try #require(generatedFile["file_path"] as? String)
         #expect(FileManager.default.fileExists(atPath: generatedFilePath))

--- a/docs/releases/v4-0-1-release-notes.md
+++ b/docs/releases/v4-0-1-release-notes.md
@@ -1,0 +1,38 @@
+# v4.0.1 Release Notes
+
+## What changed
+
+- changed `SpeakSwiftly.RequestContext` to a public typealias for
+  `TextForSpeech.RequestContext`, so request-origin metadata now uses one
+  shared concrete model across normalization, generation, and downstream
+  packages that import `SpeakSwiftly`
+- added a library-surface regression test that proves the shared request
+  context still round-trips through the public `SpeakSwiftly` API
+- refreshed generated-artifact E2E assertions to use the current
+  `voice_profile` field in generated file and generated batch payloads
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- existing callers can keep spelling the type as `SpeakSwiftly.RequestContext`
+- generated artifact payloads continue to use `voice_profile`; this release
+  updates stale E2E coverage to match that existing contract
+- this release starts the stable `v4.0.x` line from the earlier
+  `v4.0.0-rc.1` prerelease branch
+
+## Verification performed
+
+```bash
+swift build
+```
+
+```bash
+swift test
+```
+
+```bash
+sh scripts/repo-maintenance/run-e2e-full.sh
+```

--- a/docs/releases/v4-0-1-release-prep.md
+++ b/docs/releases/v4-0-1-release-prep.md
@@ -1,0 +1,69 @@
+# v4.0.1 Release Prep
+
+Date: 2026-04-23
+
+This note captures the intended scope and validation story for the `v4.0.1`
+release.
+
+## Intended Scope
+
+The release should be framed as:
+
+- a shared request-context model dedupe across `SpeakSwiftly` and
+  `TextForSpeech`
+- an end-to-end contract cleanup for generated artifact metadata
+- a release validation pass that proves the current full E2E lane still clears
+  after the shared-type adoption
+
+Included work on the current branch:
+
+- replace the standalone `SpeakSwiftly.RequestContext` struct with a public
+  typealias to `TextForSpeech.RequestContext`
+- add a library-surface test that proves the shared request-context model still
+  round-trips through the public `SpeakSwiftly` API
+- document the shared request-context ownership in the package README
+- update E2E artifact assertions to use the current `voice_profile` field name
+  in generated file and generated batch payloads
+- rerun the full release-safe E2E lane after the stale field-name assertions
+  were corrected
+
+Not included:
+
+- a wider public API redesign beyond request-context ownership cleanup
+- a worker wire-format compatibility shim that reintroduces `profile_name`
+  inside generated artifact payloads
+- a broader release-management reorganization for the `v4` line
+
+## SemVer Framing
+
+- release this as `v4.0.1`
+- the package-side API cleanup keeps `SpeakSwiftly.RequestContext` available to
+  callers while deduplicating the underlying concrete model
+- the E2E fixes correct stale tests to match the existing generated-artifact
+  payload shape
+
+## Validation Performed
+
+Baseline package validation:
+
+```bash
+swift build
+```
+
+```bash
+swift test
+```
+
+Full release-safe end-to-end lane:
+
+```bash
+sh scripts/repo-maintenance/run-e2e-full.sh
+```
+
+## Release Checklist
+
+- call out that `SpeakSwiftly.RequestContext` now shares the concrete
+  `TextForSpeech.RequestContext` model instead of duplicating it locally
+- note that the generated-artifact E2E fixes were contract-alignment changes in
+  the tests, not worker payload regressions
+- include the full E2E lane in the release verification story


### PR DESCRIPTION
## Summary
- deduplicate `SpeakSwiftly.RequestContext` onto `TextForSpeech.RequestContext`
- align generated-artifact E2E assertions with the current `voice_profile` worker payload
- add `v4.0.1` release notes and prep docs

## Verification
- sh scripts/repo-maintenance/run-e2e-full.sh
- swift build
- swift test