### PR TITLE
release: prepare v4.0.9

### DIFF
--- a/.github/workflows/validate-repo-maintenance.yml
+++ b/.github/workflows/validate-repo-maintenance.yml
@@ -1,5 +1,8 @@
 name: Validate Repo Maintenance
 
+# Branch protection should require the Actions check context `validate`.
+# GitHub exposes the job check run by this job name, not by the workflow title.
+
 on:
   pull_request:
   push:
@@ -8,12 +11,11 @@ on:
 
 jobs:
   validate:
+    name: validate
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Install formatting and linting tools
+      - uses: actions/checkout@v4
+      - name: Install Swift repo-maintenance tools
         run: brew install swiftformat swiftlint
-
       - name: Run repo-maintenance validation
         run: bash scripts/repo-maintenance/validate-all.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,30 @@
 # AGENTS.md
 
-## Purpose
+Repo-local guidance for the standalone `SpeakSwiftly` Swift package.
+
+## Repository Scope
+
+### What This File Covers
 
 - This file is the repo-local guidance surface for the standalone `SpeakSwiftly` Swift package.
 - Treat this repository as the source of truth for `SpeakSwiftly` package development, tags, and releases.
 - Treat `../speak-to-user/packages/SpeakSwiftly` as the integration submodule copy, not the primary development home.
 
-## Swift Package Workflow
+### Where To Look First
+
+- Start with `Package.swift`, `Package.resolved`, `README.md`, `CONTRIBUTING.md`, and `ROADMAP.md` for package shape, dependency state, public docs, contributor workflow, and planned work.
+- Read `Sources/SpeakSwiftly/API`, `Sources/SpeakSwiftly/Generation`, `Sources/SpeakSwiftly/Playback`, `Sources/SpeakSwiftly/Normalization`, and `Sources/SpeakSwiftly/Runtime` according to the feature surface being changed.
+- Mirror source-tree context in `Tests/SpeakSwiftlyTests` before adding or moving test coverage.
+- Use `docs/maintainers/validation-lanes.md` and `scripts/repo-maintenance/` for validation, release, runtime publishing, and maintainer operations.
+
+## Working Rules
+
+### Change Scope
 
 - Use Swift Package Manager as the source of truth for package structure and dependencies.
 - Prefer `swift package` subcommands for dependency, target, and manifest-adjacent changes before hand-editing `Package.swift`.
 - Keep package graph updates cohesive across `Package.swift`, `Package.resolved`, and related source or test targets.
-- Run `swift build` and `swift test` as the default validation checks after package-level changes.
 - Use `xcodebuild` only when Apple-platform configuration details, test plans, SDK behavior, or Metal-toolchain behavior matter in a way plain SwiftPM cannot validate well.
-
-## Repository Workflow
-
 - Treat the local `../speak-to-user` checkout as a clean base checkout only. It must stay on `main`, and it must stay clean.
 - Never change the local branch of the base `../speak-to-user` checkout for feature work, experiments, release bumps, or submodule updates.
 - For any monorepo change, create a new branch in a new `git worktree` and do the work there instead of touching the base `../speak-to-user` checkout.
@@ -24,16 +33,13 @@
 - Land monorepo submodule bumps through a pull request against the monorepo instead of pushing those pointer updates directly to monorepo `main`.
 - Use tagged releases for the monorepo when publishing coordinated umbrella states that depend on specific submodule versions.
 
-## Repository Structure
+### Source of Truth
 
 - Keep `Sources/SpeakSwiftly/API` as the single home for public `SpeakSwiftly.Runtime` concern-handle accessors, `SpeakSwiftly.Name`, and other operator-facing library surface declarations.
 - Keep feature logic in its feature directory, not in `Runtime/`. Text-normalization logic belongs in `Normalization/`, generation and voice-profile logic belongs in `Generation/`, and playback logic belongs in `Playback/`.
 - Keep `Sources/SpeakSwiftly/Runtime` for runtime-only internals such as worker request handling, queue orchestration, lifecycle management, event emission, and other machinery that is genuinely part of the worker runtime itself.
 - Do not split one feature across three places when two will do. For any given feature, prefer one API file in `API/` plus one logic file in the relevant feature directory.
 - Mirror the source tree by feature area in tests so API, generation, playback, normalization, runtime, support, and e2e coverage are easy to find.
-
-## Public Surface and Naming
-
 - For the JSONL worker surface, keep operation names snake_case and verb-first.
 - For JSONL reads, use `get_*` for one resource or snapshot and `list_*` for collections and queue snapshots.
 - For JSONL writes, prefer `create_*`, `update_*`, `replace_*`, and `delete_*` when those verbs fit the real semantics.
@@ -48,12 +54,53 @@
 - Use `SpeakSwiftly.Name` as the semantic name type for stored voice-profile names and similar stable operator-facing resources.
 - For the voice-profile library surface, prefer one `Voices.create(...)` verb with explicit overloaded first labels, such as `create(design named: Name, ...)` and `create(clone named: Name, ...)`, instead of multiplying unrelated creation verbs.
 
-## Swift and Architecture Baseline
+### Communication and Escalation
 
 - Read the relevant Apple or Swift documentation first for any Swift, Apple-framework, Apple-platform, SwiftUI, SwiftData, Observation, AppKit, UIKit, Foundation-on-Apple, or Xcode-related task before planning or changing code.
 - Use Dash or local Apple documentation first, then official Apple or Swift web docs when local docs are insufficient.
 - Before proposing an architecture or implementation, state the documented API behavior, lifecycle rule, or workflow requirement being relied on.
 - If documentation and the current code disagree, stop and report the conflict before continuing.
+- Before adding a new layer, abstraction, wrapper, manager, bridge, coordinator, repository, store, helper type, service, dependency, or package, explain which near-term use cases it unlocks here in `SpeakSwiftly`, which real pain or duplication it removes, and which simpler extension path was considered first.
+- Do not change this repository's core architecture casually or silently. If the design starts needing a new queue, subsystem, storage model, or ownership boundary, stop and make that pivot explicit to Gale before implementing it, or as soon as the need becomes clear.
+- When future scope is already visible and the current model will not compose cleanly, prefer strengthening the core primitives on purpose over shipping narrow stopgaps that will soon block momentum.
+
+## Commands
+
+### Setup
+
+```bash
+swift package resolve
+```
+
+### Validation
+
+```bash
+swift build
+swift test
+bash scripts/repo-maintenance/validate-all.sh
+```
+
+### Optional Project Commands
+
+```bash
+sh scripts/repo-maintenance/publish-runtime.sh --configuration Debug
+sh scripts/repo-maintenance/run-e2e.sh --suite quick
+sh scripts/repo-maintenance/run-e2e-full.sh
+SPEAKSWIFTLY_E2E=1 swift test --filter SpeakSwiftlyE2ETests
+```
+
+Use `SPEAKSWIFTLY_PLAYBACK_TRACE=1` for chunk, scheduling, and rebuffer trace events during deep-trace playback work. For audible deep-trace playback verification, use:
+
+```bash
+SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_DEEP_TRACE_E2E=1 SPEAKSWIFTLY_PLAYBACK_TRACE=1 swift test --filter longCodeHeavy
+```
+
+Use `scripts/repo-maintenance/sync-shared.sh` for repo-local shared sync tasks, `scripts/repo-maintenance/release.sh` for releases, and the maintained scripts under `scripts/repo-maintenance/` for publish, verify, vendored-bundle refresh, and repo validation work instead of reconstructing those flows ad hoc.
+
+## Review and Delivery
+
+### Review Expectations
+
 - Prefer the simplest correct Swift that is easiest to read, reason about, and maintain.
 - Treat idiomatic Swift and Cocoa conventions as tools in service of readability, not goals by themselves.
 - Do not add ceremony, abstraction, or boilerplate just to make code look more architectural, more generic, or more "Swifty".
@@ -64,18 +111,12 @@
 - Preserve raw wire and persistence shapes by default; do not add DTO, domain, or view-model conversion layers unless meaning actually changes or a concrete boundary requires it.
 - Keep code compliant with Swift 6 language mode and strict concurrency checking.
 - Prefer modern structured concurrency (`async`/`await`, task groups, actors, `AsyncSequence`) when it keeps the flow clearer and more direct.
-- Before adding a new layer, abstraction, wrapper, manager, bridge, coordinator, repository, store, helper type, service, dependency, or package, explain which near-term use cases it unlocks here in `SpeakSwiftly`, which real pain or duplication it removes, and which simpler extension path was considered first.
-- Do not change this repository's core architecture casually or silently. If the design starts needing a new queue, subsystem, storage model, or ownership boundary, stop and make that pivot explicit to Gale before implementing it, or as soon as the need becomes clear.
-- When future scope is already visible and the current model will not compose cleanly, prefer strengthening the core primitives on purpose over shipping narrow stopgaps that will soon block momentum.
-
-## Dependencies, Logging, and State
-
 - Prefer first-party and top-tier Swift ecosystem packages from Apple, `swiftlang`, the Swift Server Work Group, and similar trusted core Swift projects when they simplify the code and make it easier to reason about.
 - For packages, server-side, or cross-platform Swift, prefer Swift Logging as the primary logging API.
 - Prefer Swift OpenTelemetry for telemetry and instrumentation when telemetry is needed, and prefer existing ecosystem integrations over bespoke wrappers.
 - Prefer Nick Lockwood's SwiftFormat and/or SwiftLint as the baseline Swift formatting and linting tools; at least one should stay configured and used in this repository.
 
-## Validation and Runtime Verification
+### Definition of Done
 
 - Never run multiple build toolchains, package managers, test runners, or other heavy validation commands at the same time on Gale's machine.
 - Never run multiple SwiftPM or Xcode build or test processes concurrently for this repository.
@@ -90,15 +131,23 @@
   - `profile_name`: `testing-profile`
   - `voice_description`: `A generic, warm, masculine, slow speaking voice.`
 - Expect generated `*.profraw` coverage artifacts from local test runs and do not commit them.
-- Treat `SPEAKSWIFTLY_PLAYBACK_TRACE=1` as the preferred way to get chunk, scheduling, and rebuffer trace events during deep-trace playback work.
-- For audible deep-trace playback verification, the standard opt-in path is:
-  - `SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_DEEP_TRACE_E2E=1 SPEAKSWIFTLY_PLAYBACK_TRACE=1 swift test --filter longCodeHeavy`
 
-## Runtime Publishing and Deep-Trace Guidance
+## Safety Boundaries
+
+### Never Do
 
 - For this repository, use an Xcode-built worker product for real MLX-backed command-line runs and real-model e2e coverage. Upstream `mlx-swift` does not make the Metal shader bundle available to the plain SwiftPM command-line build.
 - When launching the real worker from the shell, prefer the deterministic Xcode runtime launcher under `.local/derived-data/runtime-debug/run-speakswiftly` or `.local/derived-data/runtime-release/run-speakswiftly` instead of reconstructing `DYLD_FRAMEWORK_PATH` and `default.metallib` paths by hand.
 - If a real worker run fails with `default.metallib` or `mlx-swift_Cmlx.bundle` errors, treat that as a build-and-launch-path problem first, not as evidence that the worker runtime itself is broken.
 - For direct deep-trace worker captures, prefer the held-open stdin pattern instead of sending one JSONL file and allowing stdin to close immediately.
 - The current known worker behavior is that if stdin closes before queued work drains, the worker can cancel queued requests that are still waiting behind resident-model warmup. Treat that as a current shutdown-and-queue quirk to be fixed, not as normal playback failure.
-- Use the maintained scripts under `scripts/repo-maintenance/` for publish, verify, vendored-bundle refresh, release, and repo validation work instead of reconstructing those flows ad hoc.
+
+### Ask Before
+
+- Ask before widening a package change into a coordinated `speak-to-user` monorepo submodule bump or coordinated umbrella tag.
+- Ask before changing the shared test profile convention, release validation lane, runtime publishing layout, or resident-model queue behavior.
+- Ask before replacing the SwiftPM-first package workflow with an Xcode-first workflow for ordinary package work.
+
+## Local Overrides
+
+This repository does not currently define deeper `AGENTS.md` files. If a future subdirectory adds one, the closer file refines this root guidance for work inside that subtree.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,20 @@ Local text-to-speech for Swift apps and local toolchains, with a typed Swift API
 ## Table of Contents
 
 - [Overview](#overview)
-- [Setup](#setup)
+- [Quick Start](#quick-start)
 - [Usage](#usage)
-- [API Notes](#api-notes)
 - [Development](#development)
-- [Verification](#verification)
+- [Repo Structure](#repo-structure)
+- [Release Notes](#release-notes)
 - [License](#license)
 
 ## Overview
+
+### Status
+
+SpeakSwiftly is actively available as a local Swift text-to-speech package, with macOS-first worker and release validation surfaces.
+
+### What This Project Is
 
 SpeakSwiftly ships two public surfaces from one Swift package:
 
@@ -36,7 +42,7 @@ SpeakSwiftly currently includes:
 
 For contributor-facing architecture notes, repository workflow, runtime behavior details, and extended verification paths, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Setup
+## Quick Start
 
 SpeakSwiftly is a standard Swift package with two direct dependencies:
 
@@ -68,31 +74,6 @@ stages it into the direct MLX probe path inside the SwiftPM test product before
 the first MLX-backed test model is created. In this repository, that means the
 plain `swift test` lane can exercise MLX-backed package tests without falling
 back to Xcode just to find the metallib.
-
-For package-local validation:
-
-```bash
-swift build
-swift test
-```
-
-The current `mlx-audio-swift` `0.79.0` fork release preserves the ordinary
-SwiftPM build and test path. If a future toolchain regression brings back the
-old `EnglishG2P.swift` parser failure, use the documented fallback lane in
-[CONTRIBUTING.md](CONTRIBUTING.md) instead of repeatedly retrying the same plain
-`swift build` / `swift test` commands.
-
-Use the Xcode-backed deterministic runtime only for standalone worker runs or
-for fallback validation when a future SwiftPM parser regression actually blocks
-the ordinary package lane:
-
-```bash
-sh scripts/repo-maintenance/publish-runtime.sh --configuration Debug
-```
-
-That builds the worker into `.local/derived-data/runtime-debug` or
-`.local/derived-data/runtime-release` and writes a matching
-`run-speakswiftly` launcher at that runtime root.
 
 ## Usage
 
@@ -226,7 +207,7 @@ first-window-vs-last-window endpoint metric rather than a whole-run degradation
 score. The detailed contract is maintained in
 [`docs/maintainers/volume-probe-instrument-contract-2026-04-24.md`](docs/maintainers/volume-probe-instrument-contract-2026-04-24.md).
 
-## API Notes
+### API Notes
 
 The package publishes:
 
@@ -293,7 +274,19 @@ For the full JSONL worker contract, request and event examples, naming rules, an
 
 ## Development
 
+### Setup
+
 Use this repository as the source-of-truth development home for SpeakSwiftly. Keep the README focused on product and usage information, and keep contributor-facing architecture notes, repository workflow, and deep operational guidance in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Use the Xcode-backed deterministic runtime only for standalone worker runs or for fallback validation when a future SwiftPM parser regression actually blocks the ordinary package lane:
+
+```bash
+sh scripts/repo-maintenance/publish-runtime.sh --configuration Debug
+```
+
+That builds the worker into `.local/derived-data/runtime-debug` or `.local/derived-data/runtime-release` and writes a matching `run-speakswiftly` launcher at that runtime root.
+
+### Workflow
 
 For package-focused development, prefer:
 
@@ -304,7 +297,9 @@ swift test
 
 For formatter, lint, maintainer workflow, deterministic Xcode runtime guidance, and deeper operator guidance, use [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Verification
+The current `mlx-audio-swift` `0.79.0` fork release preserves the ordinary SwiftPM build and test path. If a future toolchain regression brings back the old `EnglishG2P.swift` parser failure, use the documented fallback lane in [CONTRIBUTING.md](CONTRIBUTING.md) instead of repeatedly retrying the same plain `swift build` / `swift test` commands.
+
+### Validation
 
 Baseline package verification:
 
@@ -324,6 +319,22 @@ If a future toolchain regression blocks the ordinary SwiftPM lane again, or if
 you specifically need the Xcode-backed package, simulator, or real-runtime
 lanes, use [CONTRIBUTING.md](CONTRIBUTING.md) and
 [docs/maintainers/validation-lanes.md](docs/maintainers/validation-lanes.md).
+
+## Repo Structure
+
+```text
+.
+|-- Package.swift
+|-- Sources/SpeakSwiftly/
+|-- Tests/SpeakSwiftlyTests/
+|-- Sources/SpeakSwiftly/SpeakSwiftly.docc/
+|-- docs/maintainers/
+`-- scripts/repo-maintenance/
+```
+
+## Release Notes
+
+Release workflow and release-grade validation are maintained through `scripts/repo-maintenance/release.sh` and the release notes attached to tagged GitHub releases. See [CONTRIBUTING.md](CONTRIBUTING.md) for maintainer workflow details before cutting a release.
 
 ## License
 

--- a/scripts/repo-maintenance/config/profile.env
+++ b/scripts/repo-maintenance/config/profile.env
@@ -1,0 +1,3 @@
+# Managed by maintain-project-repo. Do not hand-edit unless you also control the installer contract.
+REPO_MAINTENANCE_PROFILE="swift-package"
+REPO_MAINTENANCE_PROFILE_DESCRIPTION="Swift Package Manager repo-maintenance profile for library, tool, and package repos."

--- a/scripts/repo-maintenance/config/release.env
+++ b/scripts/repo-maintenance/config/release.env
@@ -1,2 +1,3 @@
 # Repo-maintenance release defaults.
 REPO_MAINTENANCE_DEFAULT_RELEASE_MODE=standard
+REPO_MAINTENANCE_RELEASE_BRANCH=main

--- a/scripts/repo-maintenance/hooks/pre-commit.sample
+++ b/scripts/repo-maintenance/hooks/pre-commit.sample
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+config_file="$repo_root/.swiftformat"
+staged_file_list="$(mktemp "${TMPDIR:-/tmp}/swiftformat-staged.XXXXXX")"
+trap 'rm -f "$staged_file_list"' EXIT HUP INT TERM
+
+if ! command -v swiftformat >/dev/null 2>&1; then
+  echo "SwiftFormat pre-commit hook could not find the \`swiftformat\` CLI on PATH. Install SwiftFormat before committing, or bypass once with --no-verify if you are unblocking an emergency." >&2
+  exit 1
+fi
+
+if [ ! -f "$config_file" ]; then
+  echo "SwiftFormat pre-commit hook expected a checked-in config at $config_file, but it was missing. Restore the managed .swiftformat file or refresh maintain-project-repo before committing." >&2
+  exit 1
+fi
+
+cd "$repo_root"
+git diff --cached --name-only --diff-filter=ACMR -- '*.swift' > "$staged_file_list"
+
+if [ ! -s "$staged_file_list" ]; then
+  exit 0
+fi
+
+echo "Running SwiftFormat on staged Swift sources..."
+swiftformat --config "$config_file" --filelist "$staged_file_list"
+
+while IFS= read -r relative_path; do
+  [ -n "$relative_path" ] || continue
+  git add -- "$relative_path"
+done < "$staged_file_list"
+
+echo "Verifying staged Swift sources with SwiftFormat lint..."
+swiftformat --lint --config "$config_file" --filelist "$staged_file_list"

--- a/scripts/repo-maintenance/install-hooks.sh
+++ b/scripts/repo-maintenance/install-hooks.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
 ensure_git_repo

--- a/scripts/repo-maintenance/lib/common.sh
+++ b/scripts/repo-maintenance/lib/common.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env sh
 set -eu
 
-COMMON_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+COMMON_DIR="${REPO_MAINTENANCE_COMMON_DIR:-}"
 
-if [ -f "$COMMON_DIR/validate-all.sh" ] && [ -f "$COMMON_DIR/release.sh" ]; then
-  REPO_MAINTENANCE_ROOT="$COMMON_DIR"
-else
-  REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_DIR/.." && pwd)
+if [ -z "$COMMON_DIR" ]; then
+  COMMON_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 fi
 
+REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_DIR/.." && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$REPO_MAINTENANCE_ROOT/../.." && pwd)
+REPO_MAINTENANCE_PROFILE="generic"
+REPO_MAINTENANCE_PROFILE_DESCRIPTION="Generic repo-maintenance baseline with no Swift or Xcode specialization."
 
 log() {
   printf '%s\n' "$*"
@@ -33,8 +34,12 @@ load_env_file() {
   set +a
 }
 
+load_profile_env() {
+  load_env_file "$REPO_MAINTENANCE_ROOT/config/profile.env"
+}
+
 ensure_git_repo() {
-  git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "The repo-maintenance toolkit must run inside a git worktree rooted at $REPO_ROOT."
+  git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "maintain-project-repo must run inside a git worktree rooted at $REPO_ROOT."
 }
 
 run_dispatch_dir() {

--- a/scripts/repo-maintenance/publish-runtime.sh
+++ b/scripts/repo-maintenance/publish-runtime.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
 configuration="Debug"

--- a/scripts/repo-maintenance/refresh-e2e-profile-fixtures.sh
+++ b/scripts/repo-maintenance/refresh-e2e-profile-fixtures.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
 load_env_file "$SELF_DIR/config/validation.env"

--- a/scripts/repo-maintenance/release.sh
+++ b/scripts/repo-maintenance/release.sh
@@ -2,14 +2,20 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
+load_profile_env
 load_env_file "$SELF_DIR/config/release.env"
 
 mode="${REPO_MAINTENANCE_DEFAULT_RELEASE_MODE:-standard}"
 release_tag=""
 skip_validate="false"
 skip_gh_release="false"
+skip_version_bump="false"
+base_branch="${REPO_MAINTENANCE_RELEASE_BRANCH:-main}"
+review_comments_addressed="false"
+skip_branch_cleanup="false"
 dry_run="false"
 
 while [ "$#" -gt 0 ]; do
@@ -30,6 +36,22 @@ while [ "$#" -gt 0 ]; do
       skip_gh_release="true"
       shift
       ;;
+    --skip-version-bump)
+      skip_version_bump="true"
+      shift
+      ;;
+    --base-branch)
+      base_branch="${2:-}"
+      shift 2
+      ;;
+    --review-comments-addressed)
+      review_comments_addressed="true"
+      shift
+      ;;
+    --skip-branch-cleanup)
+      skip_branch_cleanup="true"
+      shift
+      ;;
     --dry-run)
       dry_run="true"
       shift
@@ -37,7 +59,8 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
       cat <<'USAGE'
 Usage:
-  release.sh --mode <standard|submodule> --version <vX.Y.Z> [--skip-validate] [--skip-gh-release] [--dry-run]
+  release.sh --mode standard --version <vX.Y.Z> [--base-branch main] [--skip-validate] [--skip-version-bump] [--skip-gh-release] [--review-comments-addressed] [--skip-branch-cleanup] [--dry-run]
+  release.sh --mode submodule --version <vX.Y.Z> [--skip-validate] [--skip-gh-release] [--dry-run]
 USAGE
       exit 0
       ;;
@@ -54,11 +77,286 @@ export RELEASE_TAG="$release_tag"
 export REPO_MAINTENANCE_SKIP_GH_RELEASE="$skip_gh_release"
 export REPO_MAINTENANCE_DRY_RUN="$dry_run"
 
+ensure_clean_worktree() {
+  status_output="$(git -C "$REPO_ROOT" status --porcelain)"
+  [ -z "$status_output" ] || die "Release workflow requires committed changes and a clean worktree before it can continue."
+}
+
+ensure_gh_cli() {
+  command -v gh >/dev/null 2>&1 || die "Standard release mode requires the GitHub CLI gh so it can create the pull request, watch CI, inspect review comments, merge, and publish the release."
+}
+
+ensure_semver_tag() {
+  case "$RELEASE_TAG" in
+    v[0-9]*.[0-9]*.[0-9]*|v[0-9]*.[0-9]*.[0-9]*-*)
+      ;;
+    *)
+      die "Release tag must use vX.Y.Z SemVer syntax."
+      ;;
+  esac
+}
+
+current_branch() {
+  git -C "$REPO_ROOT" symbolic-ref --quiet --short HEAD || true
+}
+
+ensure_branch_release_context() {
+  branch_name="$(current_branch)"
+  [ -n "$branch_name" ] || die "Standard release mode requires a named feature branch or worktree instead of detached HEAD."
+  [ "$branch_name" != "$base_branch" ] || die "Standard release mode must run from a release branch or worktree, not protected $base_branch."
+  printf '%s\n' "$branch_name"
+}
+
+run_version_bump() {
+  release_version="${RELEASE_TAG#v}"
+  version_bump_script="$SELF_DIR/version-bump.sh"
+
+  if [ "$skip_version_bump" = "true" ]; then
+    log "Skipping repo version bump because --skip-version-bump was requested."
+    return 0
+  fi
+
+  [ -x "$version_bump_script" ] || die "Standard release mode expected an executable repo-specific version bump hook at $version_bump_script. Add that hook so the repo's version surfaces move together, or rerun with --skip-version-bump when this release intentionally has no version-bearing files."
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would run $version_bump_script $release_version with RELEASE_TAG=$RELEASE_TAG."
+    return 0
+  fi
+
+  RELEASE_VERSION="$release_version" "$version_bump_script" "$release_version"
+
+  if [ -z "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
+    die "Version bump hook completed without changing files. Update $version_bump_script to edit the repo's version surfaces, or rerun with --skip-version-bump if this release intentionally has no version bump."
+  fi
+
+  git -C "$REPO_ROOT" add -A
+  git -C "$REPO_ROOT" commit -m "release: bump versions for $RELEASE_TAG"
+  log "Committed version bump for $RELEASE_TAG."
+}
+
+create_release_tag() {
+  head_sha="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+  tag_sha="$(git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$RELEASE_TAG" 2>/dev/null || true)"
+
+  if [ -n "$tag_sha" ]; then
+    [ "$tag_sha" = "$head_sha" ] || die "Tag $RELEASE_TAG already exists and does not point at HEAD."
+    log "Tag $RELEASE_TAG already points at HEAD."
+    return 0
+  fi
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would create annotated tag $RELEASE_TAG at HEAD."
+    return 0
+  fi
+
+  git -C "$REPO_ROOT" tag -a "$RELEASE_TAG" -m "Release $RELEASE_TAG"
+  log "Created annotated tag $RELEASE_TAG."
+}
+
+push_branch_and_tag() {
+  branch_name="$1"
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would push branch $branch_name and tag $RELEASE_TAG to origin."
+    return 0
+  fi
+
+  git -C "$REPO_ROOT" push -u origin "$branch_name"
+  git -C "$REPO_ROOT" push origin "$RELEASE_TAG"
+  log "Pushed branch $branch_name and tag $RELEASE_TAG."
+}
+
+create_or_update_pr() {
+  branch_name="$1"
+  PR_NUMBER=""
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would create or update a release PR from $branch_name into $base_branch."
+    PR_NUMBER="DRY-RUN"
+    return 0
+  fi
+
+  body_file="$(mktemp "${TMPDIR:-/tmp}/repo-maintenance-release-pr.XXXXXX")"
+  trap 'rm -f "$body_file"' EXIT INT TERM
+
+  cat >"$body_file" <<EOF
+## Release
+
+- prepares $RELEASE_TAG from branch \`$branch_name\`
+- keeps protected \`$base_branch\` updates behind pull request review and CI
+- release tag \`$RELEASE_TAG\` was created locally before this PR so the reviewed release candidate is preserved exactly
+
+## Review Loop
+
+Before merge, \`scripts/repo-maintenance/release.sh\` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with \`--review-comments-addressed\`.
+EOF
+
+  pr_number="$(gh pr list --head "$branch_name" --base "$base_branch" --json number --jq '.[0].number // empty' --limit 1)"
+  if [ -n "$pr_number" ]; then
+    pr_url="$(gh pr view "$pr_number" --json url --jq '.url')"
+    gh pr edit "$pr_number" --title "release: prepare $RELEASE_TAG" --body-file "$body_file" >/dev/null
+    log "Updated existing release PR #$pr_number at $pr_url."
+  else
+    gh pr create --base "$base_branch" --head "$branch_name" --title "release: prepare $RELEASE_TAG" --body-file "$body_file" >/dev/null
+    pr_number="$(gh pr list --head "$branch_name" --base "$base_branch" --json number --jq '.[0].number // empty' --limit 1)"
+    [ -n "$pr_number" ] || die "GitHub CLI did not return a release PR number after creating the pull request."
+    pr_url="$(gh pr view "$pr_number" --json url --jq '.url')"
+    log "Created release PR #$pr_number at $pr_url."
+    PR_NUMBER="$pr_number"
+    return 0
+  fi
+
+  PR_NUMBER="$pr_number"
+}
+
+watch_ci() {
+  pr_number="$1"
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would watch CI for PR #$pr_number."
+    return 0
+  fi
+
+  log "Watching CI for PR #$pr_number."
+  if ! gh pr checks "$pr_number" --watch; then
+    die "CI is not green for PR #$pr_number. Fix the failing checks, push the branch, and rerun release.sh so it can watch CI again."
+  fi
+  log "CI is green for PR #$pr_number."
+}
+
+check_pr_comments() {
+  pr_number="$1"
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would check PR #$pr_number for comments and requested changes."
+    return 0
+  fi
+
+  review_decision="$(gh pr view "$pr_number" --json reviewDecision --jq '.reviewDecision // ""')"
+  comment_count="$(gh pr view "$pr_number" --json comments,reviews --jq '([.comments[]?, .reviews[]?] | length)')"
+
+  if [ "$review_decision" = "CHANGES_REQUESTED" ]; then
+    gh pr view "$pr_number" --comments
+    die "PR #$pr_number has requested changes. Address valid concerns in code, or add out-of-scope concerns to ROADMAP.md, resolve the threads, push, and rerun release.sh."
+  fi
+
+  if [ "$comment_count" != "0" ] && [ "$review_comments_addressed" != "true" ]; then
+    gh pr view "$pr_number" --comments
+    die "PR #$pr_number has review or discussion comments. Address and resolve valid concerns, add out-of-scope concerns to ROADMAP.md, then rerun release.sh with --review-comments-addressed once the comment pass is intentionally complete."
+  fi
+
+  log "PR #$pr_number has no blocking review state."
+}
+
+merge_pr() {
+  pr_number="$1"
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would merge PR #$pr_number into $base_branch with a merge commit and delete the remote branch."
+    return 0
+  fi
+
+  gh pr merge "$pr_number" --merge --delete-branch
+  log "Merged PR #$pr_number into $base_branch."
+}
+
+fast_forward_base_branch() {
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would fast-forward local $base_branch from origin/$base_branch."
+    return 0
+  fi
+
+  git -C "$REPO_ROOT" fetch origin "$base_branch"
+  if git -C "$REPO_ROOT" switch "$base_branch" 2>/dev/null || git -C "$REPO_ROOT" checkout "$base_branch" 2>/dev/null; then
+    git -C "$REPO_ROOT" pull --ff-only origin "$base_branch"
+    log "Fast-forwarded local $base_branch."
+  else
+    warn "Could not check out local $base_branch, likely because another worktree owns it. Fast-forward $base_branch from origin/$base_branch in that checkout before cleanup."
+  fi
+}
+
+create_github_release() {
+  if [ "$REPO_MAINTENANCE_SKIP_GH_RELEASE" = "true" ]; then
+    log "Skipping GitHub release creation because --skip-gh-release was requested."
+    return 0
+  fi
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would create a GitHub release for $RELEASE_TAG with gh release create --verify-tag."
+    return 0
+  fi
+
+  if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+    log "GitHub release $RELEASE_TAG already exists."
+    return 0
+  fi
+
+  gh release create "$RELEASE_TAG" --verify-tag --generate-notes
+  log "Created GitHub release $RELEASE_TAG."
+}
+
+cleanup_merged_branches() {
+  release_branch_name="$1"
+
+  if [ "$skip_branch_cleanup" = "true" ]; then
+    log "Skipping local merged-branch cleanup because --skip-branch-cleanup was requested."
+    return 0
+  fi
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would prune origin and delete local branches already merged into $base_branch, including $release_branch_name when safe."
+    return 0
+  fi
+
+  git -C "$REPO_ROOT" remote prune origin
+  for merged_branch in $(git -C "$REPO_ROOT" for-each-ref --format='%(refname:short)' --merged "$base_branch" refs/heads); do
+    case "$merged_branch" in
+      "$base_branch")
+        ;;
+      *)
+        git -C "$REPO_ROOT" branch -d "$merged_branch" >/dev/null 2>&1 || warn "Could not delete local merged branch $merged_branch; it may be checked out in another worktree."
+        ;;
+    esac
+  done
+  log "Cleaned up local branches already merged into $base_branch where safe."
+}
+
+run_standard_release() {
+  ensure_git_repo
+  ensure_gh_cli
+  ensure_semver_tag
+  branch_name="$(ensure_branch_release_context)"
+  ensure_clean_worktree
+
+  if [ "$skip_validate" != "true" ]; then
+    sh "$SELF_DIR/validate-all.sh"
+  fi
+
+  run_version_bump
+  ensure_clean_worktree
+  create_release_tag
+  push_branch_and_tag "$branch_name"
+  create_or_update_pr "$branch_name"
+  pr_number="$PR_NUMBER"
+  watch_ci "$pr_number"
+  check_pr_comments "$pr_number"
+  merge_pr "$pr_number"
+  fast_forward_base_branch
+  create_github_release
+  cleanup_merged_branches "$branch_name"
+  log "Standard release flow completed successfully for $RELEASE_TAG."
+}
+
+if [ "$mode" = "standard" ]; then
+  run_standard_release
+  exit 0
+fi
+
 if [ "$skip_validate" != "true" ]; then
   sh "$SELF_DIR/validate-all.sh"
 fi
 
-log "Running repo-maintenance release flow in $REPO_MAINTENANCE_RELEASE_MODE mode for $RELEASE_TAG"
+log "Running repo-maintenance release flow in $REPO_MAINTENANCE_RELEASE_MODE mode for $RELEASE_TAG with the $REPO_MAINTENANCE_PROFILE profile."
 run_dispatch_dir "$SELF_DIR/release" "release"
 
 if [ "$REPO_MAINTENANCE_RELEASE_MODE" = "submodule" ]; then

--- a/scripts/repo-maintenance/release/10-preflight.sh
+++ b/scripts/repo-maintenance/release/10-preflight.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 ensure_git_repo
@@ -25,8 +26,8 @@ esac
 branch_name="$(git -C "$REPO_ROOT" symbolic-ref --quiet --short HEAD || true)"
 [ -n "$branch_name" ] || die "Release workflow requires a named branch instead of detached HEAD."
 
-status_output="$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no)"
-[ -z "$status_output" ] || die "Release workflow requires a clean tracked worktree before tagging."
+status_output="$(git -C "$REPO_ROOT" status --porcelain)"
+[ -z "$status_output" ] || die "Release workflow requires a clean worktree before tagging."
 
 if [ "${REPO_MAINTENANCE_RELEASE_MODE:-}" = "submodule" ]; then
   superproject_root="$(git -C "$REPO_ROOT" rev-parse --show-superproject-working-tree || true)"

--- a/scripts/repo-maintenance/release/15-publish-local-runtimes.sh
+++ b/scripts/repo-maintenance/release/15-publish-local-runtimes.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 if [ "${REPO_MAINTENANCE_DRY_RUN:-false}" = "true" ]; then

--- a/scripts/repo-maintenance/release/20-tag-release.sh
+++ b/scripts/repo-maintenance/release/20-tag-release.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 head_sha="$(git -C "$REPO_ROOT" rev-parse HEAD)"

--- a/scripts/repo-maintenance/release/30-push-release.sh
+++ b/scripts/repo-maintenance/release/30-push-release.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 branch_name="$(git -C "$REPO_ROOT" symbolic-ref --quiet --short HEAD)"

--- a/scripts/repo-maintenance/release/40-github-release.sh
+++ b/scripts/repo-maintenance/release/40-github-release.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 if [ "${REPO_MAINTENANCE_SKIP_GH_RELEASE:-false}" = "true" ]; then

--- a/scripts/repo-maintenance/run-benchmark.sh
+++ b/scripts/repo-maintenance/run-benchmark.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
 load_env_file "$SELF_DIR/config/validation.env"

--- a/scripts/repo-maintenance/run-e2e-full.sh
+++ b/scripts/repo-maintenance/run-e2e-full.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
 load_env_file "$SELF_DIR/config/validation.env"

--- a/scripts/repo-maintenance/run-e2e.sh
+++ b/scripts/repo-maintenance/run-e2e.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
 load_env_file "$SELF_DIR/config/validation.env"

--- a/scripts/repo-maintenance/sync-shared.sh
+++ b/scripts/repo-maintenance/sync-shared.sh
@@ -2,9 +2,11 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
+load_profile_env
 ensure_git_repo
-log "Running repo-maintenance shared sync from $REPO_ROOT"
+log "Running repo-maintenance shared sync from $REPO_ROOT with the $REPO_MAINTENANCE_PROFILE profile."
 run_dispatch_dir "$SELF_DIR/syncing" "sync"
 log "Repo-maintenance shared sync completed successfully."

--- a/scripts/repo-maintenance/syncing/README.md
+++ b/scripts/repo-maintenance/syncing/README.md
@@ -1,5 +1,31 @@
 # Repo-Maintenance Syncing Steps
 
-Add repo-specific `.sh` files here when the repository needs deterministic shared-sync steps.
+Small helper surface for deterministic repo-maintenance sync hooks.
+
+## Overview
+
+This directory holds repo-specific shell hooks that the shared repo-maintenance sync entrypoint can discover and run.
+
+### Motivation
+
+It exists so a repository can keep local sync follow-up steps in one predictable place without forking the shared sync entrypoint itself.
+
+## Setup
+
+Add repo-specific executable `.sh` files here only when the repository needs deterministic shared-sync follow-up steps.
+
+## Usage
 
 The top-level `scripts/repo-maintenance/sync-shared.sh` entrypoint discovers and runs every `*.sh` file in this directory in lexical order.
+
+## Development
+
+Keep each hook small, deterministic, and specific to the owning repository's guidance or packaging sync needs.
+
+## Verification
+
+Run the owning repository's shared sync entrypoint and confirm the expected repo-specific hooks execute in lexical order.
+
+## License
+
+Covered by the parent repository license.

--- a/scripts/repo-maintenance/update-vendored-mlx-bundle.sh
+++ b/scripts/repo-maintenance/update-vendored-mlx-bundle.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
 source_bundle_path="$REPO_ROOT/.local/derived-data/runtime-release/Build/Products/Release/mlx-swift_Cmlx.bundle"

--- a/scripts/repo-maintenance/validate-all.sh
+++ b/scripts/repo-maintenance/validate-all.sh
@@ -2,10 +2,12 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
+load_profile_env
 load_env_file "$SELF_DIR/config/validation.env"
 ensure_git_repo
-log "Running repo-maintenance validation from $REPO_ROOT"
+log "Running repo-maintenance validation from $REPO_ROOT with the $REPO_MAINTENANCE_PROFILE profile."
 run_dispatch_dir "$SELF_DIR/validations" "validation"
 log "Repo-maintenance validation completed successfully."

--- a/scripts/repo-maintenance/validations/10-toolkit-layout.sh
+++ b/scripts/repo-maintenance/validations/10-toolkit-layout.sh
@@ -2,13 +2,15 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 for required in \
   "$REPO_MAINTENANCE_ROOT/validate-all.sh" \
   "$REPO_MAINTENANCE_ROOT/sync-shared.sh" \
   "$REPO_MAINTENANCE_ROOT/release.sh" \
-  "$REPO_MAINTENANCE_ROOT/lib/common.sh"
+  "$REPO_MAINTENANCE_ROOT/lib/common.sh" \
+  "$REPO_MAINTENANCE_ROOT/config/profile.env"
 do
-  [ -f "$required" ] || die "The repo-maintenance toolkit is missing the required file $required."
+  [ -f "$required" ] || die "maintain-project-repo is missing the required file $required."
 done

--- a/scripts/repo-maintenance/validations/20-agents-guidance.sh
+++ b/scripts/repo-maintenance/validations/20-agents-guidance.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 if [ "${REPO_MAINTENANCE_REQUIRE_AGENTS:-true}" != "true" ]; then
@@ -10,5 +11,13 @@ if [ "${REPO_MAINTENANCE_REQUIRE_AGENTS:-true}" != "true" ]; then
 fi
 
 agents_path="$REPO_ROOT/AGENTS.md"
-[ -f "$agents_path" ] || die "Expected $agents_path to exist so the repo-maintenance toolkit has repo guidance to complement."
+[ -f "$agents_path" ] || die "Expected $agents_path to exist so maintain-project-repo has repo guidance to complement."
 [ -s "$agents_path" ] || die "Expected $agents_path to be non-empty."
+
+for needle in \
+  "scripts/repo-maintenance/validate-all.sh" \
+  "scripts/repo-maintenance/sync-shared.sh" \
+  "scripts/repo-maintenance/release.sh"
+do
+  grep -F "$needle" "$agents_path" >/dev/null 2>&1 || die "Expected $agents_path to mention $needle so the maintainer validation, sync, and release entrypoints stay discoverable."
+done

--- a/scripts/repo-maintenance/validations/30-ci-wrapper.sh
+++ b/scripts/repo-maintenance/validations/30-ci-wrapper.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 workflow_path="$REPO_ROOT/.github/workflows/validate-repo-maintenance.yml"

--- a/scripts/repo-maintenance/validations/40-swift-format.sh
+++ b/scripts/repo-maintenance/validations/40-swift-format.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 command -v swiftformat >/dev/null 2>&1 || die "SwiftFormat is required for repository validation. Install it before running scripts/repo-maintenance/validate-all.sh."

--- a/scripts/repo-maintenance/validations/45-mlx-test-resources.sh
+++ b/scripts/repo-maintenance/validations/45-mlx-test-resources.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 vendored_metallib_path="$REPO_ROOT/Sources/SpeakSwiftly/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"

--- a/scripts/repo-maintenance/validations/50-swift-lint.sh
+++ b/scripts/repo-maintenance/validations/50-swift-lint.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 . "$SELF_DIR/../lib/common.sh"
 
 command -v swiftlint >/dev/null 2>&1 || die "SwiftLint is required for repository validation. Install it before running scripts/repo-maintenance/validate-all.sh."

--- a/scripts/repo-maintenance/verify-runtime.sh
+++ b/scripts/repo-maintenance/verify-runtime.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 . "$SELF_DIR/lib/common.sh"
 
 configuration=""


### PR DESCRIPTION
## Release

- prepares v4.0.9 from branch `docs/guidance-repo-maintenance-sync`
- keeps protected `main` updates behind pull request review and CI
- release tag `v4.0.9` was created locally before this PR so the reviewed release candidate is preserved exactly

## Review Loop

Before merge, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
