### PR TITLE
normalize: adopt TextForSpeech 0.18.9

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,7 @@ Current resident-status stages:
 ## JSONL Reference
 
 For generation requests, the worker now documents `voice_profile`, `text_profile`, `input_text_context`, and `request_context` as the current wire keys. Older generation-request aliases such as `profile_name` and `text_profile_id` are still accepted for compatibility, but new callers should prefer the newer names.
+`input_text_context.context` maps to `TextForSpeech.InputContext`, while `request_context` maps to `TextForSpeech.RequestContext`. Text-profile read payloads continue to encode the stable profile identifier as `profile_id` for JSONL compatibility even though the underlying `TextForSpeech.Runtime.Profiles.Details` model now names that field `id`.
 
 Representative request shapes:
 
@@ -327,6 +328,7 @@ When JSONL naming changes, update this file and `README.md` in the same pass so 
 Current live-playback behavior:
 
 - `generate_speech` loads the stored profile first, then routes resident generation through the active backend. `qwen3` uses stored profile reference audio and transcript, prepares missing per-model conditioning lazily when `.preparedConditioning` is active, and keeps Qwen live playback single-pass by default. A request can opt into SpeakSwiftly's pre-model Qwen text chunking with `qwen_pre_model_text_chunking: true`, which bounds long live requests by paragraph-group chunks before each model call. `chatterbox_turbo` uses stored profile reference audio with the resident model's built-in default conditioning as the no-clone fallback and now segments normalized text into speakable chunks for sequential live synthesis, and `marvis` uses stored profile vibe to select the already-warm built-in preset voice.
+- All live-speech and retained-file text normalization goes through `SpeakSwiftly.Normalizer.speechText(...)`, which delegates to the static async `TextForSpeech.Normalize` entry points with the selected stored or active custom profile, the active built-in style, source-format context, and the runtime summarization provider. Keep future generation call sites on this shared path instead of rebuilding TextForSpeech profile/style inputs locally.
 - The built-in text style is a separate persisted runtime setting from the active custom text profile. JSONL callers can inspect it with `get_active_text_profile_style`, inspect the available choices with `list_text_profile_styles`, and update it with `set_active_text_profile_style`.
 - Live playback stays a single-speaker path on one worker. When one audible live request is already playing, later live requests can still be accepted and queued immediately, but their generation waits until the active live playback drains before the next live request starts.
 - `generate_audio_file` follows that same backend-routing path, then saves the completed WAV under the generated-file store instead of scheduling playback. The Qwen pre-model text chunking flag applies only to live playback; generated audio files stay on the single-pass Qwen rendering path.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "35bb6c7d63f49ae89379f2e082610b2e87e1404313afdc264a4bec8c26c3f569",
+  "originHash" : "98ec5de0d1bb492b58ff4fef53fa3f63b8bc708d2493581ad50db5a69e1e9618",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "ef6afaf4fd07deede82d534fbfcc588f9d6258b0",
-        "version" : "0.18.6"
+        "revision" : "2f3c8c095eaef151cc28f5f977f4e4daae28c474",
+        "version" : "0.18.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/gaelic-ghost/TextForSpeech.git",
-            .upToNextMajor(from: "0.18.6"),
+            .upToNextMajor(from: "0.18.9"),
         ),
         .package(
             url: "https://github.com/gaelic-ghost/mlx-audio-swift.git",

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ let requestHandle = await runtime.generate.audio(
 ```
 
 The typed Swift surface uses `voiceProfile`, `textProfile`, `inputTextContext`, and `requestContext`.
-`SpeakSwiftly.RequestContext` is the shared `TextForSpeech.RequestContext` model, so the same request-origin metadata shape can move unchanged between normalization, generation, and downstream packages that import `SpeakSwiftly`.
+`SpeakSwiftly.InputTextContext.context` is the shared `TextForSpeech.InputContext` model, and `SpeakSwiftly.RequestContext` is the shared `TextForSpeech.RequestContext` model, so the same text-shaping and request-origin metadata shapes can move unchanged between normalization, generation, and downstream packages that import `SpeakSwiftly`.
 The JSONL worker now uses those same generation concepts with snake_case keys such as `voice_profile`, `text_profile`, `input_text_context`, and `request_context`. Older generation-request aliases like `profile_name` and `text_profile_id` are still accepted for compatibility.
 
 The runtime is organized around stored concern handles that callers can keep and reuse:
@@ -132,6 +132,8 @@ The runtime is organized around stored concern handles that callers can keep and
 - `runtime.artifacts`
 
 `runtime.normalizer.profiles` includes replacement-rule inspection and bulk-clear helpers, so hosts can inspect or reset the active or stored text-profile rules without dropping down to raw JSONL.
+
+Generation now routes all speech text through `runtime.normalizer.speechText(...)`, which delegates to the shared `TextForSpeech.Normalize` entry points. That keeps live playback, retained file generation, source-format normalization, custom text-profile selection, built-in style selection, and TextForSpeech summarization-provider selection on one package-owned path instead of reconstructing normalization inputs at each generation call site.
 
 When callers need a standalone text normalizer, `SpeakSwiftly.Normalizer(...)` throws if the persisted text-profile archive cannot be loaded or decoded. The worker runtime still uses a best-effort recovery path so `SpeakSwiftly.liftoff()` can continue starting in operator-facing environments.
 

--- a/Sources/SpeakSwiftly/API/Playback.swift
+++ b/Sources/SpeakSwiftly/API/Playback.swift
@@ -53,7 +53,7 @@ public extension SpeakSwiftly.Player {
 
     /// Cancels one queued or active request by identifier.
     func cancelRequest(_ requestID: String) async -> SpeakSwiftly.RequestHandle {
-        await runtime.cancel(.playback, requestID: requestID)
+        await runtime.submit(.cancelRequest(id: UUID().uuidString, requestID: requestID, queueType: nil))
     }
 
     /// Cancels one queued or active request in one runtime queue.

--- a/Sources/SpeakSwiftly/API/TextNormalization.swift
+++ b/Sources/SpeakSwiftly/API/TextNormalization.swift
@@ -46,7 +46,7 @@ public extension SpeakSwiftly {
         public var id: String { profileID }
 
         init(_ details: TextForSpeech.Runtime.Profiles.Details) {
-            profileID = details.profileID
+            profileID = details.id
             summary = TextProfileSummary(details.summary)
             replacements = details.replacements
         }

--- a/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
+++ b/Sources/SpeakSwiftly/Generation/FileGenerationOperations.swift
@@ -26,39 +26,12 @@ extension SpeakSwiftly.Runtime {
 
         let textContext = inputTextContext?.context
         let sourceFormat = inputTextContext?.sourceFormat
-        let textProfileStyle = await normalizerRef.style.getActive()
-        let normalizationProfile: TextForSpeech.Profile
-        if let textProfile,
-           let details = try? await normalizerRef.profiles.get(id: textProfile) {
-            normalizationProfile = TextForSpeech.Profile(
-                id: details.profileID,
-                name: details.summary.name,
-                replacements: details.replacements,
-            )
-        } else {
-            let details = await normalizerRef.profiles.getActive()
-            normalizationProfile = TextForSpeech.Profile(
-                id: details.profileID,
-                name: details.summary.name,
-                replacements: details.replacements,
-            )
-        }
-        let normalizedText = if let sourceFormat {
-            TextForSpeech.Normalize.source(
-                text,
-                as: sourceFormat,
-                context: textContext,
-                customProfile: normalizationProfile,
-                style: textProfileStyle,
-            )
-        } else {
-            TextForSpeech.Normalize.text(
-                text,
-                context: textContext,
-                customProfile: normalizationProfile,
-                style: textProfileStyle,
-            )
-        }
+        let normalizedText = try await normalizerRef.speechText(
+            text,
+            sourceFormat: sourceFormat,
+            context: textContext,
+            textProfileID: textProfile,
+        )
 
         await emitProgress(id: id, stage: .generatingFileAudio)
         let generationStartedAt = dependencies.now()

--- a/Sources/SpeakSwiftly/Generation/SpeechGenerationController.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechGenerationController.swift
@@ -3,6 +3,11 @@ import Foundation
 // MARK: - Generation Queue
 
 actor SpeechGenerationController {
+    enum QueueReadiness: Equatable {
+        case preparing
+        case ready
+    }
+
     struct Job: Equatable {
         let token: UUID
         let request: WorkerRequest
@@ -20,10 +25,21 @@ actor SpeechGenerationController {
 
     private var queue = [Job]()
     private var activeJobs = [UUID: Job]()
+    private var preparingTokens = Set<UUID>()
 
-    func enqueue(_ request: WorkerRequest) -> Job {
+    func enqueue(_ request: WorkerRequest, readiness: QueueReadiness = .ready) -> Job {
         let job = Job(request: request)
         queue.append(job)
+        if readiness == .preparing {
+            preparingTokens.insert(job.token)
+        }
+        return job
+    }
+
+    func markReady(token: UUID) -> Job? {
+        guard let job = queue.first(where: { $0.token == token }) else { return nil }
+
+        preparingTokens.remove(token)
         return job
     }
 
@@ -31,6 +47,7 @@ actor SpeechGenerationController {
         let tokenSet = Set(tokens)
         let reserved = queue.filter { tokenSet.contains($0.token) }
         queue.removeAll { tokenSet.contains($0.token) }
+        preparingTokens.subtract(tokenSet)
         for job in reserved {
             activeJobs[job.token] = job
         }
@@ -50,7 +67,9 @@ actor SpeechGenerationController {
         }
 
         if let index = queue.firstIndex(where: { $0.request.id == requestID }) {
-            return .queued(queue.remove(at: index))
+            let job = queue.remove(at: index)
+            preparingTokens.remove(job.token)
+            return .queued(job)
         }
 
         return nil
@@ -59,11 +78,16 @@ actor SpeechGenerationController {
     func clearQueued() -> [Job] {
         let queued = queue
         queue.removeAll()
+        preparingTokens.removeAll()
         return queued
     }
 
     func activeJobsOrdered() -> [Job] {
         activeJobs.values.sorted { $0.request.id < $1.request.id }
+    }
+
+    func readyQueuedJobsOrdered() -> [Job] {
+        orderedWaitingQueue(in: queue.filter { !preparingTokens.contains($0.token) })
     }
 
     func queuedJobsOrdered() -> [Job] {

--- a/Sources/SpeakSwiftly/Generation/SpeechGenerationController.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechGenerationController.swift
@@ -43,6 +43,14 @@ actor SpeechGenerationController {
         return job
     }
 
+    func isPreparing(token: UUID) -> Bool {
+        preparingTokens.contains(token)
+    }
+
+    func preparingJobTokens() -> Set<UUID> {
+        preparingTokens
+    }
+
     func reserveQueuedJobs(tokens: [UUID]) -> [Job] {
         let tokenSet = Set(tokens)
         let reserved = queue.filter { tokenSet.contains($0.token) }

--- a/Sources/SpeakSwiftly/Normalization/TextNormalizer.swift
+++ b/Sources/SpeakSwiftly/Normalization/TextNormalizer.swift
@@ -6,7 +6,7 @@ import TextForSpeech
 private extension SpeakSwiftly.Normalizer {
     func profile(from details: TextForSpeech.Runtime.Profiles.Details) -> TextForSpeech.Profile {
         TextForSpeech.Profile(
-            id: details.profileID,
+            id: details.id,
             name: details.summary.name,
             replacements: details.replacements,
         )
@@ -34,10 +34,6 @@ private extension SpeakSwiftly.Normalizer {
 
     func storedTextProfile(id: String) throws -> TextForSpeech.Profile {
         try profile(from: textProfileDetails(id: id))
-    }
-
-    func effectiveTextProfile() -> TextForSpeech.Profile {
-        profile(from: effectiveTextProfileDetails())
     }
 
     func activeTextProfileStyle() -> TextForSpeech.BuiltInProfileStyle {
@@ -126,6 +122,41 @@ private extension SpeakSwiftly.Normalizer {
         fromProfile profileID: String,
     ) throws -> TextForSpeech.Runtime.Profiles.Details {
         try textRuntime.profiles.removeReplacement(id: replacementID, fromProfile: profileID)
+    }
+
+    func normalizeSpeechText(
+        _ text: String,
+        sourceFormat: TextForSpeech.SourceFormat?,
+        context: TextForSpeech.InputContext?,
+        textProfileID: SpeakSwiftly.TextProfileID?,
+    ) async throws -> String {
+        let textProfile = if let textProfileID,
+                             let storedProfile = try? storedTextProfile(id: textProfileID) {
+            storedProfile
+        } else {
+            activeTextProfile()
+        }
+        let style = textRuntime.builtInStyle
+        let summarizationProvider = textRuntime.activeSummarizationProvider
+
+        if let sourceFormat {
+            return try await TextForSpeech.Normalize.source(
+                text,
+                as: sourceFormat,
+                withContext: context,
+                customProfile: textProfile,
+                style: style,
+                summarizationProvider: summarizationProvider,
+            )
+        }
+
+        return try await TextForSpeech.Normalize.text(
+            text,
+            withContext: context,
+            customProfile: textProfile,
+            style: style,
+            summarizationProvider: summarizationProvider,
+        )
     }
 }
 
@@ -263,5 +294,22 @@ public extension SpeakSwiftly.Normalizer.Profiles {
         fromProfile profileID: String,
     ) async throws -> TextForSpeech.Runtime.Profiles.Details {
         try await normalizer.removeTextReplacement(id: replacementID, fromProfile: profileID)
+    }
+}
+
+public extension SpeakSwiftly.Normalizer {
+    /// Normalizes generation text through the shared TextForSpeech runtime.
+    func speechText(
+        _ text: String,
+        sourceFormat: TextForSpeech.SourceFormat? = nil,
+        context: TextForSpeech.InputContext? = nil,
+        textProfileID: SpeakSwiftly.TextProfileID? = nil,
+    ) async throws -> String {
+        try await normalizeSpeechText(
+            text,
+            sourceFormat: sourceFormat,
+            context: context,
+            textProfileID: textProfileID,
+        )
     }
 }

--- a/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
@@ -88,6 +88,7 @@ extension SpeakSwiftly.Runtime {
             }
             playbackState.execution.continuation.finish(throwing: cancellation)
             await completePlaybackJob(playbackState.request, result: .failure(cancellation))
+            try? await startNextGenerationIfPossible()
             await playbackController.startNextIfPossible()
             return targetRequestID
         }

--- a/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackOperations.swift
@@ -82,6 +82,10 @@ extension SpeakSwiftly.Runtime {
 
         if queueType == nil || queueType == .playback,
            let playbackState = await playbackController.cancel(requestID: targetRequestID, cancelGenerationTask: false) {
+            let cancelledGenerationTarget = await generationController.cancel(requestID: targetRequestID, removeActive: false)
+            if case let .active(job) = cancelledGenerationTarget {
+                activeGenerationCancellations[job.request.id] = cancellation
+            }
             playbackState.execution.continuation.finish(throwing: cancellation)
             await completePlaybackJob(playbackState.request, result: .failure(cancellation))
             await playbackController.startNextIfPossible()

--- a/Sources/SpeakSwiftly/Runtime/LiveSpeechRequestState.swift
+++ b/Sources/SpeakSwiftly/Runtime/LiveSpeechRequestState.swift
@@ -6,7 +6,7 @@ final class LiveSpeechRequestState: @unchecked Sendable {
     let text: String
     let profileName: String
     let textProfileID: String?
-    let textContext: TextForSpeech.Context?
+    let textContext: TextForSpeech.InputContext?
     let sourceFormat: TextForSpeech.SourceFormat?
     let requestContext: SpeakSwiftly.RequestContext?
     let normalizedText: String

--- a/Sources/SpeakSwiftly/Runtime/WorkerProtocol+RawRequests.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerProtocol+RawRequests.swift
@@ -386,7 +386,7 @@ struct RawWorkerRequest: Decodable {
                 message: "Request '\(id)' cannot combine the whole-source lane (`source_format`) with mixed-text lane fields (`text_format` or `nested_source_format`).",
             )
         }
-        let textContext = TextForSpeech.Context(
+        let textContext = TextForSpeech.InputContext(
             cwd: cwd,
             repoRoot: repoRoot,
             textFormat: textFormat,
@@ -508,7 +508,7 @@ private extension String {
     }
 }
 
-private extension TextForSpeech.Context {
+private extension TextForSpeech.InputContext {
     var isEmpty: Bool {
         cwd == nil && repoRoot == nil && textFormat == nil && nestedSourceFormat == nil
     }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeLifecycle.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeLifecycle.swift
@@ -252,6 +252,29 @@ extension SpeakSwiftly.Runtime {
             await emitFailure(id: request.id, error: workerError)
             return
         }
+        let speechJob: LiveSpeechRequestState?
+        if request.requiresPlayback {
+            do {
+                speechJob = try await makeSpeechJobState(for: request)
+            } catch let workerError as WorkerError {
+                failRequestStream(for: request.id, error: workerError)
+                await emitFailure(id: request.id, error: workerError)
+                return
+            } catch {
+                let workerError = WorkerError(
+                    code: .modelGenerationFailed,
+                    message: "Request '\(request.id)' could not normalize text before queueing live playback. \(error.localizedDescription)",
+                )
+                failRequestStream(for: request.id, error: workerError)
+                await emitFailure(id: request.id, error: workerError)
+                return
+            }
+            if let speechJob {
+                await playbackController.enqueue(speechJob)
+            }
+        } else {
+            speechJob = nil
+        }
         let job = await generationController.enqueue(request)
         await logRequestEvent(
             "request_accepted",
@@ -260,10 +283,6 @@ extension SpeakSwiftly.Runtime {
             profileName: request.voiceProfile,
             queueDepth: generationQueueDepth(),
         )
-        if request.requiresPlayback {
-            let speechJob = await makeSpeechJobState(for: request)
-            await playbackController.enqueue(speechJob)
-        }
         if let queuedEvent = await makeQueuedEvent(for: job) {
             await emit(queuedEvent)
             yieldRequestEvent(.queued(queuedEvent), for: request.id)

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeLifecycle.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeLifecycle.swift
@@ -252,30 +252,10 @@ extension SpeakSwiftly.Runtime {
             await emitFailure(id: request.id, error: workerError)
             return
         }
-        let speechJob: LiveSpeechRequestState?
-        if request.requiresPlayback {
-            do {
-                speechJob = try await makeSpeechJobState(for: request)
-            } catch let workerError as WorkerError {
-                failRequestStream(for: request.id, error: workerError)
-                await emitFailure(id: request.id, error: workerError)
-                return
-            } catch {
-                let workerError = WorkerError(
-                    code: .modelGenerationFailed,
-                    message: "Request '\(request.id)' could not normalize text before queueing live playback. \(error.localizedDescription)",
-                )
-                failRequestStream(for: request.id, error: workerError)
-                await emitFailure(id: request.id, error: workerError)
-                return
-            }
-            if let speechJob {
-                await playbackController.enqueue(speechJob)
-            }
-        } else {
-            speechJob = nil
-        }
-        let job = await generationController.enqueue(request)
+        let job = await generationController.enqueue(
+            request,
+            readiness: request.requiresPlayback ? .preparing : .ready,
+        )
         await logRequestEvent(
             "request_accepted",
             requestID: request.id,
@@ -313,6 +293,33 @@ extension SpeakSwiftly.Runtime {
                 queueDepth: generationQueueDepth(),
             )
             await emit(acknowledgement)
+        }
+        if request.requiresPlayback {
+            let speechJob: LiveSpeechRequestState
+            do {
+                speechJob = try await makeSpeechJobState(for: request)
+            } catch let workerError as WorkerError {
+                guard await generationController.cancel(requestID: request.id) != nil else { return }
+
+                failRequestStream(for: request.id, error: workerError)
+                await emitFailure(id: request.id, error: workerError)
+                return
+            } catch {
+                let workerError = WorkerError(
+                    code: .modelGenerationFailed,
+                    message: "Request '\(request.id)' could not normalize text before queueing live playback. \(error.localizedDescription)",
+                )
+                guard await generationController.cancel(requestID: request.id) != nil else { return }
+
+                failRequestStream(for: request.id, error: workerError)
+                await emitFailure(id: request.id, error: workerError)
+                return
+            }
+            await playbackController.enqueue(speechJob)
+            guard await generationController.markReady(token: job.token) != nil else {
+                _ = await playbackController.discard(requestID: request.id)
+                return
+            }
         }
         try? await startNextGenerationIfPossible()
         await playbackController.startNextIfPossible()

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeProcessing+GenerationSupport.swift
@@ -7,26 +7,15 @@ extension SpeakSwiftly.Runtime {
     private func normalizeSpeechText(
         _ text: String,
         sourceFormat: TextForSpeech.SourceFormat?,
-        textContext: TextForSpeech.Context?,
-        textProfile: TextForSpeech.Profile,
-        textProfileStyle: TextForSpeech.BuiltInProfileStyle,
-    ) -> String {
-        if let sourceFormat {
-            TextForSpeech.Normalize.source(
-                text,
-                as: sourceFormat,
-                context: textContext,
-                customProfile: textProfile,
-                style: textProfileStyle,
-            )
-        } else {
-            TextForSpeech.Normalize.text(
-                text,
-                context: textContext,
-                customProfile: textProfile,
-                style: textProfileStyle,
-            )
-        }
+        textContext: TextForSpeech.InputContext?,
+        textProfileID: SpeakSwiftly.TextProfileID?,
+    ) async throws -> String {
+        try await normalizerRef.speechText(
+            text,
+            sourceFormat: sourceFormat,
+            context: textContext,
+            textProfileID: textProfileID,
+        )
     }
 
     func loadGeneratedBatch(id batchID: String) throws -> SpeakSwiftly.GeneratedBatch {
@@ -191,7 +180,7 @@ extension SpeakSwiftly.Runtime {
         }
     }
 
-    func makeSpeechJobState(for request: WorkerRequest) async -> LiveSpeechRequestState {
+    func makeSpeechJobState(for request: WorkerRequest) async throws -> LiveSpeechRequestState {
         let text = switch request {
             case .queueSpeech(id: _, text: let text, profileName: _, textProfileID: _, jobType: _, inputTextContext: _, requestContext: _, qwenPreModelTextChunking: _):
                 text
@@ -202,29 +191,11 @@ extension SpeakSwiftly.Runtime {
         let inputTextContext = request.inputTextContext
         let textContext = inputTextContext?.context
         let sourceFormat = inputTextContext?.sourceFormat
-        let textProfileStyle = await normalizerRef.style.getActive()
-        let textProfile: TextForSpeech.Profile
-        if let textProfileID,
-           let details = try? await normalizerRef.profiles.get(id: textProfileID) {
-            textProfile = TextForSpeech.Profile(
-                id: details.profileID,
-                name: details.summary.name,
-                replacements: details.replacements,
-            )
-        } else {
-            let details = await normalizerRef.profiles.getActive()
-            textProfile = TextForSpeech.Profile(
-                id: details.profileID,
-                name: details.summary.name,
-                replacements: details.replacements,
-            )
-        }
-        let normalizedText = normalizeSpeechText(
+        let normalizedText = try await normalizeSpeechText(
             text,
             sourceFormat: sourceFormat,
             textContext: textContext,
-            textProfile: textProfile,
-            textProfileStyle: textProfileStyle,
+            textProfileID: textProfileID,
         )
         let normalizedLiveChunks: [LiveSpeechTextChunk]?
         if speechBackend == .qwen3, request.qwenPreModelTextChunking == true {
@@ -232,23 +203,24 @@ extension SpeakSwiftly.Runtime {
                 for: text,
                 strategy: .smartParagraphGroups(),
             )
-            let normalizedChunks = plannedChunks.compactMap { plannedChunk -> LiveSpeechTextChunk? in
-                let normalizedChunkText = normalizeSpeechText(
+            var normalizedChunks = [LiveSpeechTextChunk]()
+            normalizedChunks.reserveCapacity(plannedChunks.count)
+            for plannedChunk in plannedChunks {
+                let normalizedChunkText = try await normalizeSpeechText(
                     plannedChunk.text,
                     sourceFormat: sourceFormat,
                     textContext: textContext,
-                    textProfile: textProfile,
-                    textProfileStyle: textProfileStyle,
+                    textProfileID: textProfileID,
                 ).trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
 
-                guard !normalizedChunkText.isEmpty else { return nil }
+                guard !normalizedChunkText.isEmpty else { continue }
 
-                return LiveSpeechTextChunk(
+                normalizedChunks.append(LiveSpeechTextChunk(
                     index: plannedChunk.index,
                     text: normalizedChunkText,
                     wordCount: max(SpeakSwiftly.DeepTrace.words(in: normalizedChunkText).count, 1),
                     segmentation: plannedChunk.segmentation,
-                )
+                ))
             }
 
             normalizedLiveChunks = normalizedChunks.isEmpty ? nil : normalizedChunks

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift
@@ -9,7 +9,7 @@ extension SpeakSwiftly.Runtime {
         guard !isShuttingDown else { return }
 
         let activeJobs = await generationController.activeJobsOrdered()
-        let queuedJobs = await generationController.queuedJobsOrdered()
+        let queuedJobs = await generationController.readyQueuedJobsOrdered()
         let playbackAdmission = await playbackController.generationAdmissionSnapshot()
         let playbackTelemetry = await playbackController.coordinationTelemetrySnapshot()
         let decision = try evaluateGenerationSchedule(

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeScheduling.swift
@@ -9,12 +9,14 @@ extension SpeakSwiftly.Runtime {
         guard !isShuttingDown else { return }
 
         let activeJobs = await generationController.activeJobsOrdered()
-        let queuedJobs = await generationController.readyQueuedJobsOrdered()
+        let queuedJobs = await generationController.queuedJobsOrdered()
+        let preparingJobTokens = await generationController.preparingJobTokens()
         let playbackAdmission = await playbackController.generationAdmissionSnapshot()
         let playbackTelemetry = await playbackController.coordinationTelemetrySnapshot()
         let decision = try evaluateGenerationSchedule(
             activeJobs: activeJobs,
             queuedJobs: queuedJobs,
+            preparingJobTokens: preparingJobTokens,
             playbackAdmission: playbackAdmission,
         )
 
@@ -72,6 +74,7 @@ extension SpeakSwiftly.Runtime {
     func evaluateGenerationSchedule(
         activeJobs: [SpeechGenerationController.Job],
         queuedJobs: [SpeechGenerationController.Job],
+        preparingJobTokens: Set<UUID> = [],
         playbackAdmission: PlaybackController.GenerationAdmissionSnapshot,
     ) throws -> GenerationScheduleDecision {
         guard !queuedJobs.isEmpty else {
@@ -84,6 +87,11 @@ extension SpeakSwiftly.Runtime {
         var selectedJobs = [SpeechGenerationController.Job]()
 
         for job in queuedJobs where !isBlockedByProfileCreation(job, activeJobs: activeJobs, queuedJobs: queuedJobs) {
+            if preparingJobTokens.contains(job.token) {
+                parkReasons[job.token] = .waitingForActiveRequest
+                break
+            }
+
             if sawParkedResidentDependentWork, !job.request.canBypassParkedResidentWork {
                 break
             }

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/TextProfileManagement.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/TextProfileManagement.md
@@ -6,7 +6,7 @@ Shape normalization behavior through the shared normalizer, its stored text prof
 
 SpeakSwiftly uses ``SpeakSwiftly/Normalizer`` as the top-level home for text normalization behavior. You can construct a normalizer yourself and pass it into ``SpeakSwiftly/Configuration`` during runtime startup, or you can work through the normalizer already attached to an active runtime at ``SpeakSwiftly/Runtime/normalizer``.
 
-The normalizer splits its public API into two focused handles:
+The normalizer splits its public API into focused handles:
 
 - ``SpeakSwiftly/Normalizer/Style`` for built-in style selection.
 - ``SpeakSwiftly/Normalizer/Profiles`` for profile and replacement-rule management.
@@ -36,6 +36,8 @@ let styleOptions = await normalizer.style.list()
 ```
 
 Use the active profile when you want the currently selected custom profile, the stored list when you want the saved profiles on disk or in memory, and the effective profile when you want the merged result after built-in style and custom replacements are applied together.
+
+Generation uses the same normalizer through ``SpeakSwiftly/Normalizer/speechText(_:sourceFormat:context:textProfileID:)``. That shared path passes the selected text profile, active built-in style, optional `TextForSpeech.InputContext`, source format, and TextForSpeech summarization provider into the current `TextForSpeech.Normalize` APIs before speech or retained-file generation starts.
 
 ## Create Or Update Profiles
 

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/WorkerContract.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/WorkerContract.md
@@ -32,7 +32,7 @@ Every request includes an `id` and an `op`:
 {"id":"req-1","op":"generate_speech","text":"Hello there","voice_profile":"default-femme"}
 ```
 
-For generation requests, the current worker keys are `voice_profile`, `text_profile`, `input_text_context`, and `request_context`. Qwen live playback can also opt into pre-model text chunking with `qwen_pre_model_text_chunking: true`; when omitted, Qwen live playback remains single-pass. Qwen resident model selection is a startup configuration concern, and prepared Qwen conditioning is stored per resident model repo so a profile can lazily accumulate conditioning for each selected Qwen model. Older generation-request aliases such as `profile_name` and `text_profile_id` are still accepted for compatibility.
+For generation requests, the current worker keys are `voice_profile`, `text_profile`, `input_text_context`, and `request_context`. `input_text_context.context` uses the shared `TextForSpeech.InputContext` shape, while `request_context` uses the shared `TextForSpeech.RequestContext` shape. Qwen live playback can also opt into pre-model text chunking with `qwen_pre_model_text_chunking: true`; when omitted, Qwen live playback remains single-pass. Qwen resident model selection is a startup configuration concern, and prepared Qwen conditioning is stored per resident model repo so a profile can lazily accumulate conditioning for each selected Qwen model. Older generation-request aliases such as `profile_name` and `text_profile_id` are still accepted for compatibility.
 
 Representative operations include:
 

--- a/Sources/SpeakSwiftly/SpeakSwiftly.swift
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.swift
@@ -17,11 +17,11 @@ public enum SpeakSwiftly {
 
     /// Describes how one input text payload should be interpreted before generation.
     public struct InputTextContext: Codable, Sendable, Equatable {
-        public let context: TextForSpeech.Context?
+        public let context: TextForSpeech.InputContext?
         public let sourceFormat: TextForSpeech.SourceFormat?
 
         public init(
-            context: TextForSpeech.Context? = nil,
+            context: TextForSpeech.InputContext? = nil,
             sourceFormat: TextForSpeech.SourceFormat? = nil,
         ) {
             self.context = context
@@ -177,7 +177,7 @@ typealias PlaybackState = SpeakSwiftly.PlaybackState
 typealias WorkerRequestStreamEvent = SpeakSwiftly.RequestEvent
 typealias WorkerRequestHandle = SpeakSwiftly.RequestHandle
 typealias WorkerRuntime = SpeakSwiftly.Runtime
-typealias SpeechNormalizationContext = TextForSpeech.Context
+typealias SpeechNormalizationContext = TextForSpeech.InputContext
 typealias SpeechTextDeepTraceFeatures = SpeakSwiftly.DeepTrace.Features
 typealias SpeechTextDeepTraceSection = SpeakSwiftly.DeepTrace.Section
 typealias SpeechTextDeepTraceSectionWindow = SpeakSwiftly.DeepTrace.SectionWindow

--- a/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/ModelClientsTests.swift
@@ -595,7 +595,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
 
 // MARK: - Deep Trace and Normalization
 
-@Test func `speech text deep trace features capture code heavy and weird text shapes`() {
+@Test func `speech text deep trace features capture code heavy and weird text shapes`() async throws {
     let original = """
     # Header
 
@@ -611,7 +611,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     Also say chrommmaticallly and qqqwweerrtyy once.
     """
 
-    let normalized = TextForSpeech.Normalize.text(original)
+    let normalized = try await TextForSpeech.Normalize.text(original)
     let features = SpeakSwiftly.DeepTrace.features(
         originalText: original,
         normalizedText: normalized,
@@ -677,12 +677,12 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     #expect(windowsAreContiguous)
 }
 
-@Test func `speech text normalization makes paths and identifiers more speakable`() {
+@Test func `speech text normalization makes paths and identifiers more speakable`() async throws {
     let original = """
     Please read /Users/galew/Workspace/SpeakSwiftly/Sources/SpeakSwiftly/SpeechTextNormalizer.swift, NSApplication.didFinishLaunchingNotification, camelCaseStuff, snake_case_stuff, and `profile?.sampleRate ?? 24000`.
     """
 
-    let normalized = TextForSpeech.Normalize.text(original)
+    let normalized = try await TextForSpeech.Normalize.text(original)
 
     #expect(normalized.contains("gale wumbo Workspace Speak Swiftly"))
     #expect(normalized.contains("NSApplication dot did Finish Launching Notification"))
@@ -1466,7 +1466,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     let logs = try await runtime.normalizer.profiles.create(name: "Logs")
     _ = try await runtime.normalizer.profiles.addReplacement(
         TextForSpeech.Replacement("stderr", with: "standard error"),
-        toProfile: logs.profileID,
+        toProfile: logs.id,
     )
     _ = try await runtime.normalizer.profiles.addReplacement(
         TextForSpeech.Replacement(
@@ -1474,7 +1474,7 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
             with: "settings token",
             during: .afterBuiltIns,
         ),
-        toProfile: logs.profileID,
+        toProfile: logs.id,
     )
     await runtime.start()
     #expect(await waitUntil {

--- a/Tests/SpeakSwiftlyTests/Generation/SpeechGenerationControllerTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/SpeechGenerationControllerTests.swift
@@ -1,0 +1,41 @@
+@testable import SpeakSwiftly
+import Testing
+
+@Test func `preparing jobs are visible but not runnable until marked ready`() async {
+    let controller = SpeechGenerationController()
+    let request = makeLiveSpeechRequest(id: "req-preparing")
+
+    let job = await controller.enqueue(request, readiness: .preparing)
+
+    #expect(await controller.queuedJobsOrdered() == [job])
+    #expect(await controller.readyQueuedJobsOrdered().isEmpty)
+
+    #expect(await controller.markReady(token: job.token) == job)
+    #expect(await controller.readyQueuedJobsOrdered() == [job])
+}
+
+@Test func `preparing jobs remain cancellable before they are ready`() async {
+    let controller = SpeechGenerationController()
+    let request = makeLiveSpeechRequest(id: "req-cancellable-preparing")
+
+    let job = await controller.enqueue(request, readiness: .preparing)
+    let cancelled = await controller.cancel(requestID: request.id)
+
+    #expect(cancelled == .queued(job))
+    #expect(await controller.queuedJobsOrdered().isEmpty)
+    #expect(await controller.readyQueuedJobsOrdered().isEmpty)
+    #expect(await controller.markReady(token: job.token) == nil)
+}
+
+private func makeLiveSpeechRequest(id: String) -> WorkerRequest {
+    .queueSpeech(
+        id: id,
+        text: "Hello from a live request that is still preparing playback.",
+        profileName: "testing-profile",
+        textProfileID: nil,
+        jobType: .live,
+        inputTextContext: nil,
+        requestContext: nil,
+        qwenPreModelTextChunking: nil,
+    )
+}

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
@@ -83,7 +83,7 @@ import TextForSpeech
             textProfileID: "logs",
             jobType: .live,
             inputTextContext: .init(
-                context: TextForSpeech.Context(
+                context: TextForSpeech.InputContext(
                     cwd: "/Users/galew/Workspace/SpeakSwiftly",
                     repoRoot: "/Users/galew/Workspace/SpeakSwiftly",
                     textFormat: .cli,
@@ -109,7 +109,7 @@ import TextForSpeech
             textProfileID: nil,
             jobType: .live,
             inputTextContext: .init(
-                context: TextForSpeech.Context(
+                context: TextForSpeech.InputContext(
                     textFormat: .markdown,
                     nestedSourceFormat: .swift,
                 ),

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeQueueingTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeQueueingTests.swift
@@ -471,14 +471,14 @@ import TextForSpeech
     let logs = try await firstRuntime.normalizer.profiles.create(name: "Logs")
     _ = try await firstRuntime.normalizer.profiles.addReplacement(
         TextForSpeech.Replacement("stderr", with: "standard error", id: "logs-rule"),
-        toProfile: logs.profileID,
+        toProfile: logs.id,
     )
     let ops = try await firstRuntime.normalizer.profiles.create(name: "Ops")
     _ = try await firstRuntime.normalizer.profiles.addReplacement(
         TextForSpeech.Replacement("stdout", with: "standard output", id: "ops-rule"),
-        toProfile: ops.profileID,
+        toProfile: ops.id,
     )
-    try await firstRuntime.normalizer.profiles.setActive(id: ops.profileID)
+    try await firstRuntime.normalizer.profiles.setActive(id: ops.id)
 
     let secondRuntime = try await makeRuntime(
         rootURL: rootURL,
@@ -487,12 +487,12 @@ import TextForSpeech
         residentModelLoader: { _ in makeResidentModel() },
     )
 
-    let storedLogs = try await secondRuntime.normalizer.profiles.get(id: logs.profileID)
+    let storedLogs = try await secondRuntime.normalizer.profiles.get(id: logs.id)
     let activeProfile = await secondRuntime.normalizer.profiles.getActive()
     let effectiveProfile = await secondRuntime.normalizer.profiles.getEffective()
 
     #expect(storedLogs.replacements.map(\.id) == ["logs-rule"])
-    #expect(activeProfile.profileID == ops.profileID)
+    #expect(activeProfile.id == ops.id)
     #expect(activeProfile.replacements.map(\.id) == ["ops-rule"])
     #expect(effectiveProfile.replacements.map(\.id).contains("ops-rule"))
     #expect(effectiveProfile.replacements.map(\.id).contains("base-url"))
@@ -514,20 +514,20 @@ import TextForSpeech
 
     let added = try await runtime.normalizer.profiles.addReplacement(
         TextForSpeech.Replacement("stderr", with: "standard error", id: "stderr-rule"),
-        toProfile: created.profileID,
+        toProfile: created.id,
     )
     #expect(added.replacements.map(\.id) == ["stderr-rule"])
 
     let replaced = try await runtime.normalizer.profiles.patchReplacement(
         TextForSpeech.Replacement("stderr", with: "standard standard error", id: "stderr-rule"),
-        inProfile: created.profileID,
+        inProfile: created.id,
     )
     #expect(replaced.replacements.first?.replacement == "standard standard error")
-    #expect(try await runtime.normalizer.profiles.get(id: created.profileID).replacements.map(\.id) == ["stderr-rule"])
+    #expect(try await runtime.normalizer.profiles.get(id: created.id).replacements.map(\.id) == ["stderr-rule"])
 
     let emptied = try await runtime.normalizer.profiles.removeReplacement(
         id: "stderr-rule",
-        fromProfile: created.profileID,
+        fromProfile: created.id,
     )
     #expect(emptied.replacements.isEmpty)
 
@@ -537,7 +537,7 @@ import TextForSpeech
         playback: PlaybackSpy(),
         residentModelLoader: { _ in makeResidentModel() },
     )
-    #expect(try await reloaded.normalizer.profiles.get(id: created.profileID).replacements.isEmpty == true)
+    #expect(try await reloaded.normalizer.profiles.get(id: created.id).replacements.isEmpty == true)
 }
 
 @Test func `active text profile editing helpers mutate and persist custom profile`() async throws {

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeQueueingTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeQueueingTests.swift
@@ -296,6 +296,43 @@ import TextForSpeech
     await playbackDrain.open()
 }
 
+@Test func `preparing live speech blocks later resident control barriers`() async throws {
+    let runtime = try await makeRuntime(
+        output: OutputRecorder(),
+        playback: PlaybackSpy(),
+        residentModelLoader: { _ in makeResidentModel() },
+    )
+    let preparingLiveJob = SpeechGenerationController.Job(
+        request: .queueSpeech(
+            id: "req-preparing-live",
+            text: "Hello while playback state is still preparing.",
+            profileName: "default-femme",
+            textProfileID: nil,
+            jobType: .live,
+            inputTextContext: nil,
+            requestContext: nil,
+            qwenPreModelTextChunking: nil,
+        ),
+    )
+    let reloadJob = SpeechGenerationController.Job(
+        request: .reloadModels(id: "req-reload-models"),
+    )
+
+    let decision = try await runtime.evaluateGenerationSchedule(
+        activeJobs: [],
+        queuedJobs: [preparingLiveJob, reloadJob],
+        preparingJobTokens: [preparingLiveJob.token],
+        playbackAdmission: PlaybackController.GenerationAdmissionSnapshot(
+            activeRequestID: nil,
+            activeRequestTuningProfile: nil,
+            allowsConcurrentGeneration: true,
+        ),
+    )
+
+    #expect(decision.runnableJobs.isEmpty)
+    #expect(decision.parkReasons == [preparingLiveJob.token: .waitingForActiveRequest])
+}
+
 @Test func `runtime uses configured speech backend for resident model preload`() async throws {
     let output = OutputRecorder()
     let recorder = LoadedBackendRecorder()

--- a/docs/maintainers/slices.md
+++ b/docs/maintainers/slices.md
@@ -2,7 +2,7 @@
 
 ## Why this exists
 
-This note explains the current post-`TextForSpeech 0.18.0` model in maintainer terms.
+This note explains the current post-`TextForSpeech 0.18.9` model in maintainer terms.
 
 The three concepts that most often get conflated are:
 
@@ -23,7 +23,7 @@ Those now live in three different places on purpose.
 - `persistence`
   The persisted runtime state on disk or in memory.
 
-That split is the whole simplification.
+That split is the public simplification. Generation then uses one shared `SpeakSwiftly.Normalizer.speechText(...)` entry point to call the async `TextForSpeech.Normalize` APIs, so live playback, retained files, source-format handling, custom profiles, built-in style, and summarization-provider selection all pass through the same package-owned path.
 
 We no longer expose a mixed bag of “style plus active profile plus stored profiles plus raw replacement list” helpers on one surface, and we no longer support whole-profile replace/store/use workflows through `SpeakSwiftly`.
 
@@ -61,7 +61,7 @@ The important point is that stored profiles are now addressed by stable identifi
 
 Each stored profile has:
 
-- a stable `profileID`
+- a stable identifier exposed as `profileID` in `SpeakSwiftly.TextProfileDetails` and `profile_id` in JSONL payloads
 - a mutable human-facing `name`
 - a `replacements` array
 
@@ -148,9 +148,9 @@ The optional `text_profile_id` on those JSONL operations means:
 For any single generation request, the mental model is:
 
 1. pick the built-in style
-2. pick the active custom profile
-3. compute the effective merged profile for that job
-4. normalize the input text with request-local context
+2. pick the requested stored custom profile, or the active custom profile when the request does not name one
+3. snapshot the active TextForSpeech summarization provider
+4. normalize the input text with request-local source format and `TextForSpeech.InputContext`
 
 That is why the generation APIs now carry `textProfile` rather than `textProfileName`.
 

--- a/docs/releases/v4-1-0-release-notes.md
+++ b/docs/releases/v4-1-0-release-notes.md
@@ -1,0 +1,66 @@
+# v4.1.0 Release Notes
+
+## What changed
+
+- refreshed the `TextForSpeech` dependency to `0.18.9`
+- changed `SpeakSwiftly.InputTextContext.context` to use the shared
+  `TextForSpeech.InputContext` model
+- kept `SpeakSwiftly.RequestContext` on the shared `TextForSpeech.RequestContext`
+  model so text-shaping context and request-origin metadata now both come from
+  TextForSpeech
+- centralized generation normalization through
+  `SpeakSwiftly.Normalizer.speechText(...)` for live playback and retained file
+  output
+- preserved selected text profiles, active built-in style, source format, input
+  context, and TextForSpeech summarization-provider selection through the shared
+  normalization path
+- kept JSONL text-profile payloads on the compatible `profile_id` field while
+  mapping from the current `TextForSpeech.Runtime.Profiles.Details.id` source
+  model
+- queued live playback state before generation admission so async
+  normalization cannot race generation ahead of playback registration
+- aligned `runtime.player.cancelRequest(_:)` with its documented broad
+  request-id behavior while keeping queue-specific cancellation available
+
+## Breaking changes
+
+- Swift callers that explicitly constructed `SpeakSwiftly.InputTextContext` with
+  the old `TextForSpeech.Context` type should move to
+  `TextForSpeech.InputContext`
+- JSONL request and response compatibility is preserved
+
+## Migration or upgrade notes
+
+- continue using `input_text_context.context` and `request_context` in JSONL
+  requests; their shapes are now the current TextForSpeech context models
+- use `runtime.cancel(.generation, requestID:)` or
+  `runtime.cancel(.playback, requestID:)` when a cancellation must stay scoped
+  to one queue
+- use `runtime.player.cancelRequest(_:)` when the operator intent is to cancel
+  the named request wherever it currently lives
+
+## Verification to complete before release
+
+```bash
+swift build
+```
+
+```bash
+swift test
+```
+
+```bash
+swift test --enable-code-coverage
+```
+
+```bash
+git diff --check
+```
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```
+
+```bash
+sh scripts/repo-maintenance/run-e2e-full.sh
+```

--- a/docs/releases/v4-1-0-release-prep.md
+++ b/docs/releases/v4-1-0-release-prep.md
@@ -1,0 +1,92 @@
+# v4.1.0 Release Prep
+
+Date: 2026-04-28
+
+This note captures the intended scope and validation story for the `v4.1.0`
+release.
+
+## Intended Scope
+
+The release should be framed as:
+
+- a minor TextForSpeech integration refresh that adopts `TextForSpeech` `0.18.9`
+- a normalization simplification that routes live speech and retained file
+  generation through one shared `SpeakSwiftly.Normalizer.speechText(...)` path
+- a package-surface alignment with the current `TextForSpeech.InputContext`,
+  `TextForSpeech.RequestContext`, and profile-details naming model
+
+Included work on the current branch:
+
+- update the `TextForSpeech` dependency floor and resolved pin to `0.18.9`
+- change `SpeakSwiftly.InputTextContext.context` to use
+  `TextForSpeech.InputContext`
+- keep JSONL text-profile payloads encoded as `profile_id` while mapping from
+  `TextForSpeech.Runtime.Profiles.Details.id`
+- centralize normalization through the shared normalizer before live playback
+  or retained file generation
+- preserve source-format handling, selected text profiles, active built-in
+  style, and TextForSpeech summarization-provider selection through that shared
+  path
+- enqueue live playback state before generation admission so async
+  normalization cannot let generation outrun playback registration
+- make `runtime.player.cancelRequest(_:)` submit the broad request-cancel
+  operation promised by its documentation, while retaining queue-specific
+  cancellation through `runtime.cancel(_:requestID:)`
+
+Not included:
+
+- a coordinated `speak-to-user` submodule bump
+- a voice-profile storage migration
+- a real-model backend default change
+
+## SemVer Framing
+
+- release this as `v4.1.0`
+- this is a minor release because it updates the public Swift normalization
+  typing around `TextForSpeech.InputContext` and simplifies the generation
+  normalization path while preserving JSONL compatibility
+- JSONL callers can keep sending the existing `input_text_context`,
+  `request_context`, and `text_profile_id` compatibility keys
+
+## Validation Target
+
+Baseline package validation before release:
+
+```bash
+swift build
+```
+
+```bash
+swift test
+```
+
+Coverage before release:
+
+```bash
+swift test --enable-code-coverage
+```
+
+Formatting, linting, and repo-maintenance validation before release:
+
+```bash
+git diff --check
+```
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```
+
+Release-safe E2E validation before release:
+
+```bash
+sh scripts/repo-maintenance/run-e2e-full.sh
+```
+
+## Release Checklist
+
+- confirm the release-safe E2E lane passes after the PR branch is pushed
+- check GitHub CI and PR comments before tagging
+- rerun E2E after any PR feedback fix that touches runtime, generation,
+  playback, or normalization behavior
+- release through `scripts/repo-maintenance/release.sh --mode standard
+  --version v4.1.0`


### PR DESCRIPTION
## Summary
- refresh TextForSpeech to 0.18.9 and align SpeakSwiftly input-context/profile-detail types
- centralize live and retained-file text normalization through the shared normalizer path
- document the v4.1.0 release scope and normalization behavior

## Verification
- swift build
- swift test
- swift test --enable-code-coverage
- git diff --check
- sh scripts/repo-maintenance/validate-all.sh

## Follow-up before release
- run sh scripts/repo-maintenance/run-e2e-full.sh
- check CI and PR comments before tagging v4.1.0