### PR TITLE
tests: reduce queue-control e2e pressure

### DIFF
--- a/Tests/SpeakSwiftlyTests/E2E/QueueControlE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/QueueControlE2ETests.swift
@@ -12,6 +12,8 @@ import Testing
     ),
 )
 struct QueueControlE2ETests {
+    private static let queueControlTimeout: Duration = .seconds(180)
+
     @Test func `generation queue clear and cancel stay generation scoped`() async throws {
         let sandbox = try E2ESandbox()
         defer { sandbox.cleanup() }
@@ -28,67 +30,67 @@ struct QueueControlE2ETests {
 
         try worker.sendJSON(
             """
-            {"id":"req-generation-active-e2e","op":"generate_audio_file","text":"\(E2EHarness.qwenLongFormPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            {"id":"req-generation-active-e2e","op":"generate_audio_file","text":"\(E2EHarness.testingPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
             """,
         )
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-generation-active-e2e"
                 && $0["event"] as? String == "started"
-        } != nil)
+        })
 
         try worker.sendJSON(
             """
             {"id":"req-generation-queued-e2e","op":"generate_audio_file","text":"\(E2EHarness.testingPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
             """,
         )
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-generation-queued-e2e"
                 && $0["event"] as? String == "queued"
                 && $0["reason"] as? String == "waiting_for_active_request"
-        } != nil)
+        })
 
         try worker.sendJSON(
             """
             {"id":"req-clear-playback-e2e","op":"clear_playback_queue"}
             """,
         )
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-clear-playback-e2e"
                 && $0["ok"] as? Bool == true
                 && $0["cleared_count"] as? Int == 0
-        } != nil)
+        })
 
         try worker.sendJSON(
             """
             {"id":"req-clear-generation-e2e","op":"clear_generation_queue"}
             """,
         )
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-clear-generation-e2e"
                 && $0["ok"] as? Bool == true
                 && $0["cleared_count"] as? Int == 1
-        } != nil)
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        })
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-generation-queued-e2e"
                 && $0["ok"] as? Bool == false
                 && $0["code"] as? String == "request_cancelled"
-        } != nil)
+        })
 
         try worker.sendJSON(
             """
             {"id":"req-cancel-generation-e2e","op":"cancel_generation","request_id":"req-generation-active-e2e"}
             """,
         )
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-cancel-generation-e2e"
                 && $0["ok"] as? Bool == true
                 && $0["cancelled_request_id"] as? String == "req-generation-active-e2e"
-        } != nil)
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        })
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-generation-active-e2e"
                 && $0["ok"] as? Bool == false
                 && $0["code"] as? String == "request_cancelled"
-        } != nil)
+        })
 
         try worker.closeInput()
         try await worker.waitForExit(timeout: .seconds(30))
@@ -110,30 +112,30 @@ struct QueueControlE2ETests {
 
         try worker.sendJSON(
             """
-            {"id":"req-playback-active-e2e","op":"generate_speech","text":"\(E2EHarness.qwenLongFormPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
+            {"id":"req-playback-active-e2e","op":"generate_speech","text":"\(E2EHarness.testingPlaybackText.jsonEscaped)","profile_name":"\(E2EHarness.testingProfileName)"}
             """,
         )
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-playback-active-e2e"
                 && $0["event"] as? String == "progress"
-                && $0["stage"] as? String == "buffering_audio"
-        } != nil)
+                && $0["stage"] as? String == "starting_playback"
+        })
 
         try worker.sendJSON(
             """
             {"id":"req-cancel-playback-e2e","op":"cancel_playback","request_id":"req-playback-active-e2e"}
             """,
         )
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-cancel-playback-e2e"
                 && $0["ok"] as? Bool == true
                 && $0["cancelled_request_id"] as? String == "req-playback-active-e2e"
-        } != nil)
-        #expect(try await worker.waitForJSONObject(timeout: E2EHarness.e2eTimeout) {
+        })
+        _ = try #require(try await worker.waitForJSONObject(timeout: Self.queueControlTimeout) {
             $0["id"] as? String == "req-playback-active-e2e"
                 && $0["ok"] as? Bool == false
                 && $0["code"] as? String == "request_cancelled"
-        } != nil)
+        })
 
         try worker.closeInput()
         try await worker.waitForExit(timeout: .seconds(30))


### PR DESCRIPTION
## Summary

- Replaces the queue-control E2E active-generation text with the shorter shared Chatterbox playback text instead of the long Qwen endurance fixture.
- Cancels playback after the worker reaches starting_playback, before the first Chatterbox audio chunk can race straight through playback completion.
- Uses focused 180s hard-require waits so bad control responses fail this suite promptly instead of sitting on the global E2E timeout.

Closes #47.

## Validation

- swift build
- swift test
- bash scripts/repo-maintenance/validate-all.sh
- sh scripts/repo-maintenance/run-e2e.sh --suite queue-control

The queue-control E2E suite passed in 28.859s, and the wrapper reloaded live SpeakSwiftlyServer resident models after the run.