### PR TITLE
build: track latest mlx-audio fork release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ The wire shape is intentionally more literal and transport-oriented than the Swi
 
 `SpeakSwiftly.Configuration` is the typed runtime-startup surface. It now carries the preferred resident `speechBackend`, the Qwen conditioning strategy, and an optional startup `textNormalizer`.
 
-The current prepared-conditioning integration depends on a temporary frozen `mlx-audio-swift` fork pin while the matching `Qwen3TTS` API is being upstreamed. Keep that pin exact and intentional; do not loosen it back to a moving branch dependency.
+The current prepared-conditioning integration depends on `mlx-audio-swift` `69.2.1`, the latest tagged release on the `gaelic-ghost/mlx-audio-swift` fork's `main` branch. Keep this dependency version-based so downstream Xcode package consumers do not inherit a branch dependency.
 
 Default persisted configuration path:
 
@@ -538,10 +538,10 @@ swift build
 swift test
 ```
 
-The current `mlx-audio-swift` `0.7.0` fork pin restores the ordinary SwiftPM
-lane for this repository, including the worker-backed `QuickE2ETests` path.
-Treat plain `swift build` and `swift test` as the default verification story
-again.
+The current `mlx-audio-swift` `69.2.1` fork release restores the ordinary
+SwiftPM lane for this repository, including the worker-backed `QuickE2ETests`
+path. Treat plain `swift build` and `swift test` as the default verification
+story again.
 
 For MLX-backed package tests, the plain `swift test` lane now works because the
 `SpeakSwiftlyTests` target carries a bundled `default.metallib` resource and

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "32de28bbb82fef4e21d7ea4b7a641ed464a106620626fde0a47f14eb685bccb7",
+  "originHash" : "c810361449883354aee9d1dcfc9d3ae512afcfc776b091c8fe80f1b4733a6d20",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/mlx-audio-swift.git",
       "state" : {
-        "revision" : "dfb55adee9437e973b98b9dbd00caa30d48b3809",
-        "version" : "0.7.0"
+        "revision" : "b3f26d0214c932c231023c286ae5995234d32774",
+        "version" : "69.2.1"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
-        "version" : "2.31.3"
+        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
+        "version" : "3.31.3"
       }
     },
     {
@@ -107,6 +107,15 @@
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",
-            exact: "0.7.0",
+            exact: "69.2.1",
         ),
         .package(
             url: "https://github.com/ml-explore/mlx-swift.git",

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ swift build
 swift test
 ```
 
-The current `mlx-audio-swift` `0.7.0` fork pin restores the ordinary SwiftPM
-build and test path. If a future toolchain regression brings back the old
-`EnglishG2P.swift` parser failure, use the documented fallback lane in
-[CONTRIBUTING.md](CONTRIBUTING.md) instead of repeatedly retrying the same
-plain `swift build` / `swift test` commands.
+The current `mlx-audio-swift` `69.2.1` fork release restores the ordinary
+SwiftPM build and test path. If a future toolchain regression brings back the
+old `EnglishG2P.swift` parser failure, use the documented fallback lane in
+[CONTRIBUTING.md](CONTRIBUTING.md) instead of repeatedly retrying the same plain
+`swift build` / `swift test` commands.
 
 Use the Xcode-backed deterministic runtime only for standalone worker runs or
 for fallback validation when a future SwiftPM parser regression actually blocks

--- a/docs/maintainers/validation-lanes.md
+++ b/docs/maintainers/validation-lanes.md
@@ -27,11 +27,11 @@ reason to jump straight to `xcodebuild`.
 
 ## Historical SwiftPM Snag
 
-The current `mlx-audio-swift` `69.2.0` fork pin restores the ordinary SwiftPM
-lane for this repository. The notes below are retained because earlier pins
-could fail under plain SwiftPM with parser errors in `EnglishG2P.swift`, and we
-may need the same fallback again if a future toolchain regression reintroduces
-that behavior.
+The current `mlx-audio-swift` `69.2.1` fork release restores the ordinary
+SwiftPM lane for this repository. The notes below are retained because earlier
+pins could fail under plain SwiftPM with parser errors in `EnglishG2P.swift`,
+and we may need the same fallback again if a future toolchain regression
+reintroduces that behavior.
 
 Typical symptom:
 

--- a/docs/releases/v4-0-5-release-prep.md
+++ b/docs/releases/v4-0-5-release-prep.md
@@ -42,7 +42,6 @@ Included work on the current branch:
 Not included:
 
 - a Qwen generation-default change
-- a `mlx-audio-swift` dependency update
 - real-model Qwen decay conclusions from the new probes
 - tagging or publishing the release before the branch lands on `main`
 


### PR DESCRIPTION
## Summary

- update `mlx-audio-swift` from exact `0.7.0` to exact `69.2.1`, the latest tagged release on the `gaelic-ghost/mlx-audio-swift` fork main branch
- refresh `Package.resolved` for the newer MLX dependency graph
- update docs so the dependency is described as a versioned fork release, not a branch dependency

## Verification

- `swift build`
- `swift test` (214 tests; E2E opt-ins skipped)
- `git diff --check`
- commit hook repo-maintenance validation: SwiftFormat, MLX resource check, SwiftLint
