### PR TITLE
Split generation and playback queue controls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -603,7 +603,7 @@ sh scripts/repo-maintenance/run-e2e.sh --suite quick
 sh scripts/repo-maintenance/run-e2e-full.sh
 ```
 
-`run-e2e.sh` intentionally runs exactly one top-level suite per invocation. `run-e2e-full.sh` runs the default release-safe suite list sequentially: `GeneratedFileE2ETests`, `GeneratedBatchE2ETests`, `ChatterboxE2ETests`, `MarvisE2ETests`, and `QwenE2ETests`. The `quick` alias points at `GeneratedFileE2ETests` because that suite covers worker boot, seeded profile loading, generated-file output, artifact read, and artifact listing without running a second duplicate worker pass.
+`run-e2e.sh` intentionally runs exactly one top-level suite per invocation. `run-e2e-full.sh` runs the default release-safe suite list sequentially: `GeneratedFileE2ETests`, `GeneratedBatchE2ETests`, `ChatterboxE2ETests`, `QueueControlE2ETests`, `MarvisE2ETests`, and `QwenE2ETests`. The `quick` alias points at `GeneratedFileE2ETests` because that suite covers worker boot, seeded profile loading, generated-file output, artifact read, and artifact listing without running a second duplicate worker pass.
 
 For a deliberately small worker-backed smoke lane after narrow changes, run the dedicated quick suite:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,8 @@ Current typed-surface conventions:
 - live playback and file rendering are separate generation calls, with `Generate.speech(...)` and `Generate.audio(...)`
 - generation-queue inspection lives under `Jobs`
 - playback-queue inspection lives under `Player.list(...)`
+- queue-specific controls live on `Runtime` as `clearQueue(.generation)`, `clearQueue(.playback)`, `cancel(.generation, requestID:)`, and `cancel(.playback, requestID:)`
+- the `Jobs` and `Player` handles may expose same-queue convenience methods, but cross-queue behavior should stay explicit on `Runtime`
 - resident runtime controls use `status()`, `switchSpeechBackend(to:)`, `reloadModels()`, and `unloadModels()`
 - decode/result model memberwise initializers should stay internal unless callers have a concrete need to construct those values themselves
 - `BatchItem` remains public only because batch submission is still intentionally caller-authored at that layer
@@ -290,6 +292,12 @@ Representative request shapes:
 {"id":"req-switch","op":"set_speech_backend","speech_backend":"chatterbox_turbo"}
 {"id":"req-reload","op":"reload_models"}
 {"id":"req-unload","op":"unload_models"}
+{"id":"req-generation-queue","op":"list_generation_queue"}
+{"id":"req-playback-queue","op":"list_playback_queue"}
+{"id":"req-clear-generation","op":"clear_generation_queue"}
+{"id":"req-clear-playback","op":"clear_playback_queue"}
+{"id":"req-cancel-generation","op":"cancel_generation","request_id":"req-1"}
+{"id":"req-cancel-playback","op":"cancel_playback","request_id":"req-1"}
 ```
 
 Representative response and event shapes:
@@ -363,7 +371,8 @@ The main entry points into the playback layer are:
 
 - typed Swift submission through `Generate.speech(...)`
 - JSONL submission through `generate_speech`
-- playback control reads and writes through `runtime.player` and the wire control ops such as `playback_pause`, `playback_resume`, `get_playback_state`, `list_playback_queue`, `clear_queue`, and `cancel_request`
+- playback control reads and writes through `runtime.player` and the wire control ops such as `playback_pause`, `playback_resume`, `get_playback_state`, `list_playback_queue`, `clear_playback_queue`, and `cancel_playback`
+- generation queue control reads and writes through `runtime.jobs`, `runtime.clearQueue(.generation)`, `runtime.cancel(.generation, requestID:)`, and the wire control ops `list_generation_queue`, `clear_generation_queue`, and `cancel_generation`
 
 The runtime accepts a live speech request as a generation request first. It then creates the playback-side job state that will receive streamed audio and complete only after playback finishes.
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ Key typed runtime entry points include:
 - `runtime.player.state()`
 - `runtime.player.clearQueue()`
 - `runtime.player.cancelRequest(_:)`
+- `runtime.clearQueue(.generation)`
+- `runtime.clearQueue(.playback)`
+- `runtime.cancel(.generation, requestID:)`
+- `runtime.cancel(.playback, requestID:)`
+- `runtime.jobs.clearQueue()`
+- `runtime.jobs.cancel(_:)`
 - `runtime.jobs.expire(id:)`
 - `runtime.jobs.generationQueue()`
 - `runtime.jobs.job(id:)`
@@ -275,6 +281,10 @@ Resident runtime controls currently map like this:
 | `switchSpeechBackend(to:)` | `"set_speech_backend"` | Requires a `"speech_backend"` field on the JSONL request. |
 | `reloadModels()` | `"reload_models"` | Re-warms the currently selected resident backend. |
 | `unloadModels()` | `"unload_models"` | Drops resident models from memory and parks later resident-dependent generation until residency returns. |
+| `clearQueue(.generation)` | `"clear_generation_queue"` | Cancels queued generation work that has not started. |
+| `clearQueue(.playback)` | `"clear_playback_queue"` | Cancels queued playback work that has not started. |
+| `cancel(.generation, requestID:)` | `"cancel_generation"` | Cancels one queued or active generation request by `request_id`. |
+| `cancel(.playback, requestID:)` | `"cancel_playback"` | Cancels one queued or active playback request by `request_id`. |
 
 For the full JSONL worker contract, request and event examples, naming rules, and queue semantics, see:
 

--- a/Sources/SpeakSwiftly/API/GenerationJobs.swift
+++ b/Sources/SpeakSwiftly/API/GenerationJobs.swift
@@ -239,6 +239,16 @@ public extension SpeakSwiftly.Jobs {
         await runtime.submit(.listQueue(id: UUID().uuidString, queueType: .generation))
     }
 
+    /// Clears queued generation work that has not started yet.
+    func clearQueue() async -> SpeakSwiftly.RequestHandle {
+        await runtime.clearQueue(.generation)
+    }
+
+    /// Cancels one queued or active generation request by identifier.
+    func cancel(_ requestID: String) async -> SpeakSwiftly.RequestHandle {
+        await runtime.cancel(.generation, requestID: requestID)
+    }
+
     /// Expires one retained generation job.
     func expire(id jobID: String) async -> SpeakSwiftly.RequestHandle {
         await runtime.submit(.expireGenerationJob(id: UUID().uuidString, jobID: jobID))

--- a/Sources/SpeakSwiftly/API/Playback.swift
+++ b/Sources/SpeakSwiftly/API/Playback.swift
@@ -43,12 +43,22 @@ public extension SpeakSwiftly.Player {
 
     /// Clears queued playback work that has not started yet.
     func clearQueue() async -> SpeakSwiftly.RequestHandle {
-        await runtime.submit(.clearQueue(id: UUID().uuidString))
+        await runtime.clearQueue(.playback)
+    }
+
+    /// Clears queued work from one runtime queue.
+    func clearQueue(_ queueType: SpeakSwiftly.QueueType) async -> SpeakSwiftly.RequestHandle {
+        await runtime.clearQueue(queueType)
     }
 
     /// Cancels one queued or active request by identifier.
     func cancelRequest(_ requestID: String) async -> SpeakSwiftly.RequestHandle {
-        await runtime.submit(.cancelRequest(id: UUID().uuidString, requestID: requestID))
+        await runtime.cancel(.playback, requestID: requestID)
+    }
+
+    /// Cancels one queued or active request in one runtime queue.
+    func cancel(_ queueType: SpeakSwiftly.QueueType, requestID: String) async -> SpeakSwiftly.RequestHandle {
+        await runtime.cancel(queueType, requestID: requestID)
     }
 }
 

--- a/Sources/SpeakSwiftly/API/QueueControls.swift
+++ b/Sources/SpeakSwiftly/API/QueueControls.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public extension SpeakSwiftly.Runtime {
+    // MARK: Queue Control
+
+    /// Clears queued work from one runtime queue.
+    func clearQueue(_ queueType: SpeakSwiftly.QueueType) async -> SpeakSwiftly.RequestHandle {
+        await submit(.clearQueue(id: UUID().uuidString, queueType: queueType))
+    }
+
+    /// Cancels one queued or active request in one runtime queue.
+    func cancel(_ queueType: SpeakSwiftly.QueueType, requestID: String) async -> SpeakSwiftly.RequestHandle {
+        await submit(.cancelRequest(id: UUID().uuidString, requestID: requestID, queueType: queueType))
+    }
+}

--- a/Sources/SpeakSwiftly/Generation/SpeechGenerationController.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechGenerationController.swift
@@ -41,9 +41,11 @@ actor SpeechGenerationController {
         activeJobs.removeValue(forKey: token)
     }
 
-    func cancel(requestID: String) -> CancellationTarget? {
+    func cancel(requestID: String, removeActive: Bool = true) -> CancellationTarget? {
         if let active = activeJobs.values.first(where: { $0.request.id == requestID }) {
-            activeJobs.removeValue(forKey: active.token)
+            if removeActive {
+                activeJobs.removeValue(forKey: active.token)
+            }
             return .active(active)
         }
 

--- a/Sources/SpeakSwiftly/Playback/PlaybackController.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackController.swift
@@ -294,10 +294,12 @@ actor PlaybackController {
         }
     }
 
-    func cancel(requestID: String) async -> LiveSpeechPlaybackState? {
+    func cancel(requestID: String, cancelGenerationTask: Bool = true) async -> LiveSpeechPlaybackState? {
         guard let playbackState = jobs[requestID] else { return nil }
 
-        playbackState.execution.generationTask?.cancel()
+        if cancelGenerationTask {
+            playbackState.execution.generationTask?.cancel()
+        }
         playbackState.execution.playbackTask?.cancel()
         queue.removeAll { $0 == requestID }
         jobs.removeValue(forKey: requestID)

--- a/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
@@ -5,11 +5,23 @@ import Foundation
 extension SpeakSwiftly.Runtime {
     // MARK: - Queue Management
 
-    func clearQueuedRequests(cancelledByRequestID: String, reason: String) async -> Int {
-        let queuedJobs = await generationController.clearQueued()
+    func clearQueuedRequests(
+        queueType: WorkerQueueType?,
+        cancelledByRequestID: String,
+        reason: String,
+    ) async -> Int {
+        let queuedJobs = if queueType == nil || queueType == .generation {
+            await generationController.clearQueued()
+        } else {
+            [SpeechGenerationController.Job]()
+        }
         let activePlaybackRequestID = await playbackController.activeRequestSummary()?.id
         let protectedRequestIDs = Set(activeGenerations.values.map(\.request.id) + [activePlaybackRequestID].compactMap { $0 })
-        let waitingPlaybackJobs = await playbackController.clearQueued(excluding: protectedRequestIDs)
+        let waitingPlaybackJobs = if queueType == nil || queueType == .playback {
+            await playbackController.clearQueued(excluding: protectedRequestIDs)
+        } else {
+            [LiveSpeechPlaybackState]()
+        }
 
         let cancellation = WorkerError(
             code: .requestCancelled,
@@ -58,15 +70,18 @@ extension SpeakSwiftly.Runtime {
         }
     }
 
-    func cancelRequestNow(_ targetRequestID: String, cancelledByRequestID: String) async throws -> String {
+    func cancelRequestNow(
+        _ targetRequestID: String,
+        queueType: WorkerQueueType?,
+        cancelledByRequestID: String,
+    ) async throws -> String {
         let cancellation = WorkerError(
             code: .requestCancelled,
             message: "Request '\(targetRequestID)' was cancelled by control request '\(cancelledByRequestID)'.",
         )
 
-        let cancelledGenerationTarget = await generationController.cancel(requestID: targetRequestID)
-
-        if let playbackState = await playbackController.cancel(requestID: targetRequestID) {
+        if queueType == nil || queueType == .playback,
+           let playbackState = await playbackController.cancel(requestID: targetRequestID) {
             playbackState.execution.continuation.finish(throwing: cancellation)
             await completePlaybackJob(playbackState.request, result: .failure(cancellation))
             try? await startNextGenerationIfPossible()
@@ -74,9 +89,20 @@ extension SpeakSwiftly.Runtime {
             return targetRequestID
         }
 
+        guard queueType == nil || queueType == .generation else {
+            throw requestNotFoundError(targetRequestID, queueType: queueType, cancelledByRequestID: cancelledByRequestID)
+        }
+
+        let cancelledGenerationTarget = await generationController.cancel(requestID: targetRequestID)
+
         switch cancelledGenerationTarget {
             case let .active(job):
                 activeGenerations.removeValue(forKey: job.token)?.task.cancel()
+                if job.request.requiresPlayback,
+                   let playbackState = await playbackController.cancel(requestID: targetRequestID) {
+                    playbackState.execution.continuation.finish(throwing: cancellation)
+                    await completePlaybackJob(playbackState.request, result: .failure(cancellation))
+                }
                 markGenerationJobFailedIfNeeded(for: job.request, error: cancellation)
                 failRequestStream(for: targetRequestID, error: cancellation)
                 await logError(
@@ -88,6 +114,9 @@ extension SpeakSwiftly.Runtime {
                 try? await startNextGenerationIfPossible()
                 return targetRequestID
             case let .queued(job):
+                if job.request.requiresPlayback {
+                    _ = await playbackController.discard(requestID: job.request.id)
+                }
                 markGenerationJobFailedIfNeeded(for: job.request, error: cancellation)
                 failRequestStream(for: targetRequestID, error: cancellation)
                 await logError(
@@ -101,9 +130,18 @@ extension SpeakSwiftly.Runtime {
                 break
         }
 
-        throw WorkerError(
+        throw requestNotFoundError(targetRequestID, queueType: queueType, cancelledByRequestID: cancelledByRequestID)
+    }
+
+    private func requestNotFoundError(
+        _ targetRequestID: String,
+        queueType: WorkerQueueType?,
+        cancelledByRequestID: String,
+    ) -> WorkerError {
+        let scope = queueType.map { " in the \($0.rawValue) queue" } ?? " in the active or queued SpeakSwiftly work set"
+        return WorkerError(
             code: .requestNotFound,
-            message: "Control request '\(cancelledByRequestID)' could not find request '\(targetRequestID)' in the active or queued SpeakSwiftly work set.",
+            message: "Control request '\(cancelledByRequestID)' could not find request '\(targetRequestID)'\(scope).",
         )
     }
 

--- a/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
@@ -81,10 +81,9 @@ extension SpeakSwiftly.Runtime {
         )
 
         if queueType == nil || queueType == .playback,
-           let playbackState = await playbackController.cancel(requestID: targetRequestID) {
+           let playbackState = await playbackController.cancel(requestID: targetRequestID, cancelGenerationTask: false) {
             playbackState.execution.continuation.finish(throwing: cancellation)
             await completePlaybackJob(playbackState.request, result: .failure(cancellation))
-            try? await startNextGenerationIfPossible()
             await playbackController.startNextIfPossible()
             return targetRequestID
         }
@@ -93,25 +92,16 @@ extension SpeakSwiftly.Runtime {
             throw requestNotFoundError(targetRequestID, queueType: queueType, cancelledByRequestID: cancelledByRequestID)
         }
 
-        let cancelledGenerationTarget = await generationController.cancel(requestID: targetRequestID)
+        let cancelledGenerationTarget = await generationController.cancel(requestID: targetRequestID, removeActive: false)
 
         switch cancelledGenerationTarget {
             case let .active(job):
-                activeGenerations.removeValue(forKey: job.token)?.task.cancel()
+                activeGenerationCancellations[job.request.id] = cancellation
                 if job.request.requiresPlayback,
-                   let playbackState = await playbackController.cancel(requestID: targetRequestID) {
+                   let playbackState = await playbackController.cancel(requestID: targetRequestID, cancelGenerationTask: false) {
                     playbackState.execution.continuation.finish(throwing: cancellation)
                     await completePlaybackJob(playbackState.request, result: .failure(cancellation))
                 }
-                markGenerationJobFailedIfNeeded(for: job.request, error: cancellation)
-                failRequestStream(for: targetRequestID, error: cancellation)
-                await logError(
-                    cancellation.message,
-                    requestID: targetRequestID,
-                    details: ["failure_code": .string(cancellation.code.rawValue)],
-                )
-                await emitFailure(id: targetRequestID, error: cancellation)
-                try? await startNextGenerationIfPossible()
                 return targetRequestID
             case let .queued(job):
                 if job.request.requiresPlayback {

--- a/Sources/SpeakSwiftly/Runtime/WorkerProtocol+Decoding.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerProtocol+Decoding.swift
@@ -267,11 +267,25 @@ extension WorkerRequest {
                 return .playback(id: id, action: .state)
 
             case "clear_queue":
-                return .clearQueue(id: id)
+                return .clearQueue(id: id, queueType: nil)
+
+            case "clear_generation_queue":
+                return .clearQueue(id: id, queueType: .generation)
+
+            case "clear_playback_queue":
+                return .clearQueue(id: id, queueType: .playback)
 
             case "cancel_request":
                 let requestID = try requireNonEmpty(raw.requestID, field: "request_id", id: id)
-                return .cancelRequest(id: id, requestID: requestID)
+                return .cancelRequest(id: id, requestID: requestID, queueType: nil)
+
+            case "cancel_generation":
+                let requestID = try requireNonEmpty(raw.requestID, field: "request_id", id: id)
+                return .cancelRequest(id: id, requestID: requestID, queueType: .generation)
+
+            case "cancel_playback":
+                let requestID = try requireNonEmpty(raw.requestID, field: "request_id", id: id)
+                return .cancelRequest(id: id, requestID: requestID, queueType: .playback)
 
             default:
                 throw WorkerError(code: .unknownOperation, message: "Request '\(id)' uses unsupported operation '\(op)'.")

--- a/Sources/SpeakSwiftly/Runtime/WorkerProtocol.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerProtocol.swift
@@ -71,8 +71,8 @@ enum WorkerRequest: Equatable {
     case reloadModels(id: String)
     case unloadModels(id: String)
     case playback(id: String, action: PlaybackAction)
-    case clearQueue(id: String)
-    case cancelRequest(id: String, requestID: String)
+    case clearQueue(id: String, queueType: WorkerQueueType?)
+    case cancelRequest(id: String, requestID: String, queueType: WorkerQueueType?)
 
     var id: String {
         switch self {
@@ -117,8 +117,8 @@ enum WorkerRequest: Equatable {
                  let .reloadModels(id),
                  let .unloadModels(id),
                  let .playback(id, _),
-                 let .clearQueue(id),
-                 let .cancelRequest(id, _):
+                 let .clearQueue(id, _),
+                 let .cancelRequest(id, _, _):
                 id
         }
     }
@@ -215,10 +215,18 @@ enum WorkerRequest: Equatable {
                 "playback_resume"
             case .playback(_, .state):
                 "get_playback_state"
-            case .clearQueue:
+            case .clearQueue(_, nil):
                 "clear_queue"
-            case .cancelRequest:
+            case .clearQueue(_, .generation):
+                "clear_generation_queue"
+            case .clearQueue(_, .playback):
+                "clear_playback_queue"
+            case .cancelRequest(_, _, nil):
                 "cancel_request"
+            case .cancelRequest(_, _, .generation):
+                "cancel_generation"
+            case .cancelRequest(_, _, .playback):
+                "cancel_playback"
         }
     }
 

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Emission.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Emission.swift
@@ -494,9 +494,9 @@ extension SpeakSwiftly.Runtime {
                 await submitRequest(id: id, op: request.opName)
             case let .playback(id, _):
                 await submitRequest(id: id, op: request.opName)
-            case let .clearQueue(id):
+            case let .clearQueue(id, _):
                 await submitRequest(id: id, op: request.opName)
-            case let .cancelRequest(id, requestID):
+            case let .cancelRequest(id, requestID, _):
                 await submitRequest(id: id, op: request.opName, requestID: requestID)
         }
     }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+ImmediateControl.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+ImmediateControl.swift
@@ -339,16 +339,18 @@ extension SpeakSwiftly.Runtime {
                         ),
                     )
 
-                case let .clearQueue(id):
+                case let .clearQueue(id, queueType):
                     let clearedCount = await clearQueuedRequests(
+                        queueType: queueType,
                         cancelledByRequestID: id,
                         reason: "queued work was cleared from the SpeakSwiftly queue",
                     )
                     result = .success(WorkerSuccessPayload(id: id, clearedCount: clearedCount))
 
-                case let .cancelRequest(id, targetRequestID):
+                case let .cancelRequest(id, targetRequestID, queueType):
                     let cancelledRequestID = try await cancelRequestNow(
                         targetRequestID,
+                        queueType: queueType,
                         cancelledByRequestID: id,
                     )
                     result = .success(WorkerSuccessPayload(id: id, cancelledRequestID: cancelledRequestID))

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
@@ -392,6 +392,7 @@ public extension SpeakSwiftly {
         var requestBrokers = [String: RequestBroker]()
         var terminalRequestBrokerOrder = [String]()
         var activeGenerations = [UUID: ActiveRequest]()
+        var activeGenerationCancellations = [String: WorkerError]()
         var lastLoggedMarvisSchedulerState: String?
         var qwenConditioningCache = [QwenConditioningCacheKey: Qwen3TTSModel.Qwen3TTSReferenceConditioning]()
 

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
@@ -310,7 +310,10 @@ extension SpeakSwiftly.Runtime {
             activeJobs: generationController.activeJobsOrdered(),
             disposition: disposition,
         )
-        let finalDisposition: GenerationCompletionDisposition = if isShuttingDown {
+        let cancellation = activeGenerationCancellations.removeValue(forKey: request.id)
+        let finalDisposition: GenerationCompletionDisposition = if let cancellation {
+            .requestCompleted(.failure(cancellation))
+        } else if isShuttingDown {
             switch disposition {
                 case .requestCompleted(.success):
                     .requestCompleted(.failure(cancellationError(for: request.id)))

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/WorkerContract.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/WorkerContract.md
@@ -41,6 +41,10 @@ Representative operations include:
 - `generate_batch` for grouped retained artifacts.
 - `create_voice_profile_from_description`, `create_voice_profile_from_audio`, `list_voice_profiles`, and related voice-management operations.
 - `get_status`, `reload_models`, and `unload_models` for runtime control.
+- `list_generation_queue`, `clear_generation_queue`, and `cancel_generation` for generation-queue inspection and control.
+- `list_playback_queue`, `clear_playback_queue`, and `cancel_playback` for playback-queue inspection and control.
+
+The broad compatibility operations `clear_queue` and `cancel_request` still exist for hosts that intentionally want to affect any queued work, but new operators should prefer the queue-specific operations when the target queue is known.
 
 ## Read Events And Results
 

--- a/Sources/SpeakSwiftly/SpeakSwiftly.swift
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.swift
@@ -137,16 +137,17 @@ public enum SpeakSwiftly {
         }
     }
 
+    /// Identifies a runtime work queue for queue-specific controls.
+    public enum QueueType: String, Sendable, Equatable {
+        case generation
+        case playback
+    }
+
     // MARK: Internal Request Helpers
 
     enum SpeechJobType: Equatable {
         case live
         case file
-    }
-
-    enum WorkerQueueType: String, Equatable {
-        case generation
-        case playback
     }
 
     enum PlaybackAction: Equatable {
@@ -170,7 +171,7 @@ public enum SpeakSwiftly {
 // MARK: - Internal Compatibility
 
 typealias SpeechJobType = SpeakSwiftly.SpeechJobType
-typealias WorkerQueueType = SpeakSwiftly.WorkerQueueType
+typealias WorkerQueueType = SpeakSwiftly.QueueType
 typealias PlaybackAction = SpeakSwiftly.PlaybackAction
 typealias PlaybackState = SpeakSwiftly.PlaybackState
 typealias WorkerRequestStreamEvent = SpeakSwiftly.RequestEvent

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -426,6 +426,23 @@ import Darwin
     let generationQueue: @Sendable (SpeakSwiftly.Jobs) async -> SpeakSwiftly.RequestHandle = { jobs in
         await jobs.generationQueue()
     }
+    let clearGenerationQueue: @Sendable (SpeakSwiftly.Jobs) async -> SpeakSwiftly.RequestHandle = { jobs in
+        await jobs.clearQueue()
+    }
+    let cancelGeneration: @Sendable (SpeakSwiftly.Jobs, String) async -> SpeakSwiftly.RequestHandle = { jobs, requestID in
+        await jobs.cancel(requestID)
+    }
+    let clearRuntimeQueue: @Sendable (SpeakSwiftly.Runtime, SpeakSwiftly.QueueType) async -> SpeakSwiftly.RequestHandle = {
+        runtime,
+        queueType in
+        await runtime.clearQueue(queueType)
+    }
+    let cancelRuntimeQueue: @Sendable (SpeakSwiftly.Runtime, SpeakSwiftly.QueueType, String) async -> SpeakSwiftly.RequestHandle = {
+        runtime,
+        queueType,
+        requestID in
+        await runtime.cancel(queueType, requestID: requestID)
+    }
     let status: @Sendable (SpeakSwiftly.Runtime) async -> SpeakSwiftly.RequestHandle = { runtime in
         await runtime.status()
     }
@@ -467,6 +484,15 @@ import Darwin
     }
     let cancelRequest: @Sendable (SpeakSwiftly.Player, String) async -> SpeakSwiftly.RequestHandle = { player, requestID in
         await player.cancelRequest(requestID)
+    }
+    let clearScopedQueue: @Sendable (SpeakSwiftly.Player, SpeakSwiftly.QueueType) async -> SpeakSwiftly.RequestHandle = { player, queueType in
+        await player.clearQueue(queueType)
+    }
+    let cancelScopedQueue: @Sendable (SpeakSwiftly.Player, SpeakSwiftly.QueueType, String) async -> SpeakSwiftly.RequestHandle = {
+        player,
+        queueType,
+        requestID in
+        await player.cancel(queueType, requestID: requestID)
     }
     let statusEvents: @Sendable (SpeakSwiftly.Runtime) async -> AsyncStream<SpeakSwiftly.StatusEvent> = { runtime in
         await runtime.statusEvents()
@@ -527,6 +553,10 @@ import Darwin
     _ = requestSnapshot
     _ = updates
     _ = generationEvents
+    _ = clearGenerationQueue
+    _ = cancelGeneration
+    _ = clearRuntimeQueue
+    _ = cancelRuntimeQueue
     _ = switchSpeechBackend
     _ = reloadModels
     _ = unloadModels
@@ -534,6 +564,8 @@ import Darwin
     _ = playbackPause
     _ = clearQueue
     _ = cancelRequest
+    _ = clearScopedQueue
+    _ = cancelScopedQueue
     _ = statusEvents
 }
 

--- a/Tests/SpeakSwiftlyTests/E2E/QueueControlE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/QueueControlE2ETests.swift
@@ -1,0 +1,142 @@
+#if os(macOS)
+import Foundation
+@testable import SpeakSwiftly
+import Testing
+
+@Suite(
+    .serialized,
+    .tags(.e2e, .chatterbox),
+    .enabled(
+        if: speakSwiftlyE2ETestsEnabled(),
+        "These end-to-end worker tests are opt-in and require SPEAKSWIFTLY_E2E=1.",
+    ),
+)
+struct QueueControlE2ETests {
+    @Test func `generation queue clear and cancel stay generation scoped`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        let worker = try WorkerProcess(
+            profileRootURL: sandbox.profileRootURL,
+            silentPlayback: true,
+            speechBackend: .chatterboxTurbo,
+        )
+        defer { Task { await worker.stop() } }
+
+        try await E2EHarness.awaitWorkerReady(worker)
+        try sandbox.seedProfileFixture(.mascDesign, as: E2EHarness.testingProfileName)
+
+        try worker.sendJSON(
+            """
+            {"id":"req-generation-active-e2e","op":"generate_audio_file","text":"\(E2EHarness.qwenLongFormPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            """,
+        )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-generation-active-e2e"
+                && $0["event"] as? String == "started"
+        } != nil)
+
+        try worker.sendJSON(
+            """
+            {"id":"req-generation-queued-e2e","op":"generate_audio_file","text":"\(E2EHarness.testingPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            """,
+        )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-generation-queued-e2e"
+                && $0["event"] as? String == "queued"
+                && $0["reason"] as? String == "waiting_for_active_request"
+        } != nil)
+
+        try worker.sendJSON(
+            """
+            {"id":"req-clear-playback-e2e","op":"clear_playback_queue"}
+            """,
+        )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-clear-playback-e2e"
+                && $0["ok"] as? Bool == true
+                && $0["cleared_count"] as? Int == 0
+        } != nil)
+
+        try worker.sendJSON(
+            """
+            {"id":"req-clear-generation-e2e","op":"clear_generation_queue"}
+            """,
+        )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-clear-generation-e2e"
+                && $0["ok"] as? Bool == true
+                && $0["cleared_count"] as? Int == 1
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-generation-queued-e2e"
+                && $0["ok"] as? Bool == false
+                && $0["code"] as? String == "request_cancelled"
+        } != nil)
+
+        try worker.sendJSON(
+            """
+            {"id":"req-cancel-generation-e2e","op":"cancel_generation","request_id":"req-generation-active-e2e"}
+            """,
+        )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-cancel-generation-e2e"
+                && $0["ok"] as? Bool == true
+                && $0["cancelled_request_id"] as? String == "req-generation-active-e2e"
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-generation-active-e2e"
+                && $0["ok"] as? Bool == false
+                && $0["code"] as? String == "request_cancelled"
+        } != nil)
+
+        try worker.closeInput()
+        try await worker.waitForExit(timeout: .seconds(30))
+    }
+
+    @Test func `playback cancel stops active live playback`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        let worker = try WorkerProcess(
+            profileRootURL: sandbox.profileRootURL,
+            silentPlayback: true,
+            speechBackend: .chatterboxTurbo,
+        )
+        defer { Task { await worker.stop() } }
+
+        try await E2EHarness.awaitWorkerReady(worker)
+        try sandbox.seedProfileFixture(.mascDesign, as: E2EHarness.testingProfileName)
+
+        try worker.sendJSON(
+            """
+            {"id":"req-playback-active-e2e","op":"generate_speech","text":"\(E2EHarness.qwenLongFormPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            """,
+        )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-playback-active-e2e"
+                && $0["event"] as? String == "progress"
+                && $0["stage"] as? String == "buffering_audio"
+        } != nil)
+
+        try worker.sendJSON(
+            """
+            {"id":"req-cancel-playback-e2e","op":"cancel_playback","request_id":"req-playback-active-e2e"}
+            """,
+        )
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-cancel-playback-e2e"
+                && $0["ok"] as? Bool == true
+                && $0["cancelled_request_id"] as? String == "req-playback-active-e2e"
+        } != nil)
+        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["id"] as? String == "req-playback-active-e2e"
+                && $0["ok"] as? Bool == false
+                && $0["code"] as? String == "request_cancelled"
+        } != nil)
+
+        try worker.closeInput()
+        try await worker.waitForExit(timeout: .seconds(30))
+    }
+}
+#endif

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
@@ -479,12 +479,32 @@ import TextForSpeech
 
 @Test func `decodes clear queue request`() throws {
     let request = try WorkerRequest.decode(from: #"{"id":"req-6","op":"clear_queue"}"#)
-    #expect(request == .clearQueue(id: "req-6"))
+    #expect(request == .clearQueue(id: "req-6", queueType: nil))
+}
+
+@Test func `decodes queue scoped clear requests`() throws {
+    let generation = try WorkerRequest.decode(from: #"{"id":"req-clear-generation","op":"clear_generation_queue"}"#)
+    let playback = try WorkerRequest.decode(from: #"{"id":"req-clear-playback","op":"clear_playback_queue"}"#)
+
+    #expect(generation == .clearQueue(id: "req-clear-generation", queueType: .generation))
+    #expect(playback == .clearQueue(id: "req-clear-playback", queueType: .playback))
 }
 
 @Test func `decodes cancel request`() throws {
     let request = try WorkerRequest.decode(from: #"{"id":"req-7","op":"cancel_request","request_id":"req-target"}"#)
-    #expect(request == .cancelRequest(id: "req-7", requestID: "req-target"))
+    #expect(request == .cancelRequest(id: "req-7", requestID: "req-target", queueType: nil))
+}
+
+@Test func `decodes queue scoped cancel requests`() throws {
+    let generation = try WorkerRequest.decode(
+        from: #"{"id":"req-cancel-generation","op":"cancel_generation","request_id":"req-target"}"#,
+    )
+    let playback = try WorkerRequest.decode(
+        from: #"{"id":"req-cancel-playback","op":"cancel_playback","request_id":"req-target"}"#,
+    )
+
+    #expect(generation == .cancelRequest(id: "req-cancel-generation", requestID: "req-target", queueType: .generation))
+    #expect(playback == .cancelRequest(id: "req-cancel-playback", requestID: "req-target", queueType: .playback))
 }
 
 @Test func `rejects malformed JSON`() throws {

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
@@ -656,7 +656,7 @@ import TextForSpeech
         ),
     )
 
-    let clearID = await runtime.player.clearQueue().id
+    let clearID = await runtime.clearQueue(.generation).id
 
     #expect(await waitUntil {
         output.containsJSONObject {
@@ -684,6 +684,90 @@ import TextForSpeech
         $0["id"] as? String == activeCreateID
             && $0["ok"] as? Bool == false
     })
+    await profileGate.open()
+}
+
+@Test func `playback clear does not clear waiting generation work`() async throws {
+    let output = OutputRecorder()
+    let profileGate = AsyncGate()
+
+    let runtime = try await makeRuntime(
+        output: output,
+        playback: PlaybackSpy(),
+        residentModelLoader: { _ in makeResidentModel() },
+        profileModelLoader: {
+            makeProfileModel {
+                await profileGate.wait()
+            }
+        },
+    )
+
+    await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    let activeCreateID = await runtime.voices
+        .create(design: "bright-guide",
+                from: "Hello there",
+                vibe: .femme,
+                voice: "Warm and bright")
+        .id
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == activeCreateID
+                && $0["event"] as? String == "started"
+        }
+    })
+
+    let queuedHandle = await runtime.submit(.listProfiles(id: "req-generation-queued"))
+    var iterator = queuedHandle.events.makeAsyncIterator()
+    let queued = try await iterator.next()
+    #expect(
+        queued == .queued(
+            WorkerQueuedEvent(
+                id: "req-generation-queued",
+                reason: .waitingForActiveRequest,
+                queuePosition: 1,
+            ),
+        ),
+    )
+
+    let playbackClearID = await runtime.clearQueue(.playback).id
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == playbackClearID
+                && $0["ok"] as? Bool == true
+                && $0["cleared_count"] as? Int == 0
+        }
+    })
+
+    let generationClearID = await runtime.clearQueue(.generation).id
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == generationClearID
+                && $0["ok"] as? Bool == true
+                && $0["cleared_count"] as? Int == 1
+        }
+    })
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == "req-generation-queued"
+                && $0["ok"] as? Bool == false
+                && $0["code"] as? String == "request_cancelled"
+        }
+    })
+
+    do {
+        while let _ = try await iterator.next() {}
+        Issue.record("The queued request stream should have thrown after generation clear removed it.")
+    } catch let error as WorkerError {
+        #expect(error.code == .requestCancelled)
+    }
+
     await profileGate.open()
 }
 
@@ -816,7 +900,7 @@ import TextForSpeech
         ),
     )
 
-    let cancelID = await runtime.player.cancelRequest("req-queued").id
+    let cancelID = await runtime.cancel(.generation, requestID: "req-queued").id
 
     #expect(await waitUntil {
         output.containsJSONObject {

--- a/docs/maintainers/queue-persistence-core-data-plan-2026-04-25.md
+++ b/docs/maintainers/queue-persistence-core-data-plan-2026-04-25.md
@@ -1,0 +1,119 @@
+# Queue Persistence Core Data Plan
+
+## Goal
+
+Persist generation and playback queue state so a future runtime can explain, recover, or intentionally discard queued work after a worker restart.
+
+The first persisted version should restore only work that is safe to replay. It should not pretend an interrupted model stream or partially played audio buffer can resume from the exact sample where the previous process stopped.
+
+## Apple API Rule
+
+Apple documents `NSPersistentContainer` as the object that sets up the Core Data model, context, and store coordinator together. Apple also documents `NSManagedObjectContext` as queue-confined: work that touches managed objects belongs on the context queue through `perform`, `performAndWait`, or the async `perform` API.
+
+For SpeakSwiftly, that means queue persistence should be owned by a small persistence component that receives value snapshots from the runtime and writes them through one Core Data context boundary. Runtime queue actors should pass plain `Sendable` values into that component, not managed objects.
+
+## Scope
+
+Persist these queue records:
+
+- generation queued records
+- playback queued records
+- active generation markers
+- active playback markers
+- terminal cancellation or discard reason for records removed during recovery
+
+Do not persist:
+
+- resident model objects
+- live model stream iterators
+- `AVAudioEngine` state
+- queued PCM buffers
+- task handles, continuations, or actor-isolated runtime objects
+
+## Data Model
+
+Use one Core Data store for runtime queue state.
+
+`QueueRecord`
+
+- `requestID: String`
+- `queueType: String`, either `generation` or `playback`
+- `operation: String`
+- `state: String`, such as `queued`, `active`, `completed`, `cancelled`, or `discarded`
+- `position: Int64`
+- `createdAt: Date`
+- `updatedAt: Date`
+- `payloadJSON: Data`
+- `requestContextJSON: Data?`
+- `recoveryPolicy: String`
+- `terminalReason: String?`
+
+`QueueRecoveryEvent`
+
+- `id: UUID`
+- `requestID: String`
+- `queueType: String`
+- `event: String`
+- `reason: String`
+- `createdAt: Date`
+
+## Runtime Write Points
+
+Write or update records at these runtime moments:
+
+- request accepted into the generation queue
+- generation job reserved as active
+- generation job finishes, fails, or is cancelled
+- playback state created for live speech
+- playback state enters the waiting queue
+- playback starts
+- playback finishes, fails, or is cancelled
+- queue-specific clear operations remove waiting work
+- queue-specific cancel operations remove active or waiting work
+
+The persistence call should be best-effort for status updates, but request acceptance should fail loudly if the future configuration declares durable queue persistence mandatory.
+
+## Recovery Policy
+
+On startup, load persisted records before accepting new work.
+
+Handle records this way:
+
+- `generation` + `queued`: restore only if the request payload can be decoded into a current `WorkerRequest`.
+- `generation` + `active`: mark discarded with a clear recovery event; the previous model stream cannot be resumed.
+- `playback` + `queued`: restore only if the dependent generation has already completed and the audio source is a retained artifact.
+- `playback` + `active`: mark discarded; partially played live audio should not restart without explicit operator action.
+
+A future operator command can expose these recovery events so hosts can explain what was restored or discarded after restart.
+
+## Public Surface
+
+Keep the current queue-specific controls as the operator vocabulary:
+
+- `clear_generation_queue`
+- `clear_playback_queue`
+- `cancel_generation`
+- `cancel_playback`
+- `list_generation_queue`
+- `list_playback_queue`
+
+Add persistence inspection later as a separate surface, for example:
+
+- `get_queue_persistence`
+- `list_queue_recovery_events`
+
+Do not overload `list_generation_queue` or `list_playback_queue` with historical recovery events; those should stay snapshots of current runtime work.
+
+## Validation Plan
+
+Add unit coverage with an in-memory Core Data store first:
+
+- enqueue generation, persist, restore queued generation
+- reserve generation as active, restart, mark active generation discarded
+- enqueue playback for retained artifact, persist, restore playback
+- active playback on restart becomes discarded
+- `clear_generation_queue` writes generation cancellation events only
+- `clear_playback_queue` writes playback cancellation events only
+- `cancel_generation` and `cancel_playback` preserve queue-specific terminal reasons
+
+Add one file-backed persistence test after the model shape stabilizes, using a temporary store directory and no real MLX model.

--- a/docs/maintainers/validation-lanes.md
+++ b/docs/maintainers/validation-lanes.md
@@ -194,6 +194,7 @@ xcodebuild test-without-building -quiet \
   -only-testing:'SpeakSwiftlyTests/GeneratedFileE2ETests' \
   -only-testing:'SpeakSwiftlyTests/GeneratedBatchE2ETests' \
   -only-testing:'SpeakSwiftlyTests/ChatterboxE2ETests' \
+  -only-testing:'SpeakSwiftlyTests/QueueControlE2ETests' \
   -only-testing:'SpeakSwiftlyTests/MarvisE2ETests' \
   -only-testing:'SpeakSwiftlyTests/QwenE2ETests'
 ```

--- a/scripts/repo-maintenance/run-e2e-full.sh
+++ b/scripts/repo-maintenance/run-e2e-full.sh
@@ -29,6 +29,7 @@ Runs the default release-safe top-level E2E suite list sequentially:
   GeneratedFileE2ETests
   GeneratedBatchE2ETests
   ChatterboxE2ETests
+  QueueControlE2ETests
   MarvisE2ETests
   QwenE2ETests
 USAGE
@@ -60,6 +61,7 @@ run_suite() {
 run_suite GeneratedFileE2ETests
 run_suite GeneratedBatchE2ETests
 run_suite ChatterboxE2ETests
+run_suite QueueControlE2ETests
 run_suite MarvisE2ETests
 run_suite QwenE2ETests
 

--- a/scripts/repo-maintenance/run-e2e.sh
+++ b/scripts/repo-maintenance/run-e2e.sh
@@ -52,6 +52,7 @@ Suite names:
   chatterbox | ChatterboxE2ETests
   marvis | MarvisE2ETests
   qwen | QwenE2ETests
+  queue-control | QueueControlE2ETests
   qwen-longform | QwenLongFormE2ETests
   trace | TraceCaptureE2ETests
   deep-trace | DeepTraceE2ETests
@@ -83,6 +84,7 @@ resolve_suite_name() {
     chatterbox|ChatterboxE2ETests) printf '%s\n' "ChatterboxE2ETests" ;;
     marvis|MarvisE2ETests) printf '%s\n' "MarvisE2ETests" ;;
     qwen|QwenE2ETests) printf '%s\n' "QwenE2ETests" ;;
+    queue-control|QueueControlE2ETests) printf '%s\n' "QueueControlE2ETests" ;;
     qwen-longform|QwenLongFormE2ETests) printf '%s\n' "QwenLongFormE2ETests" ;;
     trace|TraceCaptureE2ETests) printf '%s\n' "TraceCaptureE2ETests" ;;
     deep-trace|DeepTraceE2ETests) printf '%s\n' "DeepTraceE2ETests" ;;
@@ -98,7 +100,7 @@ suite_name=$(resolve_suite_name "$suite_arg") \
   || die "Unsupported E2E suite '$suite_arg'. Use --help to see the supported top-level suite names."
 
 case "$suite_name" in
-  GeneratedFileE2ETests|GeneratedBatchE2ETests|ChatterboxE2ETests|MarvisE2ETests|QwenE2ETests|QwenLongFormE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests|BackendBenchmarkE2ETests)
+  GeneratedFileE2ETests|GeneratedBatchE2ETests|ChatterboxE2ETests|MarvisE2ETests|QwenE2ETests|QueueControlE2ETests|QwenLongFormE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests|BackendBenchmarkE2ETests)
     ;;
   *)
     die "Refusing to run '$suite_name' because only one top-level E2E suite may run per invocation."


### PR DESCRIPTION
## Summary
- add queue-specific Swift runtime controls for generation and playback queues
- add JSONL operations for clear_generation_queue, clear_playback_queue, cancel_generation, and cancel_playback
- document the Core Data queue-persistence plan and update public worker docs

## Verification
- swift test --filter "WorkerProtocolTests|LibrarySurfaceTests|WorkerRuntimeControlSurfaceTests"
- swift build
- commit hook repo-maintenance validation