### PR TITLE
release: prep v4.0.5 probe contract patch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,27 @@ Treat SwiftFormat as the primary style tool in this repository. Keep SwiftLint f
 
 The repository-managed `pre-commit` hook is now the intended local enforcement path. Run `sh scripts/repo-maintenance/install-hooks.sh` after cloning, and Git will use `scripts/repo-maintenance/hooks/pre-commit` for this clone. That hook applies `swiftformat`, restages tracked changes, and then runs the same validation entry point as release preflight and CI.
 
+## Test Harness Probes
+
+The `SpeakSwiftlyTesting` executable is a package-local smoke and investigation
+harness. Keep it small, explicit, and honest about what each command measures.
+
+The volume commands have separate jobs:
+
+- `volume-probe` profiles one retained generated file and writes a versioned
+  JSON artifact under `.local/volume-probes/`.
+- `compare-volume` compares retained streamed output against direct Qwen decode
+  only after it proves the analyzed spans are compatible.
+- `compare-volume --matched-duration trim-to-shorter` is the explicit mode for
+  trimming both outputs to the shorter sample count before comparing them.
+
+Do not use `compare-volume` output for streamed-vs-direct conclusions unless the
+artifact proves matched spans or explicitly records the trim mode. Keep
+generated-code capture and replay investigations separate from waveform volume
+probing; they answer different questions. The detailed volume measurement
+contract lives in
+[docs/maintainers/volume-probe-instrument-contract-2026-04-24.md](docs/maintainers/volume-probe-instrument-contract-2026-04-24.md).
+
 ## Runtime Shape
 
 The current intended runtime shape is:

--- a/Package.swift
+++ b/Package.swift
@@ -59,16 +59,21 @@ let package = Package(
             name: "SpeakSwiftlyTests",
             dependencies: [
                 "SpeakSwiftly",
+                "SpeakSwiftlyTestingSupport",
                 .product(name: "TextForSpeech", package: "TextForSpeech"),
             ],
             resources: [
                 .copy("Resources/default.metallib"),
             ],
         ),
+        .target(
+            name: "SpeakSwiftlyTestingSupport",
+        ),
         .executableTarget(
             name: "SpeakSwiftlyTesting",
             dependencies: [
                 "SpeakSwiftly",
+                "SpeakSwiftlyTestingSupport",
                 .product(name: "MLXAudioTTS", package: "mlx-audio-swift"),
                 .product(name: "MLXAudioCore", package: "mlx-audio-swift"),
                 .product(name: "MLX", package: "mlx-swift"),

--- a/README.md
+++ b/README.md
@@ -201,9 +201,20 @@ swift run SpeakSwiftlyTesting smoke
 swift run SpeakSwiftlyTesting create-design-profile --profile probe-fresh-a --voice "A steady, intimate, softly spoken feminine voice with even projection."
 swift run SpeakSwiftlyTesting volume-probe --profile default-femme --profile-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16
 swift run SpeakSwiftlyTesting compare-volume --profile default-femme --profile-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16
+swift run SpeakSwiftlyTesting compare-volume --profile default-femme --profile-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16 --matched-duration trim-to-shorter
 ```
 
-`resources` prints the packaged bundle and metallib paths, `status` constructs the typed runtime and prints the first terminal status payload it sees, `smoke` runs both checks in sequence, `create-design-profile` creates and stores a fresh voice-design profile through the typed runtime, `volume-probe` generates a retained file then prints per-window RMS and peak measurements so long-form loudness drift can be inspected against a real stored profile, and `compare-volume` runs that retained-file path against a direct non-stream Qwen decode using the same stored profile conditioning so the drift can be compared side by side.
+`resources` prints the packaged bundle and metallib paths, `status` constructs the typed runtime and prints the first terminal status payload it sees, `smoke` runs both checks in sequence, `create-design-profile` creates and stores a fresh voice-design profile through the typed runtime, `volume-probe` generates a retained file then prints per-window RMS and peak measurements so long-form loudness drift can be inspected against a real stored profile, and `compare-volume` runs that retained-file path against a direct non-stream Qwen decode using the same stored profile conditioning, refusing to compare when the analyzed spans do not match.
+
+The volume tools also write versioned JSON artifacts under `.local/volume-probes/`.
+`volume-probe` is a single-output profiler: its summary records duration,
+sample count, fixed-duration window count, quarter-bucket RMS, averaged head and
+tail RMS, tail/head ratio, last-window average RMS, and an explicitly named
+`endpoint_rms_delta_pct`. `compare-volume` refuses mismatched durations by
+default; use `--matched-duration trim-to-shorter` only when you intentionally
+want both outputs trimmed to the same analyzed sample count. The detailed
+measurement contract is maintained in
+[`docs/maintainers/volume-probe-instrument-contract-2026-04-24.md`](docs/maintainers/volume-probe-instrument-contract-2026-04-24.md).
 
 ## API Notes
 

--- a/README.md
+++ b/README.md
@@ -204,16 +204,25 @@ swift run SpeakSwiftlyTesting compare-volume --profile default-femme --profile-r
 swift run SpeakSwiftlyTesting compare-volume --profile default-femme --profile-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16 --matched-duration trim-to-shorter
 ```
 
-`resources` prints the packaged bundle and metallib paths, `status` constructs the typed runtime and prints the first terminal status payload it sees, `smoke` runs both checks in sequence, `create-design-profile` creates and stores a fresh voice-design profile through the typed runtime, `volume-probe` generates a retained file then prints per-window RMS and peak measurements so long-form loudness drift can be inspected against a real stored profile, and `compare-volume` runs that retained-file path against a direct non-stream Qwen decode using the same stored profile conditioning, refusing to compare when the analyzed spans do not match.
+`resources` prints the packaged bundle and metallib paths, `status` constructs
+the typed runtime and prints the first terminal status payload it sees, `smoke`
+runs both checks in sequence, and `create-design-profile` creates and stores a
+fresh voice-design profile through the typed runtime.
 
-The volume tools also write versioned JSON artifacts under `.local/volume-probes/`.
-`volume-probe` is a single-output profiler: its summary records duration,
-sample count, fixed-duration window count, quarter-bucket RMS, averaged head and
-tail RMS, tail/head ratio, last-window average RMS, and an explicitly named
-`endpoint_rms_delta_pct`. `compare-volume` refuses mismatched durations by
-default; use `--matched-duration trim-to-shorter` only when you intentionally
-want both outputs trimmed to the same analyzed sample count. The detailed
-measurement contract is maintained in
+The two volume commands are investigation tools. `volume-probe` profiles one
+retained generated file and reports the exact analyzed span, fixed-duration
+windows, RMS, peak, slope, quarter-bucket summaries, head/tail averages, and
+last-window averages. `compare-volume` runs the retained-file path against a
+direct non-stream Qwen decode using the same stored profile conditioning, but it
+refuses to compare by default when the analyzed sample counts differ. Use
+`--matched-duration trim-to-shorter` only when the question can tolerate
+trimming both outputs to the same shorter span.
+
+Both commands write versioned JSON artifacts under `.local/volume-probes/`. The
+console table is only a readable summary; the artifact records the durable
+measurement contract, including `endpoint_rms_delta_pct` as an explicit
+first-window-vs-last-window endpoint metric rather than a whole-run degradation
+score. The detailed contract is maintained in
 [`docs/maintainers/volume-probe-instrument-contract-2026-04-24.md`](docs/maintainers/volume-probe-instrument-contract-2026-04-24.md).
 
 ## API Notes

--- a/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
+++ b/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
@@ -3,6 +3,7 @@ import Foundation
 import MLXAudioCore
 import MLXAudioTTS
 import SpeakSwiftly
+import SpeakSwiftlyTestingSupport
 
 @main
 struct SpeakSwiftlyTestingMain {
@@ -29,39 +30,56 @@ struct SpeakSwiftlyTestingMain {
         var textFile: String?
         var repeatCount = 10
         var windowSeconds = 2.0
+        var matchedDurationMode = MatchedDurationMode.refuse
     }
 
-    struct VolumeWindow {
-        let index: Int
-        let startSeconds: Double
-        let durationSeconds: Double
-        let rms: Double
-        let peak: Double
-    }
-
-    struct VolumeSummary {
-        let firstRMS: Double
-        let lastRMS: Double
-        let rmsDropPercent: Double
-        let slopePerWindow: Double
-        let firstPeak: Double
-        let lastPeak: Double
-    }
-
-    struct ProbeAnalysis {
-        let sampleRate: Int
-        let windows: [VolumeWindow]
-        let summary: VolumeSummary?
+    enum MatchedDurationMode: String, Codable {
+        case refuse
+        case trimToShorter = "trim-to-shorter"
     }
 
     struct CompareRun {
         let generatedFilePath: String
-        let analysis: ProbeAnalysis
+        let fullAnalysis: ProbeAnalysis
+        let comparedAnalysis: ProbeAnalysis
     }
 
     struct ComparisonResult {
         let streamed: CompareRun
         let direct: CompareRun
+        let matchedDurationMode: MatchedDurationMode
+        let comparisonSampleCount: Int
+    }
+
+    struct VolumeProbeArtifact: Codable {
+        let schemaVersion: Int
+        let toolName: String
+        let sourceSurface: String
+        let profileName: String
+        let profileRoot: String?
+        let textCharacters: Int
+        let textWords: Int
+        let textFingerprint: String
+        let generatedFilePath: String
+        let analysis: ProbeAnalysis
+    }
+
+    struct CompareVolumeArtifact: Codable {
+        let schemaVersion: Int
+        let toolName: String
+        let profileName: String
+        let profileRoot: String?
+        let textCharacters: Int
+        let textWords: Int
+        let textFingerprint: String
+        let matchedDurationMode: MatchedDurationMode
+        let comparisonSampleCount: Int
+        let streamedGeneratedFilePath: String
+        let directGeneratedFilePath: String
+        let streamedFullAnalysis: ProbeAnalysis
+        let directFullAnalysis: ProbeAnalysis
+        let streamedComparedAnalysis: ProbeAnalysis
+        let directComparedAnalysis: ProbeAnalysis
     }
 
     struct ProbeProfileManifest: Decodable {
@@ -248,6 +266,14 @@ struct SpeakSwiftlyTestingMain {
                     }
 
                     options.windowSeconds = windowSeconds
+                case "--matched-duration":
+                    index += 1
+                    let value = try requireOptionValue(arguments, index: index, for: argument)
+                    guard let mode = MatchedDurationMode(rawValue: value) else {
+                        throw UsageError.invalidOptionValue(argument, value)
+                    }
+
+                    options.matchedDurationMode = mode
                 default:
                     throw UsageError.unknownCommand(argument)
             }
@@ -326,10 +352,25 @@ struct SpeakSwiftlyTestingMain {
         print("text_characters: \(text.count)")
         print("text_words: \(text.split(whereSeparator: \.isWhitespace).count)")
         print("generated_file: \(result.generatedFilePath)")
-        print("sample_rate: \(result.analysis.sampleRate)")
-        print("window_seconds: \(options.windowSeconds)")
+        print("sample_rate: \(result.fullAnalysis.sampleRate)")
+        print("window_seconds: \(result.fullAnalysis.windowSeconds)")
 
-        printAnalysis(result.analysis, prefix: "window", summaryLabel: "summary")
+        printAnalysis(result.fullAnalysis, prefix: "window", summaryLabel: "summary")
+
+        let artifact = VolumeProbeArtifact(
+            schemaVersion: 1,
+            toolName: "volume-probe",
+            sourceSurface: "retained-file",
+            profileName: options.profileName,
+            profileRoot: options.profileRoot,
+            textCharacters: text.count,
+            textWords: text.split(whereSeparator: \.isWhitespace).count,
+            textFingerprint: fingerprint(text),
+            generatedFilePath: result.generatedFilePath,
+            analysis: result.fullAnalysis,
+        )
+        let artifactPath = try writeProbeArtifact(artifact, stem: "volume-probe")
+        print("artifact_file: \(artifactPath)")
     }
 
     static func runCreateDesignProfile(options: CreateDesignProfileOptions) async throws {
@@ -374,36 +415,58 @@ struct SpeakSwiftlyTestingMain {
         print("text_words: \(text.split(whereSeparator: \.isWhitespace).count)")
         print("window_seconds: \(options.windowSeconds)")
         print("streamed_generated_file: \(comparison.streamed.generatedFilePath)")
-        print("streamed_sample_rate: \(comparison.streamed.analysis.sampleRate)")
+        print("streamed_sample_rate: \(comparison.streamed.fullAnalysis.sampleRate)")
         print("direct_generated_file: \(comparison.direct.generatedFilePath)")
-        print("direct_sample_rate: \(comparison.direct.analysis.sampleRate)")
+        print("direct_sample_rate: \(comparison.direct.fullAnalysis.sampleRate)")
+        print("matched_duration_mode: \(comparison.matchedDurationMode.rawValue)")
+        print("comparison_sample_count: \(comparison.comparisonSampleCount)")
 
         printAnalysis(
-            comparison.streamed.analysis,
+            comparison.streamed.comparedAnalysis,
             prefix: "streamed_window",
             summaryLabel: "streamed_summary",
         )
         printAnalysis(
-            comparison.direct.analysis,
+            comparison.direct.comparedAnalysis,
             prefix: "direct_window",
             summaryLabel: "direct_summary",
         )
 
-        if let streamedSummary = comparison.streamed.analysis.summary,
-           let directSummary = comparison.direct.analysis.summary {
+        if let streamedSummary = comparison.streamed.comparedAnalysis.summary,
+           let directSummary = comparison.direct.comparedAnalysis.summary {
             print(
                 String(
-                    format: "comparison: streamed_last_rms=%.5f direct_last_rms=%.5f streamed_drop_pct=%.2f direct_drop_pct=%.2f drop_delta_pct=%.2f streamed_slope=%.6f direct_slope=%.6f",
+                    format: "comparison: streamed_last_rms=%.5f direct_last_rms=%.5f streamed_endpoint_rms_delta_pct=%.2f direct_endpoint_rms_delta_pct=%.2f endpoint_delta_gap_pct=%.2f streamed_slope=%.6f direct_slope=%.6f",
                     streamedSummary.lastRMS,
                     directSummary.lastRMS,
-                    streamedSummary.rmsDropPercent,
-                    directSummary.rmsDropPercent,
-                    streamedSummary.rmsDropPercent - directSummary.rmsDropPercent,
+                    streamedSummary.endpointRMSDeltaPercent,
+                    directSummary.endpointRMSDeltaPercent,
+                    streamedSummary.endpointRMSDeltaPercent - directSummary.endpointRMSDeltaPercent,
                     streamedSummary.slopePerWindow,
                     directSummary.slopePerWindow,
                 ),
             )
         }
+
+        let artifact = CompareVolumeArtifact(
+            schemaVersion: 1,
+            toolName: "compare-volume",
+            profileName: options.profileName,
+            profileRoot: options.profileRoot,
+            textCharacters: text.count,
+            textWords: text.split(whereSeparator: \.isWhitespace).count,
+            textFingerprint: fingerprint(text),
+            matchedDurationMode: comparison.matchedDurationMode,
+            comparisonSampleCount: comparison.comparisonSampleCount,
+            streamedGeneratedFilePath: comparison.streamed.generatedFilePath,
+            directGeneratedFilePath: comparison.direct.generatedFilePath,
+            streamedFullAnalysis: comparison.streamed.fullAnalysis,
+            directFullAnalysis: comparison.direct.fullAnalysis,
+            streamedComparedAnalysis: comparison.streamed.comparedAnalysis,
+            directComparedAnalysis: comparison.direct.comparedAnalysis,
+        )
+        let artifactPath = try writeProbeArtifact(artifact, stem: "compare-volume")
+        print("artifact_file: \(artifactPath)")
     }
 
     static func loadVolumeProbeText(options: VolumeProbeOptions) throws -> String {
@@ -482,13 +545,13 @@ struct SpeakSwiftlyTestingMain {
         let generatedFile = try await awaitGeneratedFile(from: handle)
         let analysis = try analyzeVolume(
             at: generatedFile.filePath,
-            sampleRate: generatedFile.sampleRate,
             windowSeconds: windowSeconds,
         )
 
         return CompareRun(
             generatedFilePath: generatedFile.filePath,
-            analysis: analysis,
+            fullAnalysis: analysis,
+            comparedAnalysis: analysis,
         )
     }
 
@@ -512,7 +575,72 @@ struct SpeakSwiftlyTestingMain {
             profileDirectoryURL: profileDirectoryURL,
             windowSeconds: options.windowSeconds,
         )
-        return ComparisonResult(streamed: streamed, direct: direct)
+        return try alignComparison(
+            streamed: streamed,
+            direct: direct,
+            mode: options.matchedDurationMode,
+            windowSeconds: options.windowSeconds,
+        )
+    }
+
+    static func alignComparison(
+        streamed: CompareRun,
+        direct: CompareRun,
+        mode: MatchedDurationMode,
+        windowSeconds: Double,
+    ) throws -> ComparisonResult {
+        guard streamed.fullAnalysis.sampleRate == direct.fullAnalysis.sampleRate else {
+            throw UsageError.comparisonSampleRateMismatch(
+                streamed.fullAnalysis.sampleRate,
+                direct.fullAnalysis.sampleRate,
+            )
+        }
+
+        let streamedCount = streamed.fullAnalysis.sampleCount
+        let directCount = direct.fullAnalysis.sampleCount
+        guard streamedCount == directCount else {
+            switch mode {
+                case .refuse:
+                    throw UsageError.comparisonDurationMismatch(
+                        streamedCount,
+                        directCount,
+                        streamed.fullAnalysis.sampleRate,
+                    )
+                case .trimToShorter:
+                    let comparisonSampleCount = min(streamedCount, directCount)
+                    let streamedAnalysis = try analyzeVolume(
+                        at: streamed.generatedFilePath,
+                        windowSeconds: windowSeconds,
+                        maxSampleCount: comparisonSampleCount,
+                    )
+                    let directAnalysis = try analyzeVolume(
+                        at: direct.generatedFilePath,
+                        windowSeconds: windowSeconds,
+                        maxSampleCount: comparisonSampleCount,
+                    )
+                    return ComparisonResult(
+                        streamed: CompareRun(
+                            generatedFilePath: streamed.generatedFilePath,
+                            fullAnalysis: streamed.fullAnalysis,
+                            comparedAnalysis: streamedAnalysis,
+                        ),
+                        direct: CompareRun(
+                            generatedFilePath: direct.generatedFilePath,
+                            fullAnalysis: direct.fullAnalysis,
+                            comparedAnalysis: directAnalysis,
+                        ),
+                        matchedDurationMode: mode,
+                        comparisonSampleCount: comparisonSampleCount,
+                    )
+            }
+        }
+
+        return ComparisonResult(
+            streamed: streamed,
+            direct: direct,
+            matchedDurationMode: mode,
+            comparisonSampleCount: streamedCount,
+        )
     }
 
     static func runDirectProbe(
@@ -573,7 +701,8 @@ struct SpeakSwiftlyTestingMain {
 
         return CompareRun(
             generatedFilePath: directOutputURL.path,
-            analysis: analysis,
+            fullAnalysis: analysis,
+            comparedAnalysis: analysis,
         )
     }
 
@@ -671,62 +800,24 @@ struct SpeakSwiftlyTestingMain {
         withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
     }
 
-    static func analyzeVolume(
-        at path: String,
-        sampleRate: Int,
-        windowSeconds: Double,
-    ) throws -> ProbeAnalysis {
-        let data = try Data(contentsOf: URL(fileURLWithPath: path))
-        let wav = try parseFloatWAV(data)
-        return analyzeVolume(
-            samples: wav.samples,
-            sampleRate: sampleRate,
-            windowSeconds: windowSeconds,
-        )
-    }
-
-    static func analyzeVolume(
-        samples: [Float],
-        sampleRate: Int,
-        windowSeconds: Double,
-    ) -> ProbeAnalysis {
-        let framesPerWindow = max(1, Int((Double(sampleRate) * windowSeconds).rounded()))
-        var windows = [VolumeWindow]()
-        windows.reserveCapacity(max(1, samples.count / framesPerWindow))
-
-        var index = 0
-        var start = 0
-        while start < samples.count {
-            let end = min(start + framesPerWindow, samples.count)
-            let segment = Array(samples[start..<end])
-            let durationSeconds = Double(segment.count) / Double(sampleRate)
-            let rms = rootMeanSquare(segment)
-            let peak = segment.map { abs($0) }.max() ?? 0
-            windows.append(
-                VolumeWindow(
-                    index: index + 1,
-                    startSeconds: Double(start) / Double(sampleRate),
-                    durationSeconds: durationSeconds,
-                    rms: rms,
-                    peak: Double(peak),
-                ),
-            )
-            index += 1
-            start = end
-        }
-
-        return ProbeAnalysis(
-            sampleRate: sampleRate,
-            windows: windows,
-            summary: summarizeWindows(windows),
-        )
-    }
-
     static func printAnalysis(
         _ analysis: ProbeAnalysis,
         prefix: String,
         summaryLabel: String,
     ) {
+        print(
+            String(
+                format: "%@: duration=%.3fs analyzed_duration=%.3fs sample_count=%d analyzed_sample_count=%d window_seconds=%.3f window_count=%d",
+                summaryLabel,
+                analysis.durationSeconds,
+                Double(analysis.analyzedSampleCount) / Double(analysis.sampleRate),
+                analysis.sampleCount,
+                analysis.analyzedSampleCount,
+                analysis.windowSeconds,
+                analysis.windows.count,
+            ),
+        )
+
         for window in analysis.windows {
             print(
                 String(
@@ -744,152 +835,66 @@ struct SpeakSwiftlyTestingMain {
         if let summary = analysis.summary {
             print(
                 String(
-                    format: "%@: first_rms=%.5f last_rms=%.5f rms_drop_pct=%.2f slope_per_window=%.6f first_peak=%.5f last_peak=%.5f",
+                    format: "%@: first_rms=%.5f last_rms=%.5f endpoint_rms_delta_pct=%.2f slope_per_window=%.6f head_rms=%.5f tail_rms=%.5f tail_head_ratio=%.5f last_%d_window_avg_rms=%.5f first_peak=%.5f last_peak=%.5f",
                     summaryLabel,
                     summary.firstRMS,
                     summary.lastRMS,
-                    summary.rmsDropPercent,
+                    summary.endpointRMSDeltaPercent,
                     summary.slopePerWindow,
+                    summary.headRMS,
+                    summary.tailRMS,
+                    summary.tailHeadRatio,
+                    summary.lastWindowAverageCount,
+                    summary.lastWindowAverageRMS,
                     summary.firstPeak,
                     summary.lastPeak,
                 ),
             )
+            for bucket in summary.buckets {
+                print(
+                    String(
+                        format: "%@_%@: windows=%d-%d average_rms=%.5f average_peak=%.5f",
+                        summaryLabel,
+                        bucket.label,
+                        bucket.startWindow,
+                        bucket.endWindow,
+                        bucket.averageRMS,
+                        bucket.averagePeak,
+                    ),
+                )
+            }
         }
     }
 
-    static func rootMeanSquare(_ samples: [Float]) -> Double {
-        guard !samples.isEmpty else { return 0 }
-
-        let sum = samples.reduce(into: 0.0) { partialResult, sample in
-            let value = Double(sample)
-            partialResult += value * value
-        }
-        return Foundation.sqrt(sum / Double(samples.count))
+    static func writeProbeArtifact(_ artifact: some Encodable, stem: String) throws -> String {
+        let directory = try probeArtifactDirectory()
+        let timestamp = ISO8601DateFormatter().string(from: Date()).replacingOccurrences(of: ":", with: "-")
+        let artifactURL = directory.appendingPathComponent("\(stem)-\(timestamp).json", isDirectory: false)
+        let latestURL = directory.appendingPathComponent("\(stem)-latest.json", isDirectory: false)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(artifact)
+        try data.write(to: artifactURL, options: .atomic)
+        try data.write(to: latestURL, options: .atomic)
+        return artifactURL.path
     }
 
-    static func summarizeWindows(_ windows: [VolumeWindow]) -> VolumeSummary? {
-        guard let first = windows.first, let last = windows.last else { return nil }
-
-        let firstRMS = first.rms
-        let lastRMS = last.rms
-        let rmsDropPercent = firstRMS == 0 ? 0 : ((lastRMS - firstRMS) / firstRMS) * 100.0
-
-        let xValues = windows.map { Double($0.index - 1) }
-        let yValues = windows.map(\.rms)
-        let xMean = xValues.reduce(0, +) / Double(xValues.count)
-        let yMean = yValues.reduce(0, +) / Double(yValues.count)
-        let numerator = zip(xValues, yValues).reduce(into: 0.0) { partialResult, pair in
-            partialResult += (pair.0 - xMean) * (pair.1 - yMean)
-        }
-        let denominator = xValues.reduce(into: 0.0) { partialResult, x in
-            let offset = x - xMean
-            partialResult += offset * offset
-        }
-        let slopePerWindow = denominator == 0 ? 0 : numerator / denominator
-
-        return VolumeSummary(
-            firstRMS: firstRMS,
-            lastRMS: lastRMS,
-            rmsDropPercent: rmsDropPercent,
-            slopePerWindow: slopePerWindow,
-            firstPeak: first.peak,
-            lastPeak: last.peak,
-        )
+    static func probeArtifactDirectory() throws -> URL {
+        let directory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".local", isDirectory: true)
+            .appendingPathComponent("volume-probes", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
     }
 
-    static func parseFloatWAV(_ data: Data) throws -> (sampleRate: Int, channelCount: Int, samples: [Float]) {
-        func uint16(at offset: Int) -> UInt16 {
-            data.withUnsafeBytes { rawBuffer in
-                rawBuffer.load(fromByteOffset: offset, as: UInt16.self)
-            }
-            .littleEndian
+    static func fingerprint(_ text: String) -> String {
+        let bytes = Array(text.utf8)
+        let offset: UInt64 = 14_695_981_039_346_656_037
+        let prime: UInt64 = 1_099_511_628_211
+        let value = bytes.reduce(offset) { partialResult, byte in
+            (partialResult ^ UInt64(byte)) &* prime
         }
-
-        func uint32(at offset: Int) -> UInt32 {
-            data.withUnsafeBytes { rawBuffer in
-                rawBuffer.load(fromByteOffset: offset, as: UInt32.self)
-            }
-            .littleEndian
-        }
-
-        guard data.count >= 12 else {
-            throw UsageError.invalidWAV("The generated file is too small to be a valid WAV container.")
-        }
-        guard String(decoding: data[0..<4], as: UTF8.self) == "RIFF",
-              String(decoding: data[8..<12], as: UTF8.self) == "WAVE" else {
-            throw UsageError.invalidWAV("The generated file is not a RIFF/WAVE container.")
-        }
-
-        var formatTag: UInt16?
-        var channelCount: UInt16?
-        var sampleRate: UInt32?
-        var bitsPerSample: UInt16?
-        var audioPayload: Data?
-        var offset = 12
-
-        while offset + 8 <= data.count {
-            let chunkID = String(decoding: data[offset..<(offset + 4)], as: UTF8.self)
-            let chunkSize = Int(uint32(at: offset + 4))
-            let chunkStart = offset + 8
-            let chunkEnd = chunkStart + chunkSize
-            guard chunkEnd <= data.count else {
-                throw UsageError.invalidWAV("A WAV chunk overruns the file boundary.")
-            }
-
-            if chunkID == "fmt " {
-                guard chunkSize >= 16 else {
-                    throw UsageError.invalidWAV("The WAV fmt chunk is too small.")
-                }
-
-                formatTag = uint16(at: chunkStart)
-                channelCount = uint16(at: chunkStart + 2)
-                sampleRate = uint32(at: chunkStart + 4)
-                bitsPerSample = uint16(at: chunkStart + 14)
-            } else if chunkID == "data" {
-                audioPayload = data[chunkStart..<chunkEnd]
-            }
-
-            offset = chunkEnd + (chunkSize % 2)
-        }
-
-        guard formatTag == 3 else {
-            throw UsageError.invalidWAV("SpeakSwiftlyTesting expected 32-bit float WAV output, but found format tag \(formatTag ?? 0).")
-        }
-        guard bitsPerSample == 32 else {
-            throw UsageError.invalidWAV("SpeakSwiftlyTesting expected 32-bit float WAV output, but found \(bitsPerSample ?? 0) bits per sample.")
-        }
-        guard let resolvedChannelCount = channelCount, let resolvedSampleRate = sampleRate, let payload = audioPayload else {
-            throw UsageError.invalidWAV("The WAV file is missing required fmt or data chunks.")
-        }
-        guard payload.count % 4 == 0 else {
-            throw UsageError.invalidWAV("The WAV float payload is not aligned to 32-bit samples.")
-        }
-
-        let interleaved = payload.withUnsafeBytes { rawBuffer in
-            Array(rawBuffer.bindMemory(to: Float.self))
-        }
-
-        if resolvedChannelCount == 1 {
-            return (
-                sampleRate: Int(resolvedSampleRate),
-                channelCount: Int(resolvedChannelCount),
-                samples: interleaved,
-            )
-        }
-
-        var mono = [Float]()
-        mono.reserveCapacity(interleaved.count / Int(resolvedChannelCount))
-        var sampleIndex = 0
-        while sampleIndex < interleaved.count {
-            mono.append(interleaved[sampleIndex])
-            sampleIndex += Int(resolvedChannelCount)
-        }
-
-        return (
-            sampleRate: Int(resolvedSampleRate),
-            channelCount: Int(resolvedChannelCount),
-            samples: mono,
-        )
+        return String(format: "%016llx", value)
     }
 
     static func formatStatus(_ status: SpeakSwiftly.StatusEvent?) -> String {
@@ -913,10 +918,11 @@ extension SpeakSwiftlyTestingMain {
         case volumeProbeEndedWithoutGeneratedFile
         case createProfileEndedWithoutProfilePayload
         case emptyProbeText
-        case invalidWAV(String)
         case profileMissingQwenMaterialization(String)
         case profileModelIsNotQwen(String)
         case referenceAudioLoadFailed(String)
+        case comparisonSampleRateMismatch(Int, Int)
+        case comparisonDurationMismatch(Int, Int, Int)
 
         var errorDescription: String? {
             switch self {
@@ -940,14 +946,16 @@ extension SpeakSwiftlyTestingMain {
                     "SpeakSwiftlyTesting submitted a voice-design profile creation request, but the request stream ended before a created profile payload arrived."
                 case .emptyProbeText:
                     "SpeakSwiftlyTesting could not run the volume probe because the selected text input was empty after trimming whitespace."
-                case let .invalidWAV(message):
-                    message
                 case let .profileMissingQwenMaterialization(path):
                     "SpeakSwiftlyTesting could not find a stored qwen3 backend materialization in '\(path)/profile.json'."
                 case let .profileModelIsNotQwen(modelRepo):
                     "SpeakSwiftlyTesting expected model repo '\(modelRepo)' to load as Qwen3TTSModel for the direct comparison path, but it resolved to a different speech model type."
                 case let .referenceAudioLoadFailed(path):
                     "SpeakSwiftlyTesting could not decode any audio samples from '\(path)' for the direct Qwen comparison path."
+                case let .comparisonSampleRateMismatch(streamed, direct):
+                    "SpeakSwiftlyTesting refused compare-volume because the retained-file path used sample rate \(streamed), but the direct path used sample rate \(direct). The two runs are not like-for-like."
+                case let .comparisonDurationMismatch(streamed, direct, sampleRate):
+                    "SpeakSwiftlyTesting refused compare-volume because the retained-file path analyzed \(streamed) samples and the direct path analyzed \(direct) samples at \(sampleRate) Hz. Use '--matched-duration trim-to-shorter' only when you explicitly want both sides trimmed to the same analyzed span."
             }
         }
 
@@ -959,7 +967,7 @@ extension SpeakSwiftlyTestingMain {
               swift run SpeakSwiftlyTesting smoke
               swift run SpeakSwiftlyTesting create-design-profile --profile NAME --voice DESCRIPTION [--text SOURCE] [--vibe femme|masc|neutral] [--profile-root PATH]
               swift run SpeakSwiftlyTesting volume-probe [--profile NAME] [--profile-root PATH] [--text-file PATH] [--repeat COUNT] [--window-seconds SECONDS]
-              swift run SpeakSwiftlyTesting compare-volume [--profile NAME] [--profile-root PATH] [--text-file PATH] [--repeat COUNT] [--window-seconds SECONDS]
+              swift run SpeakSwiftlyTesting compare-volume [--profile NAME] [--profile-root PATH] [--text-file PATH] [--repeat COUNT] [--window-seconds SECONDS] [--matched-duration refuse|trim-to-shorter]
             """
         }
     }

--- a/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
+++ b/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
@@ -693,7 +693,7 @@ struct SpeakSwiftlyTestingMain {
             sampleRate: qwenModel.sampleRate,
             name: "qwen-direct-volume-probe.wav",
         )
-        let analysis = analyzeVolume(
+        let analysis = try analyzeVolume(
             samples: directSamples,
             sampleRate: qwenModel.sampleRate,
             windowSeconds: windowSeconds,

--- a/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
+++ b/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
@@ -691,7 +691,7 @@ struct SpeakSwiftlyTestingMain {
         let directOutputURL = try writeProbeWAV(
             samples: directSamples,
             sampleRate: qwenModel.sampleRate,
-            name: "qwen-direct-volume-probe.wav",
+            name: "qwen-direct-volume-probe-\(UUID().uuidString).wav",
         )
         let analysis = try analyzeVolume(
             samples: directSamples,
@@ -869,7 +869,7 @@ struct SpeakSwiftlyTestingMain {
     static func writeProbeArtifact(_ artifact: some Encodable, stem: String) throws -> String {
         let directory = try probeArtifactDirectory()
         let timestamp = ISO8601DateFormatter().string(from: Date()).replacingOccurrences(of: ":", with: "-")
-        let artifactURL = directory.appendingPathComponent("\(stem)-\(timestamp).json", isDirectory: false)
+        let artifactURL = directory.appendingPathComponent("\(stem)-\(timestamp)-\(UUID().uuidString).json", isDirectory: false)
         let latestURL = directory.appendingPathComponent("\(stem)-latest.json", isDirectory: false)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Sources/SpeakSwiftlyTestingSupport/VolumeProbeAnalysis.swift
+++ b/Sources/SpeakSwiftlyTestingSupport/VolumeProbeAnalysis.swift
@@ -1,0 +1,323 @@
+import Foundation
+
+public struct VolumeWindow: Codable, Equatable {
+    public let index: Int
+    public let startSeconds: Double
+    public let durationSeconds: Double
+    public let rms: Double
+    public let peak: Double
+}
+
+public struct VolumeBucket: Codable, Equatable {
+    public let label: String
+    public let startWindow: Int
+    public let endWindow: Int
+    public let averageRMS: Double
+    public let averagePeak: Double
+}
+
+public struct VolumeSummary: Codable, Equatable {
+    public let durationSeconds: Double
+    public let sampleCount: Int
+    public let sampleRate: Int
+    public let windowSeconds: Double
+    public let windowCount: Int
+    public let firstRMS: Double
+    public let lastRMS: Double
+    public let endpointRMSDeltaPercent: Double
+    public let slopePerWindow: Double
+    public let firstPeak: Double
+    public let lastPeak: Double
+    public let headRMS: Double
+    public let tailRMS: Double
+    public let tailHeadRatio: Double
+    public let lastWindowAverageCount: Int
+    public let lastWindowAverageRMS: Double
+    public let buckets: [VolumeBucket]
+}
+
+public struct ProbeAnalysis: Codable, Equatable {
+    public let sampleRate: Int
+    public let sampleCount: Int
+    public let durationSeconds: Double
+    public let windowSeconds: Double
+    public let analyzedSampleStart: Int
+    public let analyzedSampleCount: Int
+    public let windows: [VolumeWindow]
+    public let summary: VolumeSummary?
+}
+
+public struct ParsedFloatWAV: Equatable {
+    public let sampleRate: Int
+    public let channelCount: Int
+    public let samples: [Float]
+}
+
+public enum VolumeProbeAnalysisError: LocalizedError, Equatable {
+    case invalidWAV(String)
+
+    public var errorDescription: String? {
+        switch self {
+            case let .invalidWAV(message):
+                message
+        }
+    }
+}
+
+public func analyzeVolume(
+    samples: [Float],
+    sampleRate: Int,
+    windowSeconds: Double,
+    maxSampleCount: Int? = nil,
+) -> ProbeAnalysis {
+    let analyzedSampleCount = min(maxSampleCount ?? samples.count, samples.count)
+    let analyzedSamples = Array(samples.prefix(analyzedSampleCount))
+    let durationSeconds = Double(analyzedSampleCount) / Double(sampleRate)
+    let framesPerWindow = max(1, Int((Double(sampleRate) * windowSeconds).rounded()))
+    var windows = [VolumeWindow]()
+    windows.reserveCapacity(max(1, analyzedSamples.count / framesPerWindow))
+
+    var index = 0
+    var start = 0
+    while start < analyzedSamples.count {
+        let end = min(start + framesPerWindow, analyzedSamples.count)
+        let segment = Array(analyzedSamples[start..<end])
+        let durationSeconds = Double(segment.count) / Double(sampleRate)
+        let rms = rootMeanSquare(segment)
+        let peak = segment.map { abs($0) }.max() ?? 0
+        windows.append(
+            VolumeWindow(
+                index: index + 1,
+                startSeconds: Double(start) / Double(sampleRate),
+                durationSeconds: durationSeconds,
+                rms: rms,
+                peak: Double(peak),
+            ),
+        )
+        index += 1
+        start = end
+    }
+
+    return ProbeAnalysis(
+        sampleRate: sampleRate,
+        sampleCount: samples.count,
+        durationSeconds: Double(samples.count) / Double(sampleRate),
+        windowSeconds: windowSeconds,
+        analyzedSampleStart: 0,
+        analyzedSampleCount: analyzedSampleCount,
+        windows: windows,
+        summary: summarizeWindows(
+            windows,
+            durationSeconds: durationSeconds,
+            sampleCount: analyzedSampleCount,
+            sampleRate: sampleRate,
+            windowSeconds: windowSeconds,
+        ),
+    )
+}
+
+public func analyzeVolume(
+    at path: String,
+    windowSeconds: Double,
+    maxSampleCount: Int? = nil,
+) throws -> ProbeAnalysis {
+    let data = try Data(contentsOf: URL(fileURLWithPath: path))
+    let wav = try parseFloatWAV(data)
+    return analyzeVolume(
+        samples: wav.samples,
+        sampleRate: wav.sampleRate,
+        windowSeconds: windowSeconds,
+        maxSampleCount: maxSampleCount,
+    )
+}
+
+public func rootMeanSquare(_ samples: [Float]) -> Double {
+    guard !samples.isEmpty else { return 0 }
+
+    let sum = samples.reduce(into: 0.0) { partialResult, sample in
+        let value = Double(sample)
+        partialResult += value * value
+    }
+    return Foundation.sqrt(sum / Double(samples.count))
+}
+
+public func summarizeWindows(
+    _ windows: [VolumeWindow],
+    durationSeconds: Double,
+    sampleCount: Int,
+    sampleRate: Int,
+    windowSeconds: Double,
+) -> VolumeSummary? {
+    guard let first = windows.first, let last = windows.last else { return nil }
+
+    let firstRMS = first.rms
+    let lastRMS = last.rms
+    let endpointRMSDeltaPercent = firstRMS == 0 ? 0 : ((lastRMS - firstRMS) / firstRMS) * 100.0
+    let slopePerWindow = linearSlopePerWindow(windows)
+    let bucketSize = max(1, Int(Foundation.ceil(Double(windows.count) / 4.0)))
+    let buckets = makeBuckets(windows, bucketSize: bucketSize)
+    let headWindows = Array(windows.prefix(bucketSize))
+    let tailWindows = Array(windows.suffix(bucketSize))
+    let headRMS = average(headWindows.map(\.rms))
+    let tailRMS = average(tailWindows.map(\.rms))
+    let lastWindowAverageCount = min(3, windows.count)
+    let lastWindowAverageRMS = average(windows.suffix(lastWindowAverageCount).map(\.rms))
+
+    return VolumeSummary(
+        durationSeconds: durationSeconds,
+        sampleCount: sampleCount,
+        sampleRate: sampleRate,
+        windowSeconds: windowSeconds,
+        windowCount: windows.count,
+        firstRMS: firstRMS,
+        lastRMS: lastRMS,
+        endpointRMSDeltaPercent: endpointRMSDeltaPercent,
+        slopePerWindow: slopePerWindow,
+        firstPeak: first.peak,
+        lastPeak: last.peak,
+        headRMS: headRMS,
+        tailRMS: tailRMS,
+        tailHeadRatio: headRMS == 0 ? 0 : tailRMS / headRMS,
+        lastWindowAverageCount: lastWindowAverageCount,
+        lastWindowAverageRMS: lastWindowAverageRMS,
+        buckets: buckets,
+    )
+}
+
+public func parseFloatWAV(_ data: Data) throws -> ParsedFloatWAV {
+    func uint16(at offset: Int) -> UInt16 {
+        data.withUnsafeBytes { rawBuffer in
+            rawBuffer.load(fromByteOffset: offset, as: UInt16.self)
+        }
+        .littleEndian
+    }
+
+    func uint32(at offset: Int) -> UInt32 {
+        data.withUnsafeBytes { rawBuffer in
+            rawBuffer.load(fromByteOffset: offset, as: UInt32.self)
+        }
+        .littleEndian
+    }
+
+    guard data.count >= 12 else {
+        throw VolumeProbeAnalysisError.invalidWAV("The generated file is too small to be a valid WAV container.")
+    }
+    guard String(decoding: data[0..<4], as: UTF8.self) == "RIFF",
+          String(decoding: data[8..<12], as: UTF8.self) == "WAVE" else {
+        throw VolumeProbeAnalysisError.invalidWAV("The generated file is not a RIFF/WAVE container.")
+    }
+
+    var formatTag: UInt16?
+    var channelCount: UInt16?
+    var sampleRate: UInt32?
+    var bitsPerSample: UInt16?
+    var audioPayload: Data?
+    var offset = 12
+
+    while offset + 8 <= data.count {
+        let chunkID = String(decoding: data[offset..<(offset + 4)], as: UTF8.self)
+        let chunkSize = Int(uint32(at: offset + 4))
+        let chunkStart = offset + 8
+        let chunkEnd = chunkStart + chunkSize
+        guard chunkEnd <= data.count else {
+            throw VolumeProbeAnalysisError.invalidWAV("A WAV chunk overruns the file boundary.")
+        }
+
+        if chunkID == "fmt " {
+            guard chunkSize >= 16 else {
+                throw VolumeProbeAnalysisError.invalidWAV("The WAV fmt chunk is too small.")
+            }
+
+            formatTag = uint16(at: chunkStart)
+            channelCount = uint16(at: chunkStart + 2)
+            sampleRate = uint32(at: chunkStart + 4)
+            bitsPerSample = uint16(at: chunkStart + 14)
+        } else if chunkID == "data" {
+            audioPayload = data[chunkStart..<chunkEnd]
+        }
+
+        offset = chunkEnd + (chunkSize % 2)
+    }
+
+    guard formatTag == 3 else {
+        throw VolumeProbeAnalysisError.invalidWAV("SpeakSwiftlyTesting expected 32-bit float WAV output, but found format tag \(formatTag ?? 0).")
+    }
+    guard bitsPerSample == 32 else {
+        throw VolumeProbeAnalysisError.invalidWAV("SpeakSwiftlyTesting expected 32-bit float WAV output, but found \(bitsPerSample ?? 0) bits per sample.")
+    }
+    guard let resolvedChannelCount = channelCount, let resolvedSampleRate = sampleRate, let payload = audioPayload else {
+        throw VolumeProbeAnalysisError.invalidWAV("The WAV file is missing required fmt or data chunks.")
+    }
+    guard payload.count % 4 == 0 else {
+        throw VolumeProbeAnalysisError.invalidWAV("The WAV float payload is not aligned to 32-bit samples.")
+    }
+
+    let interleaved = payload.withUnsafeBytes { rawBuffer in
+        Array(rawBuffer.bindMemory(to: Float.self))
+    }
+
+    if resolvedChannelCount == 1 {
+        return ParsedFloatWAV(
+            sampleRate: Int(resolvedSampleRate),
+            channelCount: Int(resolvedChannelCount),
+            samples: interleaved,
+        )
+    }
+
+    var mono = [Float]()
+    mono.reserveCapacity(interleaved.count / Int(resolvedChannelCount))
+    var sampleIndex = 0
+    while sampleIndex < interleaved.count {
+        mono.append(interleaved[sampleIndex])
+        sampleIndex += Int(resolvedChannelCount)
+    }
+
+    return ParsedFloatWAV(
+        sampleRate: Int(resolvedSampleRate),
+        channelCount: Int(resolvedChannelCount),
+        samples: mono,
+    )
+}
+
+private func linearSlopePerWindow(_ windows: [VolumeWindow]) -> Double {
+    let xValues = windows.map { Double($0.index - 1) }
+    let yValues = windows.map(\.rms)
+    let xMean = xValues.reduce(0, +) / Double(xValues.count)
+    let yMean = yValues.reduce(0, +) / Double(yValues.count)
+    let numerator = zip(xValues, yValues).reduce(into: 0.0) { partialResult, pair in
+        partialResult += (pair.0 - xMean) * (pair.1 - yMean)
+    }
+    let denominator = xValues.reduce(into: 0.0) { partialResult, x in
+        let offset = x - xMean
+        partialResult += offset * offset
+    }
+    return denominator == 0 ? 0 : numerator / denominator
+}
+
+private func makeBuckets(_ windows: [VolumeWindow], bucketSize: Int) -> [VolumeBucket] {
+    var buckets = [VolumeBucket]()
+    var start = 0
+    var bucketIndex = 1
+    while start < windows.count {
+        let end = min(start + bucketSize, windows.count)
+        let bucketWindows = Array(windows[start..<end])
+        buckets.append(
+            VolumeBucket(
+                label: "bucket_\(bucketIndex)",
+                startWindow: bucketWindows.first?.index ?? 0,
+                endWindow: bucketWindows.last?.index ?? 0,
+                averageRMS: average(bucketWindows.map(\.rms)),
+                averagePeak: average(bucketWindows.map(\.peak)),
+            ),
+        )
+        bucketIndex += 1
+        start = end
+    }
+    return buckets
+}
+
+private func average(_ values: [Double]) -> Double {
+    guard !values.isEmpty else { return 0 }
+
+    return values.reduce(0, +) / Double(values.count)
+}

--- a/Sources/SpeakSwiftlyTestingSupport/VolumeProbeAnalysis.swift
+++ b/Sources/SpeakSwiftlyTestingSupport/VolumeProbeAnalysis.swift
@@ -54,10 +54,13 @@ public struct ParsedFloatWAV: Equatable {
 }
 
 public enum VolumeProbeAnalysisError: LocalizedError, Equatable {
+    case invalidAnalysisInput(String)
     case invalidWAV(String)
 
     public var errorDescription: String? {
         switch self {
+            case let .invalidAnalysisInput(message):
+                message
             case let .invalidWAV(message):
                 message
         }
@@ -69,7 +72,18 @@ public func analyzeVolume(
     sampleRate: Int,
     windowSeconds: Double,
     maxSampleCount: Int? = nil,
-) -> ProbeAnalysis {
+) throws -> ProbeAnalysis {
+    guard sampleRate > 0 else {
+        throw VolumeProbeAnalysisError.invalidAnalysisInput("SpeakSwiftlyTesting could not analyze volume because sampleRate must be greater than zero.")
+    }
+    guard windowSeconds > 0 else {
+        throw VolumeProbeAnalysisError.invalidAnalysisInput("SpeakSwiftlyTesting could not analyze volume because windowSeconds must be greater than zero.")
+    }
+
+    if let maxSampleCount, maxSampleCount < 0 {
+        throw VolumeProbeAnalysisError.invalidAnalysisInput("SpeakSwiftlyTesting could not analyze volume because maxSampleCount must be zero or greater.")
+    }
+
     let analyzedSampleCount = min(maxSampleCount ?? samples.count, samples.count)
     let analyzedSamples = Array(samples.prefix(analyzedSampleCount))
     let durationSeconds = Double(analyzedSampleCount) / Double(sampleRate)
@@ -123,7 +137,7 @@ public func analyzeVolume(
 ) throws -> ProbeAnalysis {
     let data = try Data(contentsOf: URL(fileURLWithPath: path))
     let wav = try parseFloatWAV(data)
-    return analyzeVolume(
+    return try analyzeVolume(
         samples: wav.samples,
         sampleRate: wav.sampleRate,
         windowSeconds: windowSeconds,

--- a/Tests/SpeakSwiftlyTests/TestingSupport/VolumeProbeAnalysisTests.swift
+++ b/Tests/SpeakSwiftlyTests/TestingSupport/VolumeProbeAnalysisTests.swift
@@ -1,0 +1,66 @@
+import SpeakSwiftlyTestingSupport
+import Testing
+
+@Test func `volume analysis slices samples into fixed duration windows`() {
+    let analysis = analyzeVolume(
+        samples: [1, -1, 1, -1, 2, -2, 3, -3, 4],
+        sampleRate: 4,
+        windowSeconds: 0.5,
+    )
+
+    #expect(analysis.sampleRate == 4)
+    #expect(analysis.sampleCount == 9)
+    #expect(analysis.analyzedSampleCount == 9)
+    #expect(analysis.windows.count == 5)
+    #expect(analysis.windows[0].durationSeconds == 0.5)
+    #expect(analysis.windows[4].durationSeconds == 0.25)
+    #expect(analysis.windows[0].rms == 1)
+    #expect(analysis.windows[4].rms == 4)
+}
+
+@Test func `volume summary reports averaged head tail and last windows`() throws {
+    let analysis = analyzeVolume(
+        samples: [
+            1, 1,
+            2, 2,
+            3, 3,
+            4, 4,
+            5, 5,
+            6, 6,
+            7, 7,
+            8, 8,
+        ],
+        sampleRate: 2,
+        windowSeconds: 1,
+    )
+
+    let summary = try #require(analysis.summary)
+    #expect(summary.windowCount == 8)
+    #expect(summary.firstRMS == 1)
+    #expect(summary.lastRMS == 8)
+    #expect(summary.endpointRMSDeltaPercent == 700)
+    #expect(summary.headRMS == 1.5)
+    #expect(summary.tailRMS == 7.5)
+    #expect(summary.tailHeadRatio == 5)
+    #expect(summary.lastWindowAverageCount == 3)
+    #expect(summary.lastWindowAverageRMS == 7)
+    #expect(summary.buckets.count == 4)
+    #expect(summary.buckets[0].startWindow == 1)
+    #expect(summary.buckets[0].endWindow == 2)
+    #expect(summary.buckets[3].averageRMS == 7.5)
+}
+
+@Test func `volume analysis can trim to a matched sample count`() {
+    let analysis = analyzeVolume(
+        samples: [1, 1, 2, 2, 10, 10],
+        sampleRate: 2,
+        windowSeconds: 1,
+        maxSampleCount: 4,
+    )
+
+    #expect(analysis.sampleCount == 6)
+    #expect(analysis.analyzedSampleCount == 4)
+    #expect(analysis.durationSeconds == 3)
+    #expect(analysis.summary?.durationSeconds == 2)
+    #expect(analysis.windows.map(\.rms) == [1, 2])
+}

--- a/Tests/SpeakSwiftlyTests/TestingSupport/VolumeProbeAnalysisTests.swift
+++ b/Tests/SpeakSwiftlyTests/TestingSupport/VolumeProbeAnalysisTests.swift
@@ -1,8 +1,8 @@
 import SpeakSwiftlyTestingSupport
 import Testing
 
-@Test func `volume analysis slices samples into fixed duration windows`() {
-    let analysis = analyzeVolume(
+@Test func `volume analysis slices samples into fixed duration windows`() throws {
+    let analysis = try analyzeVolume(
         samples: [1, -1, 1, -1, 2, -2, 3, -3, 4],
         sampleRate: 4,
         windowSeconds: 0.5,
@@ -19,7 +19,7 @@ import Testing
 }
 
 @Test func `volume summary reports averaged head tail and last windows`() throws {
-    let analysis = analyzeVolume(
+    let analysis = try analyzeVolume(
         samples: [
             1, 1,
             2, 2,
@@ -50,8 +50,8 @@ import Testing
     #expect(summary.buckets[3].averageRMS == 7.5)
 }
 
-@Test func `volume analysis can trim to a matched sample count`() {
-    let analysis = analyzeVolume(
+@Test func `volume analysis can trim to a matched sample count`() throws {
+    let analysis = try analyzeVolume(
         samples: [1, 1, 2, 2, 10, 10],
         sampleRate: 2,
         windowSeconds: 1,
@@ -63,4 +63,16 @@ import Testing
     #expect(analysis.durationSeconds == 3)
     #expect(analysis.summary?.durationSeconds == 2)
     #expect(analysis.windows.map(\.rms) == [1, 2])
+}
+
+@Test func `volume analysis rejects invalid input before slicing`() {
+    #expect(throws: VolumeProbeAnalysisError.invalidAnalysisInput("SpeakSwiftlyTesting could not analyze volume because sampleRate must be greater than zero.")) {
+        try analyzeVolume(samples: [1], sampleRate: 0, windowSeconds: 1)
+    }
+    #expect(throws: VolumeProbeAnalysisError.invalidAnalysisInput("SpeakSwiftlyTesting could not analyze volume because windowSeconds must be greater than zero.")) {
+        try analyzeVolume(samples: [1], sampleRate: 1, windowSeconds: 0)
+    }
+    #expect(throws: VolumeProbeAnalysisError.invalidAnalysisInput("SpeakSwiftlyTesting could not analyze volume because maxSampleCount must be zero or greater.")) {
+        try analyzeVolume(samples: [1], sampleRate: 1, windowSeconds: 1, maxSampleCount: -1)
+    }
 }

--- a/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
+++ b/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
@@ -340,9 +340,12 @@ older retained runs.
 Investigate the Qwen long-form volume-decay regression soon as a dedicated
 follow-up pass.
 
-- Re-run the retained-file `volume-probe` and direct-vs-stream
-  `compare-volume` paths after dependency updates, profile rerolls, and any
-  upstream `mlx-audio-swift` changes that could affect Qwen decode behavior.
+- Re-run the retained-file `volume-probe` path after dependency updates, profile
+  rerolls, and any upstream `mlx-audio-swift` changes that could affect Qwen
+  decode behavior.
+- Use `compare-volume` only when its artifact proves matched analyzed spans, or
+  when `--matched-duration trim-to-shorter` was explicitly selected and the
+  shortened comparison span is acceptable for the question being asked.
 - Keep comparing saved profiles against fresh voice-design profiles so prompt
   content and profile materialization changes can be separated from model-side
   drift.

--- a/docs/maintainers/volume-probe-instrument-contract-2026-04-24.md
+++ b/docs/maintainers/volume-probe-instrument-contract-2026-04-24.md
@@ -1,0 +1,87 @@
+# Volume Probe Instrument Contract
+
+Date: 2026-04-24
+
+## Purpose
+
+The volume probes are measurement tools, not proof generators. Their first job is
+to say exactly what audio span was inspected and how each number was derived, so
+Qwen long-form investigations do not rely on comforting-looking tables that
+quietly compare different things.
+
+## Tool Boundaries
+
+`volume-probe` profiles one retained generated audio file. It is the right tool
+for asking whether one output trends quieter, louder, peakier, or flatter across
+time. It does not compare model paths.
+
+`compare-volume` compares two audio outputs only after it proves the analyzed
+spans are compatible. By default it refuses mismatched sample counts. The
+explicit `--matched-duration trim-to-shorter` mode trims both outputs to the
+shorter sample count and records both the full analyses and the compared
+analyses in the JSON artifact.
+
+Generated-code capture, replay, and code-stream comparison remain separate from
+volume probing. Those tools answer whether Qwen generated different acoustic
+codes or decode inputs before waveform-level loudness analysis begins.
+
+## Measurement Terms
+
+- `sample_count`: the number of mono samples loaded from the WAV file before any
+  comparison trimming.
+- `analyzed_sample_count`: the number of mono samples actually included in the
+  reported windows and summary.
+- `duration_seconds`: the full WAV sample count divided by the sample rate.
+- `window`: a fixed sample-count slice, calculated as
+  `sampleRate * windowSeconds`, rounded to the nearest integer. The final window
+  can be shorter when the audio does not divide evenly.
+- `rms`: root mean square amplitude for one window.
+- `peak`: highest absolute sample value in one window.
+- `endpoint_rms_delta_pct`: the percent change from the first window RMS to the
+  last window RMS. This is deliberately named as an endpoint metric; it is not a
+  whole-run degradation score.
+- `slope_per_window`: the linear least-squares slope across all window RMS
+  values.
+- `head_rms` and `tail_rms`: average RMS over the first and last quarter bucket
+  of windows.
+- `tail_head_ratio`: `tail_rms / head_rms`.
+- `last_N_window_avg_rms`: average RMS across the final N windows, currently up
+  to the last three windows.
+
+## Artifact Contract
+
+Both probe commands write versioned JSON under `.local/volume-probes/` and also
+refresh a `*-latest.json` pointer.
+
+`volume-probe` artifacts include:
+
+- `schemaVersion`
+- `toolName`
+- `sourceSurface`
+- `profileName`
+- optional `profileRoot`
+- text size and stable text fingerprint
+- generated file path
+- full analysis, including sample metadata, analyzed span, windows, and summary
+
+`compare-volume` artifacts include:
+
+- the same command context fields
+- `matchedDurationMode`
+- `comparisonSampleCount`
+- streamed and direct generated file paths
+- full streamed and direct analyses
+- compared streamed and direct analyses
+
+The JSON is the durable source for future comparisons. Console output is a
+human-readable summary of the same measurement contract.
+
+## Testing Policy
+
+Measurement math should be covered with cheap synthetic sample tests before
+running real Qwen or MLX-backed probes. Those tests should prove window slicing,
+short final windows, head/tail averaging, endpoint naming, last-window averages,
+and matched-span trimming behavior without warming a model.
+
+Real-model experiments remain opt-in. Do not use `compare-volume` conclusions
+unless the artifact proves the compared spans are matched or explicitly trimmed.

--- a/docs/maintainers/volume-probe-instrument-contract-2026-04-24.md
+++ b/docs/maintainers/volume-probe-instrument-contract-2026-04-24.md
@@ -21,6 +21,11 @@ explicit `--matched-duration trim-to-shorter` mode trims both outputs to the
 shorter sample count and records both the full analyses and the compared
 analyses in the JSON artifact.
 
+The analysis support code rejects invalid measurement inputs before it slices
+audio. `sampleRate`, `windowSeconds`, and any requested trim count must describe
+a real nonnegative span; otherwise the tool should fail with a descriptive
+operator-facing error instead of writing an artifact with meaningless numbers.
+
 Generated-code capture, replay, and code-stream comparison remain separate from
 volume probing. Those tools answer whether Qwen generated different acoustic
 codes or decode inputs before waveform-level loudness analysis begins.
@@ -31,6 +36,8 @@ codes or decode inputs before waveform-level loudness analysis begins.
   comparison trimming.
 - `analyzed_sample_count`: the number of mono samples actually included in the
   reported windows and summary.
+- `analyzed_sample_start`: the start of the analyzed span. It is currently `0`
+  because trimming keeps the prefix of each output.
 - `duration_seconds`: the full WAV sample count divided by the sample rate.
 - `window`: a fixed sample-count slice, calculated as
   `sampleRate * windowSeconds`, rounded to the nearest integer. The final window
@@ -69,6 +76,7 @@ refresh a `*-latest.json` pointer.
 - the same command context fields
 - `matchedDurationMode`
 - `comparisonSampleCount`
+- full and compared sample metadata for both sides
 - streamed and direct generated file paths
 - full streamed and direct analyses
 - compared streamed and direct analyses

--- a/docs/maintainers/volume-probe-instrument-contract-2026-04-24.md
+++ b/docs/maintainers/volume-probe-instrument-contract-2026-04-24.md
@@ -58,7 +58,9 @@ codes or decode inputs before waveform-level loudness analysis begins.
 ## Artifact Contract
 
 Both probe commands write versioned JSON under `.local/volume-probes/` and also
-refresh a `*-latest.json` pointer.
+refresh a `*-latest.json` pointer. Per-run artifact filenames include a
+timestamp plus a unique suffix so fast repeated runs do not overwrite one
+another.
 
 `volume-probe` artifacts include:
 
@@ -80,6 +82,10 @@ refresh a `*-latest.json` pointer.
 - streamed and direct generated file paths
 - full streamed and direct analyses
 - compared streamed and direct analyses
+
+Direct Qwen comparison WAVs use unique temporary filenames for the same reason:
+overlapping comparison runs must not be able to overwrite another run's direct
+decode output before trimmed metrics are recomputed.
 
 The JSON is the durable source for future comparisons. Console output is a
 human-readable summary of the same measurement contract.

--- a/docs/releases/v4-0-5-release-notes.md
+++ b/docs/releases/v4-0-5-release-notes.md
@@ -1,0 +1,64 @@
+# v4.0.5 Release Notes
+
+## What changed
+
+- hardened `SpeakSwiftlyTesting volume-probe` so it reports explicit analyzed
+  span metadata, fixed-duration windows, quarter-bucket summaries, averaged
+  head/tail RMS, tail/head ratio, slope, and last-window average RMS
+- renamed the old endpoint-style drop metric in the probe output to
+  `endpoint_rms_delta_pct`, making clear that it compares only the first and
+  last windows
+- added versioned JSON artifacts for `volume-probe` and `compare-volume` under
+  `.local/volume-probes/`
+- made `compare-volume` refuse mismatched sample rates or sample counts by
+  default, with `--matched-duration trim-to-shorter` as the explicit opt-in
+  comparison mode
+- moved reusable probe math into `SpeakSwiftlyTestingSupport` and added cheap
+  synthetic tests for window slicing, tail/head summaries, matched-span
+  trimming, and invalid analysis inputs
+- documented the volume-probe measurement contract in README, CONTRIBUTING, and
+  `docs/maintainers/volume-probe-instrument-contract-2026-04-24.md`
+
+## Breaking changes
+
+- none for the public `SpeakSwiftly` runtime library or JSONL worker protocol
+
+## Migration or upgrade notes
+
+- `compare-volume` may now fail where it previously printed a comparison table
+  for mismatched outputs; this is intentional and prevents invalid
+  streamed-vs-direct conclusions
+- use `--matched-duration trim-to-shorter` only when trimming both sides to the
+  same prefix span is acceptable for the investigation
+- downstream maintainers should treat `endpoint_rms_delta_pct` as an endpoint
+  metric, not as a whole-run degradation score
+
+## Verification performed
+
+```bash
+swift build
+```
+
+```bash
+swift test --filter VolumeProbeAnalysisTests
+```
+
+```bash
+swift test
+```
+
+```bash
+swiftformat --lint --config .swiftformat .
+```
+
+```bash
+swiftlint lint --config .swiftlint.yml
+```
+
+```bash
+git diff --check
+```
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```

--- a/docs/releases/v4-0-5-release-notes.md
+++ b/docs/releases/v4-0-5-release-notes.md
@@ -9,10 +9,13 @@
   `endpoint_rms_delta_pct`, making clear that it compares only the first and
   last windows
 - added versioned JSON artifacts for `volume-probe` and `compare-volume` under
-  `.local/volume-probes/`
+  `.local/volume-probes/`, with unique per-run filenames for fast repeated
+  probes
 - made `compare-volume` refuse mismatched sample rates or sample counts by
   default, with `--matched-duration trim-to-shorter` as the explicit opt-in
   comparison mode
+- made direct Qwen comparison WAV filenames unique so overlapping runs cannot
+  overwrite another run before trimmed metrics are recomputed
 - moved reusable probe math into `SpeakSwiftlyTestingSupport` and added cheap
   synthetic tests for window slicing, tail/head summaries, matched-span
   trimming, and invalid analysis inputs

--- a/docs/releases/v4-0-5-release-prep.md
+++ b/docs/releases/v4-0-5-release-prep.md
@@ -25,11 +25,13 @@ Included work on the current branch:
   tail/head ratio, last-window average RMS, and an explicit
   `endpoint_rms_delta_pct`
 - write versioned `volume-probe` and `compare-volume` JSON artifacts under
-  `.local/volume-probes/`
+  `.local/volume-probes/` with unique per-run filenames
 - make `compare-volume` refuse mismatched sample rates or sample counts by
   default
 - add `--matched-duration trim-to-shorter` as the explicit opt-in path for
   comparing the same prefix span from both outputs
+- write direct Qwen comparison WAVs to unique temporary filenames so overlapping
+  probe runs cannot contaminate trimmed metrics
 - reject invalid analysis inputs before writing artifacts with meaningless
   values
 - document the probe contract in

--- a/docs/releases/v4-0-5-release-prep.md
+++ b/docs/releases/v4-0-5-release-prep.md
@@ -1,0 +1,103 @@
+# v4.0.5 Release Prep
+
+Date: 2026-04-24
+
+This note captures the intended scope and validation story for the `v4.0.5`
+release.
+
+## Intended Scope
+
+The release should be framed as:
+
+- a measurement-contract hardening pass for the package-local
+  `SpeakSwiftlyTesting` volume probes
+- a strict `compare-volume` safety fix that prevents streamed-vs-direct
+  conclusions unless analyzed spans are actually comparable
+- a documentation cleanup that makes the probe semantics visible in README,
+  CONTRIBUTING, and maintainer notes
+
+Included work on the current branch:
+
+- move reusable volume-analysis math into the `SpeakSwiftlyTestingSupport`
+  target so it can be covered by cheap synthetic tests
+- expand `volume-probe` summaries with duration, sample count, analyzed span,
+  fixed-duration window count, quarter buckets, averaged head and tail RMS,
+  tail/head ratio, last-window average RMS, and an explicit
+  `endpoint_rms_delta_pct`
+- write versioned `volume-probe` and `compare-volume` JSON artifacts under
+  `.local/volume-probes/`
+- make `compare-volume` refuse mismatched sample rates or sample counts by
+  default
+- add `--matched-duration trim-to-shorter` as the explicit opt-in path for
+  comparing the same prefix span from both outputs
+- reject invalid analysis inputs before writing artifacts with meaningless
+  values
+- document the probe contract in
+  `docs/maintainers/volume-probe-instrument-contract-2026-04-24.md`
+- update README, CONTRIBUTING, and the backend-benchmark follow-up note so they
+  no longer imply `compare-volume` is trustworthy without matched spans
+
+Not included:
+
+- a Qwen generation-default change
+- a `mlx-audio-swift` dependency update
+- real-model Qwen decay conclusions from the new probes
+- tagging or publishing the release before the branch lands on `main`
+
+## SemVer Framing
+
+- release this as `v4.0.5`
+- this is a patch release because it hardens package-local maintainer tooling,
+  JSON probe artifacts, tests, and documentation without changing the public
+  `SpeakSwiftly` runtime library or worker protocol
+- the only CLI behavior change is that `compare-volume` now refuses unsafe
+  comparisons unless trimming is explicitly requested
+
+## Validation Performed
+
+Baseline package validation:
+
+```bash
+swift build
+```
+
+```bash
+swift test
+```
+
+Focused probe coverage:
+
+```bash
+swift test --filter VolumeProbeAnalysisTests
+```
+
+Formatting and linting:
+
+```bash
+swiftformat --lint --config .swiftformat .
+```
+
+```bash
+swiftlint lint --config .swiftlint.yml
+```
+
+Diff hygiene:
+
+```bash
+git diff --check
+```
+
+Commit-hook repo-maintenance validation:
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```
+
+## Release Checklist
+
+- call out that `compare-volume` now refuses unmatched spans by default
+- call out that `endpoint_rms_delta_pct` is an endpoint metric, not a whole-run
+  degradation score
+- include the new maintainer contract doc in the release notes
+- keep any real-model Qwen decay investigation as a follow-up after the release
+  lands


### PR DESCRIPTION
## Summary

- harden `SpeakSwiftlyTesting` volume probe metrics and JSON artifacts
- make `compare-volume` refuse unmatched spans unless `--matched-duration trim-to-shorter` is explicit
- add probe contract docs plus v4.0.5 release prep and release notes

## Verification

- `swift build`
- `swift test --filter VolumeProbeAnalysisTests`
- `swift test`
- `swiftformat --lint --config .swiftformat .`
- `swiftlint lint --config .swiftlint.yml`
- `git diff --check`
- commit-hook `sh scripts/repo-maintenance/validate-all.sh`

## Release

Prepared as the next patch release candidate: `v4.0.5`. No tag or GitHub release has been published yet.