### PR TITLE
Normalize profile reference audio

### DIFF
--- a/Sources/SpeakSwiftly/Generation/ModelClients.swift
+++ b/Sources/SpeakSwiftly/Generation/ModelClients.swift
@@ -78,6 +78,7 @@ enum ModelFactory {
     static let profileModelRepo = "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16"
     static let cloneTranscriptionModelRepo = "mlx-community/GLM-ASR-Nano-2512-4bit"
     static let canonicalProfileSampleRate = 24000
+    static let profileReferenceTargetPeakAmplitude: Float = 0.95
     static let cloneTranscriptionSampleRate = 16000
     static let importedCloneModelRepo = "SpeakSwiftly/imported-reference-audio"
     static let importedCloneVoiceDescription = "Imported reference audio clone."

--- a/Sources/SpeakSwiftly/Generation/VoiceProfileOperations+Reroll.swift
+++ b/Sources/SpeakSwiftly/Generation/VoiceProfileOperations+Reroll.swift
@@ -25,7 +25,7 @@ extension SpeakSwiftly.Runtime {
 
         await emitProgress(id: id, stage: .generatingProfileAudio)
         let generationStartedAt = dependencies.now()
-        let audio = try await profileModel.generate(
+        let rawAudio = try await profileModel.generate(
             text: storedProfile.manifest.sourceText,
             voice: storedProfile.manifest.voiceDescription,
             refAudio: nil,
@@ -33,6 +33,7 @@ extension SpeakSwiftly.Runtime {
             language: nil,
             generationParameters: GenerationPolicy.profileModelParameters(for: storedProfile.manifest.sourceText),
         )
+        let audio = gainNormalizedProfileReferenceAudio(rawAudio)
         await logRequestEvent(
             "profile_audio_rerolled",
             requestID: id,
@@ -40,7 +41,7 @@ extension SpeakSwiftly.Runtime {
             profileName: storedProfile.manifest.profileName,
             details: [
                 "duration_ms": .int(elapsedMS(since: generationStartedAt)),
-                "sample_count": .int(audio.count),
+                "sample_count": .int(rawAudio.count),
             ],
         )
         try Task.checkCancellation()

--- a/Sources/SpeakSwiftly/Generation/VoiceProfileOperations+Support.swift
+++ b/Sources/SpeakSwiftly/Generation/VoiceProfileOperations+Support.swift
@@ -30,6 +30,24 @@ extension SpeakSwiftly.Runtime {
         }
     }
 
+    func gainNormalizedProfileReferenceAudio(_ audio: [Float]) -> [Float] {
+        let sanitizedAudio = audio.map { sample in
+            sample.isFinite ? sample : 0
+        }
+        let peakMagnitude = sanitizedAudio.reduce(Float.zero) { currentPeak, sample in
+            max(currentPeak, abs(sample))
+        }
+
+        guard peakMagnitude > 0 else {
+            return sanitizedAudio
+        }
+
+        let gain = ModelFactory.profileReferenceTargetPeakAmplitude / peakMagnitude
+        return sanitizedAudio.map { sample in
+            min(max(sample * gain, -1), 1)
+        }
+    }
+
     func resolvedCloneTranscript(
         requestID id: String,
         op: String,

--- a/Sources/SpeakSwiftly/Generation/VoiceProfileOperations.swift
+++ b/Sources/SpeakSwiftly/Generation/VoiceProfileOperations.swift
@@ -45,7 +45,7 @@ extension SpeakSwiftly.Runtime {
 
         await emitProgress(id: id, stage: .generatingProfileAudio)
         let generationStartedAt = dependencies.now()
-        let audio = try await profileModel.generate(
+        let rawAudio = try await profileModel.generate(
             text: text,
             voice: voiceDescription,
             refAudio: nil,
@@ -53,6 +53,7 @@ extension SpeakSwiftly.Runtime {
             language: nil,
             generationParameters: GenerationPolicy.profileModelParameters(for: text),
         )
+        let audio = gainNormalizedProfileReferenceAudio(rawAudio)
         await logRequestEvent(
             "profile_audio_generated",
             requestID: id,
@@ -60,7 +61,7 @@ extension SpeakSwiftly.Runtime {
             profileName: profileName,
             details: [
                 "duration_ms": .int(elapsedMS(since: generationStartedAt)),
-                "sample_count": .int(audio.count),
+                "sample_count": .int(rawAudio.count),
             ],
         )
         try Task.checkCancellation()
@@ -172,13 +173,14 @@ extension SpeakSwiftly.Runtime {
         )
 
         let sourceAudioLoadStartedAt = dependencies.now()
-        let canonicalAudio = try requireLoadedCloneAudio(
+        let rawCanonicalAudio = try requireLoadedCloneAudio(
             from: referenceAudioURL,
             sampleRate: ModelFactory.canonicalProfileSampleRate,
             requestID: id,
             pathLabel: "clone source audio",
             op: op,
         )
+        let canonicalAudio = gainNormalizedProfileReferenceAudio(rawCanonicalAudio)
         await logRequestEvent(
             "clone_source_audio_loaded",
             requestID: id,

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTestSupport.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import SpeakSwiftly
+import Testing
 
 final class WeakRuntimeBox: @unchecked Sendable {
     weak var value: WorkerRuntime?
@@ -24,4 +25,23 @@ func rawTestAudioData(for samples: [Float]) -> Data {
         withUnsafeBytes(of: value.littleEndian, Array.init)
     }
     return Data(bytes)
+}
+
+func rawTestAudioSamples(from data: Data) -> [Float] {
+    stride(from: 0, to: data.count, by: MemoryLayout<Float>.size).map { offset in
+        data[offset..<offset + MemoryLayout<Float>.size].withUnsafeBytes { bytes in
+            Float(bitPattern: UInt32(littleEndian: bytes.load(as: UInt32.self)))
+        }
+    }
+}
+
+func expectAudioSamples(
+    _ actual: [Float],
+    approximatelyEqualTo expected: [Float],
+    tolerance: Float = 0.000_001,
+) {
+    #expect(actual.count == expected.count)
+    for (actualSample, expectedSample) in zip(actual, expected) {
+        #expect(abs(actualSample - expectedSample) <= tolerance)
+    }
 }

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeLibraryControlSurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeLibraryControlSurfaceTests.swift
@@ -245,7 +245,110 @@ import TextForSpeech
     #expect(rerolledProfile.manifest.profileName == "bright-guide")
     #expect(rerolledProfile.manifest.sourceText == "Hello there")
     #expect(rerolledProfile.manifest.voiceDescription == "Warm and bright.")
-    #expect(try Data(contentsOf: rerolledProfile.referenceAudioURL) == rawTestAudioData(for: rerolledSamples))
+    try expectAudioSamples(
+        rawTestAudioSamples(from: Data(contentsOf: rerolledProfile.referenceAudioURL)),
+        approximatelyEqualTo: [0.738_888_9, 0.844_444_45, 0.95],
+    )
+}
+
+@Test func `voice design profile creation gain normalizes reference audio`() async throws {
+    let output = OutputRecorder()
+    let storeRoot = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: storeRoot) }
+
+    let store = try makeProfileStore(rootURL: storeRoot)
+    let generatedSamples: [Float] = [0.05, -0.1, 0.2]
+    let runtime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: output,
+        playback: PlaybackSpy(),
+        residentModelLoader: { _ in makeResidentModel() },
+        profileModelLoader: {
+            AnySpeechModel(
+                sampleRate: 24000,
+                generate: { _, _, _, _, _, _ in generatedSamples },
+                generateSamplesStream: { _, _, _, _, _, _, _ in
+                    AsyncThrowingStream { continuation in
+                        continuation.finish()
+                    }
+                },
+            )
+        },
+    )
+
+    await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    let createID = await runtime.voices
+        .create(design: "bright-guide",
+                from: "Hello there",
+                vibe: .femme,
+                voice: "Warm and bright",
+                outputPath: nil)
+        .id
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == createID
+                && $0["ok"] as? Bool == true
+                && $0["profile_name"] as? String == "bright-guide"
+        }
+    })
+
+    let profile = try store.loadProfile(named: "bright-guide")
+    #expect(try Data(contentsOf: profile.referenceAudioURL) == rawTestAudioData(for: [0.2375, -0.475, 0.95]))
+}
+
+@Test func `clone profile creation gain normalizes imported reference audio`() async throws {
+    let output = OutputRecorder()
+    let storeRoot = makeTempDirectoryURL()
+    let referenceDirectory = makeTempDirectoryURL()
+    defer {
+        try? FileManager.default.removeItem(at: storeRoot)
+        try? FileManager.default.removeItem(at: referenceDirectory)
+    }
+
+    let referenceAudioURL = referenceDirectory.appendingPathComponent("reference.wav")
+    try FileManager.default.createDirectory(at: referenceDirectory, withIntermediateDirectories: true)
+    try Data([0x52, 0x49, 0x46, 0x46]).write(to: referenceAudioURL)
+
+    let store = try makeProfileStore(rootURL: storeRoot)
+    let runtime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: output,
+        playback: PlaybackSpy(),
+        loadedCloneAudioSamples: [0.05, -0.1, 0.2],
+        residentModelLoader: { _ in makeResidentModel() },
+    )
+
+    await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    let createID = await runtime.voices
+        .create(clone: "imported-guide",
+                from: referenceAudioURL,
+                vibe: .femme,
+                transcript: "Hello there")
+        .id
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == createID
+                && $0["ok"] as? Bool == true
+                && $0["profile_name"] as? String == "imported-guide"
+        }
+    })
+
+    let profile = try store.loadProfile(named: "imported-guide")
+    #expect(try Data(contentsOf: profile.referenceAudioURL) == rawTestAudioData(for: [0.2375, -0.475, 0.95]))
 }
 
 @Test func `create profile resolves relative output path against explicit caller working directory`() async throws {


### PR DESCRIPTION
## Summary
- normalize generated VoiceDesign profile reference audio to a 0.95 peak before storing it
- apply the same normalization to imported clone profile reference audio used by Qwen 0.6B and 1.7B conditioning
- cover voice design creation, generated reroll, and imported clone creation with focused runtime tests

## Verification
- xcrun swift test
- sh scripts/repo-maintenance/validate-all.sh
- git diff --check