### PR TITLE
generation: keep Qwen file generation single pass

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -151,6 +151,7 @@ Tickets:
 - [ ] Compare the currently pinned `mlx-audio-swift` revision with the latest available tagged release or stable candidate.
 - [ ] Review upstream changes to Qwen3 TTS defaults, generation controls, streaming behavior, and model-loading expectations for any impact on `SpeakSwiftly`.
 - [ ] Preserve upstream `AudioGeneration` event detail through a first-class side-channel, trace stream, or equivalent logging surface instead of collapsing every resident generation path down to raw sample chunks at the first wrapper boundary.
+- [ ] Land durable Qwen generated-code investigation tooling on `main`, including capture, replay, code-stream comparison, and WAV-side prosody inspection commands that replace the invalid `compare-volume` diagnostic path.
 - [x] Add a first-class chunked live-generation path for non-streaming backends, so `SpeakSwiftly` can segment text up front, synthesize chunk waveforms sequentially, and feed completed audio chunks into playback without waiting for full-request synthesis to finish.
 - [ ] Evaluate whether the current resident backend defaults are still the right MLX choices on current Apple Silicon, and record the latency, memory, and audible tradeoffs explicitly.
 - [ ] Generalize stored Qwen materializations so profiles can load backend-appropriate conditioning material without assuming one hard-coded shape forever.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -152,6 +152,8 @@ Tickets:
 - [ ] Review upstream changes to Qwen3 TTS defaults, generation controls, streaming behavior, and model-loading expectations for any impact on `SpeakSwiftly`.
 - [ ] Preserve upstream `AudioGeneration` event detail through a first-class side-channel, trace stream, or equivalent logging surface instead of collapsing every resident generation path down to raw sample chunks at the first wrapper boundary.
 - [ ] Land durable Qwen generated-code investigation tooling on `main`, including capture, replay, code-stream comparison, and WAV-side prosody inspection commands that replace the invalid `compare-volume` diagnostic path.
+- [ ] Add Qwen E2E quality gates that inspect late-generation behavior, repeated or spiraling output, suspicious token/audio length, and per-chunk tail drift instead of treating playback completion as sufficient proof of speech quality.
+- [ ] Run the sampling-headroom investigation described in `docs/maintainers/qwen-sampling-headroom-report-2026-04-24.md` after generated-file rendering and the generated-code capture tools are trustworthy on `main`.
 - [x] Add a first-class chunked live-generation path for non-streaming backends, so `SpeakSwiftly` can segment text up front, synthesize chunk waveforms sequentially, and feed completed audio chunks into playback without waiting for full-request synthesis to finish.
 - [ ] Evaluate whether the current resident backend defaults are still the right MLX choices on current Apple Silicon, and record the latency, memory, and audible tradeoffs explicitly.
 - [ ] Generalize stored Qwen materializations so profiles can load backend-appropriate conditioning material without assuming one hard-coded shape forever.

--- a/Sources/SpeakSwiftly/Generation/SpeechGeneration+Qwen.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechGeneration+Qwen.swift
@@ -26,47 +26,30 @@ extension SpeakSwiftly.Runtime {
         generationParameters: GenerateParameters,
         streamingInterval: Double,
     ) -> AsyncThrowingStream<[Float], Error> {
-        let plannedChunks = {
-            let chunks = LiveSpeechChunkPlanner.chunks(
-                for: text,
-                strategy: .smartParagraphGroups(),
-            )
-            return chunks.isEmpty ? [
-                LiveSpeechTextChunk(
-                    index: 1,
-                    text: text,
-                    wordCount: 1,
-                    segmentation: .sentenceGroup,
-                ),
-            ] : chunks
-        }()
-
-        return AsyncThrowingStream { continuation in
+        AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    for plannedChunk in plannedChunks {
+                    let eventStream = model.generateEventStream(
+                        text: text,
+                        voice: nil,
+                        refAudio: refAudio,
+                        refText: materialization.manifest.referenceText,
+                        language: nil,
+                        generationParameters: generationParameters,
+                        streamingInterval: streamingInterval,
+                    )
+
+                    for try await event in eventStream {
                         try Task.checkCancellation()
 
-                        let eventStream = model.generateEventStream(
-                            text: plannedChunk.text,
-                            voice: nil,
-                            refAudio: refAudio,
-                            refText: materialization.manifest.referenceText,
-                            language: nil,
-                            generationParameters: generationParameters,
-                            streamingInterval: streamingInterval,
-                        )
-
-                        for try await event in eventStream {
-                            switch event {
-                                case let .token(token):
-                                    recordGenerationEvent(.token(token), for: requestID)
-                                case let .info(info):
-                                    recordGenerationEvent(.info(generationEventInfo(from: info)), for: requestID)
-                                case let .audio(samples):
-                                    recordGenerationEvent(.audioChunk(sampleCount: samples.count), for: requestID)
-                                    continuation.yield(samples)
-                            }
+                        switch event {
+                            case let .token(token):
+                                recordGenerationEvent(.token(token), for: requestID)
+                            case let .info(info):
+                                recordGenerationEvent(.info(generationEventInfo(from: info)), for: requestID)
+                            case let .audio(samples):
+                                recordGenerationEvent(.audioChunk(sampleCount: samples.count), for: requestID)
+                                continuation.yield(samples)
                         }
                     }
                     continuation.finish()
@@ -197,44 +180,27 @@ extension SpeakSwiftly.Runtime {
         generationParameters: GenerateParameters,
         streamingInterval: Double,
     ) -> AsyncThrowingStream<[Float], Error> {
-        let plannedChunks = {
-            let chunks = LiveSpeechChunkPlanner.chunks(
-                for: text,
-                strategy: .smartParagraphGroups(),
-            )
-            return chunks.isEmpty ? [
-                LiveSpeechTextChunk(
-                    index: 1,
-                    text: text,
-                    wordCount: 1,
-                    segmentation: .sentenceGroup,
-                ),
-            ] : chunks
-        }()
-
-        return AsyncThrowingStream { continuation in
+        AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    for plannedChunk in plannedChunks {
+                    let eventStream = model.generateConditionedEventStream(
+                        text: text,
+                        conditioning: conditioning,
+                        generationParameters: generationParameters,
+                        streamingInterval: streamingInterval,
+                    )
+
+                    for try await event in eventStream {
                         try Task.checkCancellation()
 
-                        let eventStream = model.generateConditionedEventStream(
-                            text: plannedChunk.text,
-                            conditioning: conditioning,
-                            generationParameters: generationParameters,
-                            streamingInterval: streamingInterval,
-                        )
-
-                        for try await event in eventStream {
-                            switch event {
-                                case let .token(token):
-                                    recordGenerationEvent(.token(token), for: requestID)
-                                case let .info(info):
-                                    recordGenerationEvent(.info(generationEventInfo(from: info)), for: requestID)
-                                case let .audio(samples):
-                                    recordGenerationEvent(.audioChunk(sampleCount: samples.count), for: requestID)
-                                    continuation.yield(samples)
-                            }
+                        switch event {
+                            case let .token(token):
+                                recordGenerationEvent(.token(token), for: requestID)
+                            case let .info(info):
+                                recordGenerationEvent(.info(generationEventInfo(from: info)), for: requestID)
+                            case let .audio(samples):
+                                recordGenerationEvent(.audioChunk(sampleCount: samples.count), for: requestID)
+                                continuation.yield(samples)
                         }
                     }
                     continuation.finish()

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -1510,10 +1510,29 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
         }
     })
 
+    let text = """
+    Please read this first paragraph slowly and clearly for testing. It should stay grouped with the next paragraph.
+
+    Please read this second paragraph slowly and clearly for testing. It should stay grouped with the first paragraph.
+
+    Please read this third paragraph slowly and clearly for testing. It should stay grouped with the fourth paragraph.
+
+    Please read this fourth paragraph slowly and clearly for testing. It should stay grouped with the third paragraph.
+
+    Please read this fifth paragraph slowly and clearly for testing. It should force live playback to use a second Qwen generation call.
+    """
+    let escapedText = text.replacingOccurrences(of: "\n", with: "\\n")
+    let expectedLiveChunkTexts = LiveSpeechChunkPlanner.chunks(
+        for: text,
+        strategy: .smartParagraphGroups(),
+    )
+    .map(\.text)
+    #expect(expectedLiveChunkTexts.count > 1)
+
     await runtime.accept(
-        line: #"""
-        {"id":"req-qwen-live","op":"generate_speech","text":"Please read this first paragraph slowly and clearly for testing. It should stay paired with the next paragraph.\n\nPlease read this second paragraph slowly and clearly for testing. It should stay paired with the first paragraph.\n\nPlease read this third paragraph slowly and clearly for testing. It should stay paired with the fourth paragraph.\n\nPlease read this fourth paragraph slowly and clearly for testing. It should stay paired with the third paragraph.","profile_name":"default-femme","text_format":"plain_text"}
-        """#,
+        line: """
+        {"id":"req-qwen-live","op":"generate_speech","text":"\(escapedText)","profile_name":"default-femme","text_format":"plain_text"}
+        """,
     )
 
     #expect(await waitUntil {
@@ -1523,16 +1542,13 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
                 && $0["stage"] as? String == "preroll_ready"
         }
     })
-    #expect(await waitUntil { residentRecorder.recordedTexts.count == 1 })
-    #expect(residentRecorder.recordedTexts[0].contains("first paragraph"))
-    #expect(residentRecorder.recordedTexts[0].contains("second paragraph"))
-    #expect(residentRecorder.recordedTexts[0].contains("third paragraph"))
-    #expect(residentRecorder.recordedTexts[0].contains("fourth paragraph"))
+    #expect(await waitUntil { residentRecorder.recordedTexts.count == expectedLiveChunkTexts.count })
+    #expect(residentRecorder.recordedTexts == expectedLiveChunkTexts)
 
     await runtime.accept(
-        line: #"""
-        {"id":"req-qwen-file","op":"generate_audio_file","text":"Please read this first paragraph slowly and clearly for testing. It should stay paired with the next paragraph.\n\nPlease read this second paragraph slowly and clearly for testing. It should stay paired with the first paragraph.\n\nPlease read this third paragraph slowly and clearly for testing. It should stay paired with the fourth paragraph.\n\nPlease read this fourth paragraph slowly and clearly for testing. It should stay paired with the third paragraph.","profile_name":"default-femme","text_format":"plain_text"}
-        """#,
+        line: """
+        {"id":"req-qwen-file","op":"generate_audio_file","text":"\(escapedText)","profile_name":"default-femme","text_format":"plain_text"}
+        """,
     )
 
     #expect(await waitUntil {
@@ -1541,9 +1557,9 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
                 && $0["ok"] as? Bool == true
         }
     })
-    #expect(await waitUntil { residentRecorder.recordedTexts.count == 2 })
+    #expect(await waitUntil { residentRecorder.recordedTexts.count == expectedLiveChunkTexts.count + 1 })
     #expect(try #require(residentRecorder.recordedTexts.last).contains("first paragraph"))
-    #expect(try #require(residentRecorder.recordedTexts.last).contains("fourth paragraph"))
+    #expect(try #require(residentRecorder.recordedTexts.last).contains("fifth paragraph"))
 }
 
 // MARK: - Sample Shaping

--- a/docs/maintainers/qwen-sampling-headroom-report-2026-04-24.md
+++ b/docs/maintainers/qwen-sampling-headroom-report-2026-04-24.md
@@ -1,0 +1,109 @@
+# Qwen Sampling Headroom Report
+
+Date: 2026-04-24
+
+This note prepares the next Qwen investigation pass. It does not change runtime
+sampling defaults by itself.
+
+## Current Runtime Policy
+
+SpeakSwiftly currently sends the resident Qwen path these caller-visible
+generation parameters:
+
+- `maxTokens`: `4096`
+- `temperature`: `0.9`
+- `topP`: `1.0`
+- `repetitionPenalty`: `1.05`
+
+The runtime also uses prepared Qwen conditioning by default. That means a stored
+voice profile can contribute a reusable speaker embedding, reference speech
+codes, and reference text token IDs to every resident Qwen generation request.
+
+Live Qwen playback streams audio chunks at `0.32` second intervals. Generated
+audio files should stay single-pass at the SpeakSwiftly runtime level so they can
+remain a cleaner comparison point against live chunked playback.
+
+## Upstream Effective Budget
+
+The pinned `mlx-audio-swift` Qwen3TTS implementation resolves the caller
+parameters into a VoiceDesign generation setting and then applies an internal
+effective token cap:
+
+```swift
+let targetTokenCount = tokenizer.encode(text: text).count
+let effectiveMaxTokens = min(maxTokens, max(75, targetTokenCount * 6))
+```
+
+Practical effect:
+
+- `4096` is not always the real number of generated codec steps.
+- Short text still gets at least `75` codec steps.
+- Longer text gets up to about six generated codec steps per text token unless
+  the global cap is reached.
+- After the available text context is consumed, generation continues with the
+  Qwen TTS pad embedding until the model emits EOS or reaches the cap.
+
+That final point is the main headroom risk. If EOS is weak near the end of a
+chunk, the model has room to keep producing speech-like tokens after the useful
+text pressure has faded.
+
+## Why This Could Spiral Near The End
+
+The most plausible failure mode is not ordinary playback shaping. Playback
+receives generated sample chunks; it can smooth samples and buffer/drain them,
+but it does not decide what words or vocal artifacts the model generates.
+
+The risk lives in generation:
+
+- `temperature: 0.9` keeps sampling expressive.
+- `topP: 1.0` leaves nucleus filtering effectively open.
+- `repetitionPenalty: 1.05` is mild.
+- the internal minimum of `75` codec steps can be generous for very short final
+  chunks.
+- prepared conditioning can be long and stylistically strong, so the reference
+  prompt may dominate short target text.
+
+Those choices can still be reasonable for lively voices. The question for the
+next pass is whether the current defaults are too permissive for Qwen's final
+chunk or tail behavior.
+
+## Current Live Profile Context
+
+The live `default-femme` profile inspected during this review was created on
+2026-04-24. Its prepared Qwen conditioning artifact reported:
+
+- `referenceSpeechCodes.shape`: `[1, 16, 560]`
+- `referenceTextTokenIDs.shape`: `[1, 160]`
+- `resolvedLanguage`: `auto`
+- `codecLanguageID`: `null`
+
+That is a fairly long style reference for a profile intended to speak many short
+assistant replies. It should be included in the sampling investigation instead
+of treating the profile as a neutral constant.
+
+## Investigation Plan
+
+1. Keep generated-file Qwen rendering single-pass at the runtime level.
+2. Restore or land generated-code capture and replay tooling on `main`.
+3. Capture matched runs for:
+   - current `default-femme`
+   - a shorter but still bright `testing-femme`
+   - a calmer baseline profile if needed
+4. Compare generated codec length, EOS timing, tail token patterns, and WAV-side
+   prosody for the same input text.
+5. Try a small parameter matrix only after the capture surface is trustworthy:
+   - current default: `temperature 0.9`, `topP 1.0`, `repetitionPenalty 1.05`
+   - slightly tighter nucleus: `temperature 0.9`, `topP 0.9`
+   - slightly stronger repeat control: `repetitionPenalty 1.1`
+   - combined conservative candidate: `temperature 0.85`, `topP 0.9`,
+     `repetitionPenalty 1.1`
+6. Treat audible output as the final check, but do not rely on listening alone as
+   the first measurement surface.
+
+## Non-Goals
+
+- Do not tune Qwen defaults from one bad live reply.
+- Do not use `compare-volume` for streamed-vs-direct conclusions unless it first
+  proves matched spans.
+- Do not make the default voice flat or subdued just to reduce variance. The
+  target is energetic but stable speech, not bland speech.


### PR DESCRIPTION
## Summary

- keep Qwen generated-file rendering as one runtime-level model pass while leaving live playback chunking intact
- add regression coverage proving live Qwen chunks long text while `generate_audio_file` records one full-text request
- capture Qwen follow-ups in ROADMAP and add the sampling-headroom report for the next investigation

## Patch release framing

This is a patch release candidate for `v4.0.4`: it fixes retained-file Qwen behavior and maintainer evidence quality without changing the public API.

## Verification

- `git diff --check`
- `swift test --filter ModelClientsTests`
- `swift build`
- commit hook: SwiftFormat, repo-maintenance validation, SwiftLint