### PR TITLE
storage: skip stale retained manifests in list calls

### DIFF
--- a/Sources/SpeakSwiftly/Storage/GeneratedFileStore.swift
+++ b/Sources/SpeakSwiftly/Storage/GeneratedFileStore.swift
@@ -205,9 +205,9 @@ struct GeneratedFileStore {
             options: [.skipsHiddenFiles],
         )
 
-        return try urls
+        return urls
             .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
-            .map { directoryURL in
+            .compactMap { directoryURL in
                 do {
                     let manifestData = try Data(contentsOf: manifestURL(for: directoryURL))
                     let manifest = try decoder.decode(GeneratedFileManifest.self, from: manifestData)
@@ -217,10 +217,7 @@ struct GeneratedFileStore {
                         audioURL: audioURL(for: directoryURL, fileName: manifest.audioFile),
                     ).summary
                 } catch {
-                    throw WorkerError(
-                        code: .filesystemError,
-                        message: "SpeakSwiftly could not list generated files because the manifest in '\(directoryURL.path)' is unreadable or corrupt. \(error.localizedDescription)",
-                    )
+                    return nil
                 }
             }
     }

--- a/Sources/SpeakSwiftly/Storage/GenerationJobStore+ManifestIO.swift
+++ b/Sources/SpeakSwiftly/Storage/GenerationJobStore+ManifestIO.swift
@@ -46,15 +46,12 @@ extension GenerationJobStore {
             options: [.skipsHiddenFiles],
         )
 
-        let jobs = try urls.map { directoryURL in
+        let jobs = urls.compactMap { directoryURL in
             do {
                 let data = try Data(contentsOf: manifestURL(for: directoryURL))
                 return try decoder.decode(SpeakSwiftly.GenerationJob.self, from: data)
             } catch {
-                throw WorkerError(
-                    code: .filesystemError,
-                    message: "SpeakSwiftly could not list generation jobs because the manifest in '\(directoryURL.path)' is unreadable or corrupt. \(error.localizedDescription)",
-                )
+                return nil
             }
         }
 

--- a/Tests/SpeakSwiftlyTests/Storage/GeneratedFileStoreTests.swift
+++ b/Tests/SpeakSwiftlyTests/Storage/GeneratedFileStoreTests.swift
@@ -32,6 +32,44 @@ import Testing
     #expect(listed == [loaded.summary])
 }
 
+@Test func `generated file store lists readable artifacts when stale retained manifests exist`() throws {
+    let rootURL = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let store = try makeGeneratedFileStore(rootURL: rootURL)
+    _ = try store.createGeneratedFile(
+        artifactID: "req-file-readable",
+        voiceProfile: "default-femme",
+        textProfile: nil,
+        inputTextContext: nil,
+        requestContext: nil,
+        sampleRate: 24000,
+        audioData: Data([0x01, 0x02, 0x03]),
+    )
+
+    let loaded = try store.loadGeneratedFile(id: "req-file-readable")
+    let staleArtifactID = "req-file-stale"
+    let staleDirectoryURL = store.generatedFileDirectoryURL(for: staleArtifactID)
+    try FileManager.default.createDirectory(at: staleDirectoryURL, withIntermediateDirectories: false)
+    let staleManifest = """
+    {
+      "artifactID" : "\(staleArtifactID)",
+      "audioFile" : "generated.wav",
+      "createdAt" : "2026-04-16T17:46:33Z",
+      "profileName" : "default-femme",
+      "sampleRate" : 24000,
+      "version" : 1
+    }
+    """
+    try Data(staleManifest.utf8).write(to: store.manifestURL(for: staleDirectoryURL))
+    try Data([0x04, 0x05, 0x06]).write(to: store.audioURL(for: staleDirectoryURL))
+
+    #expect(try store.listGeneratedFiles() == [loaded.summary])
+    #expect(throws: WorkerError.self) {
+        _ = try store.loadGeneratedFile(id: staleArtifactID)
+    }
+}
+
 @Test func `generated file store rejects missing artifacts`() throws {
     let rootURL = makeTempDirectoryURL()
     defer { try? FileManager.default.removeItem(at: rootURL) }

--- a/Tests/SpeakSwiftlyTests/Storage/GenerationJobStoreTests.swift
+++ b/Tests/SpeakSwiftlyTests/Storage/GenerationJobStoreTests.swift
@@ -66,6 +66,51 @@ import Testing
     #expect(listed == [completed])
 }
 
+@Test func `generation job store lists readable jobs when stale retained manifests exist`() throws {
+    let rootURL = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+
+    let store = try makeGenerationJobStore(rootURL: rootURL)
+    let queued = try store.createFileJob(
+        jobID: "job-file-readable",
+        voiceProfile: "default-femme",
+        textProfile: nil,
+        speechBackend: .qwen3,
+        item: SpeakSwiftly.GenerationJobItem(
+            artifactID: "artifact-readable",
+            text: "Readable retained job.",
+            textProfile: nil,
+            inputTextContext: nil,
+            requestContext: nil,
+        ),
+        createdAt: Date(timeIntervalSince1970: 3000),
+    )
+
+    let staleJobID = "job-file-stale"
+    let staleDirectoryURL = store.generationJobDirectoryURL(for: staleJobID)
+    try FileManager.default.createDirectory(at: staleDirectoryURL, withIntermediateDirectories: false)
+    let staleManifest = """
+    {
+      "artifacts" : [],
+      "created_at" : "2026-04-16T17:46:21Z",
+      "items" : [],
+      "job_id" : "\(staleJobID)",
+      "job_kind" : "file",
+      "profile_name" : "default-femme",
+      "retention_policy" : "manual",
+      "speech_backend" : "qwen3",
+      "state" : "failed",
+      "updated_at" : "2026-04-16T17:46:21Z"
+    }
+    """
+    try Data(staleManifest.utf8).write(to: store.manifestURL(for: staleDirectoryURL))
+
+    #expect(try store.listGenerationJobs() == [queued])
+    #expect(throws: WorkerError.self) {
+        _ = try store.loadGenerationJob(id: staleJobID)
+    }
+}
+
 @Test func `generation job store rejects missing jobs`() throws {
     let rootURL = makeTempDirectoryURL()
     defer { try? FileManager.default.removeItem(at: rootURL) }


### PR DESCRIPTION
## Summary
- skip stale or unreadable retained generation-job manifests during list calls
- skip stale or unreadable generated-file manifests during list calls
- add storage regression coverage for older retained manifest field names still present in live runtime stores

## Verification
- swiftformat --config .swiftformat Sources/SpeakSwiftly/Storage/GenerationJobStore+ManifestIO.swift Sources/SpeakSwiftly/Storage/GeneratedFileStore.swift Tests/SpeakSwiftlyTests/Storage/GenerationJobStoreTests.swift Tests/SpeakSwiftlyTests/Storage/GeneratedFileStoreTests.swift
- swift test --filter "GenerationJobStoreTests|GeneratedFileStoreTests"
- swift build
- pre-commit repo-maintenance validation during commit