### PR TITLE
config: add native state root override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ That split matters:
 
 The typed Swift surface uses Cocoa-style method names and one root runtime object:
 
-- `SpeakSwiftly.liftoff(configuration:)` is the single startup entry point
+- `SpeakSwiftly.liftoff(configuration:stateRootURL:)` is the single startup entry point
 - `SpeakSwiftly.liftoff(...)` returns `SpeakSwiftly.Runtime`
 - `runtime.generate`
 - `runtime.player`
@@ -176,9 +176,11 @@ Default persisted configuration path:
 
 - macOS production default: `~/Library/Application Support/SpeakSwiftly/configuration.json`
 - macOS debug and package-test default: `~/Library/Application Support/SpeakSwiftly-Debug/configuration.json`
-- with `SPEAKSWIFTLY_PROFILE_ROOT=/custom`: `/custom/configuration.json`
+- with `SpeakSwiftly.liftoff(stateRootURL: URL(fileURLWithPath: "/custom"))`: `/custom/configuration.json`
+- with `SpeakSwiftlyTool --state-root /custom`: `/custom/configuration.json`
+- with the process-level fallback `SPEAKSWIFTLY_STATE_ROOT=/custom`: `/custom/configuration.json`
 
-The same namespace split applies to the default profile store and `text-profiles.json`, so debug builds, local package tests, and production runs do not reuse the same local storage root unless you explicitly point them at one with `SPEAKSWIFTLY_PROFILE_ROOT`.
+The same namespace split applies to the default profile store and `text-profiles.json`, so debug builds, local package tests, and production runs do not reuse the same local storage root unless you explicitly point them at one state root. Prefer the typed Swift `stateRootURL` startup parameter for library callers and `--state-root` for the standalone worker. `SPEAKSWIFTLY_STATE_ROOT` remains available as a process-level fallback for hosts that cannot pass startup arguments. `SPEAKSWIFTLY_PROFILE_ROOT` is a deprecated compatibility alias for the same state-root behavior.
 For compatibility, SpeakSwiftly still recognizes the older trailing `.../profiles` form when it detects an existing legacy layout with adjacent `configuration.json` or `text-profiles.json` state.
 
 Backend resolution precedence is:

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ sh scripts/repo-maintenance/publish-runtime.sh --configuration Debug
 ```
 
 At startup the worker begins warming the resident backend and emits JSONL status events on `stdout`.
+By default, runtime state lives under the platform Application Support directory. Use `SpeakSwiftly.liftoff(stateRootURL:)` from Swift or launch the worker with `--state-root PATH` only when a host needs an isolated state root for `profiles/`, `configuration.json`, and `text-profiles.json`.
 
 ### Consumer Test Harness
 
@@ -183,9 +184,9 @@ swift run SpeakSwiftlyTesting resources
 swift run SpeakSwiftlyTesting status
 swift run SpeakSwiftlyTesting smoke
 swift run SpeakSwiftlyTesting create-design-profile --profile probe-fresh-a --voice "A steady, intimate, softly spoken feminine voice with even projection."
-swift run SpeakSwiftlyTesting volume-probe --profile default-femme --profile-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16
-swift run SpeakSwiftlyTesting compare-volume --profile default-femme --profile-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16
-swift run SpeakSwiftlyTesting compare-volume --profile default-femme --profile-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16 --matched-duration trim-to-shorter
+swift run SpeakSwiftlyTesting volume-probe --profile default-femme --state-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16
+swift run SpeakSwiftlyTesting compare-volume --profile default-femme --state-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16
+swift run SpeakSwiftlyTesting compare-volume --profile default-femme --state-root "$HOME/Library/Application Support/SpeakSwiftly" --repeat 16 --matched-duration trim-to-shorter
 ```
 
 `resources` prints the packaged bundle and metallib paths, `status` constructs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,7 +97,7 @@ Planned
 - [ ] Make profile listing and loading resilient to in-flight writes from another process without producing misleading corruption failures.
 - [ ] Add clear operator-facing diagnostics for lock contention, stale temp directories, and cross-process filesystem races.
 - [ ] Add automated coverage for concurrent create/load/remove access against the shared profile root.
-- [ ] Document the shared per-user default profile root and the override path for process-isolated profile stores.
+- [ ] Document the shared per-user default profile root and the state-root override path for process-isolated profile stores.
 
 ### Exit Criteria
 
@@ -122,12 +122,12 @@ In Progress
 - [ ] Revisit `output_path` resolution so relative paths cannot silently depend on the worker launch directory.
 - [ ] Extend the existing `get_runtime_overview` / `runtime.overview()` inspection story where parent processes still need service-health fields such as profile root, runtime-state root, or richer resident state.
 - [ ] Add a runtime-level playback and overview event stream so hosts can keep playback state current without opportunistic polling. ([#45](https://github.com/gaelic-ghost/SpeakSwiftly/issues/45))
-- [ ] Rename or supersede `SPEAKSWIFTLY_PROFILE_ROOT` so the public override name matches its current runtime-state-root behavior. ([#21](https://github.com/gaelic-ghost/SpeakSwiftly/issues/21))
+- [x] Add native state-root startup controls so Application Support stays the default while Swift callers use `stateRootURL`, worker hosts use `--state-root`, and `SPEAKSWIFTLY_PROFILE_ROOT` remains only as a deprecated compatibility alias. ([#21](https://github.com/gaelic-ghost/SpeakSwiftly/issues/21))
 - [ ] Make profile listing resilient to stray files, partial directories, and damaged entries without poisoning the full operation when recovery is possible.
 - [ ] Add a first-class default-profile concept so downstream callers are not forced to treat names like `default-femme` as hidden conventions.
 - [ ] Persist a little more voice-profile source provenance from creation flows so rerolls, diagnostics, and later profile introspection have stable grounding.
 - [ ] Investigate whether startup-side playback preload or environment observation is still correlated with `freed pointer was not the last allocation`. ([#7](https://github.com/gaelic-ghost/SpeakSwiftly/issues/7))
-- [ ] Document the parent-process ownership expectations for startup warmup, health inspection, shutdown, and profile-root selection.
+- [ ] Document the parent-process ownership expectations for startup warmup, health inspection, shutdown, and state-root selection.
 - [ ] Document the current tag-time adoption flow for active downstream consumers such as `SpeakSwiftlyServer` and the `speak-to-user` integration repository, including what is automatic and what remains explicit follow-up.
 
 ### Exit Criteria

--- a/Sources/SpeakSwiftly/API/Configuration.swift
+++ b/Sources/SpeakSwiftly/API/Configuration.swift
@@ -131,11 +131,11 @@ public extension SpeakSwiftly {
 
         static func loadDefault(
             fileManager: FileManager = .default,
-            profileRootOverride: String? = nil,
+            stateRootOverride: String? = nil,
         ) throws -> Self? {
             let persistenceURL = defaultPersistenceURL(
                 fileManager: fileManager,
-                profileRootOverride: profileRootOverride,
+                stateRootOverride: stateRootOverride,
             )
             guard fileManager.fileExists(atPath: persistenceURL.path) else {
                 return nil
@@ -146,11 +146,11 @@ public extension SpeakSwiftly {
 
         static func defaultPersistenceURL(
             fileManager: FileManager = .default,
-            profileRootOverride: String? = nil,
+            stateRootOverride: String? = nil,
         ) -> URL {
             ProfileStore.defaultConfigurationURL(
                 fileManager: fileManager,
-                profileRootOverride: profileRootOverride,
+                stateRootOverride: stateRootOverride,
             )
         }
 
@@ -182,12 +182,12 @@ public extension SpeakSwiftly {
 
         func saveDefault(
             fileManager: FileManager = .default,
-            profileRootOverride: String? = nil,
+            stateRootOverride: String? = nil,
         ) throws {
             try save(
                 to: Self.defaultPersistenceURL(
                     fileManager: fileManager,
-                    profileRootOverride: profileRootOverride,
+                    stateRootOverride: stateRootOverride,
                 ),
             )
         }

--- a/Sources/SpeakSwiftly/API/TextNormalization.swift
+++ b/Sources/SpeakSwiftly/API/TextNormalization.swift
@@ -118,9 +118,9 @@ public extension SpeakSwiftly {
                 resolvedPersistenceURL = standardizedURL
             } else {
                 let defaultURL = ProfileStore.defaultTextProfilesURL(
-                    profileRootOverride: ProcessInfo.processInfo.environment[
-                        ProfileStore.profileRootOverrideEnvironmentVariable,
-                    ],
+                    stateRootOverride: ProfileStore.runtimeStateRootOverridePath(
+                        in: ProcessInfo.processInfo.environment,
+                    ),
                 )
                 persistence = .file(defaultURL)
                 resolvedPersistenceURL = defaultURL

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Bootstrap.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Bootstrap.swift
@@ -52,12 +52,22 @@ extension SpeakSwiftly.Runtime {
 
     static func liftoff(
         configuration: SpeakSwiftly.Configuration? = nil,
+        stateRootURL: URL? = nil,
     ) async -> SpeakSwiftly.Runtime {
         let environment = ProcessInfo.processInfo.environment
         let bootstrapDependencies = WorkerDependencies.live()
+        let environmentStateRootOverride = ProfileStore.runtimeStateRootOverride(in: environment)
+        let stateRootOverridePath = stateRootURL?.standardizedFileURL.path
+            ?? environmentStateRootOverride?.path
+        if stateRootURL == nil,
+           environmentStateRootOverride?.source == .deprecatedProfileRoot {
+            bootstrapDependencies.writeStderr(
+                "SpeakSwiftly is using deprecated \(Environment.deprecatedProfileRootOverride)='\(environmentStateRootOverride?.path ?? "")' as the runtime state root. Prefer SpeakSwiftly.liftoff(stateRootURL:), the SpeakSwiftlyTool --state-root option, or \(Environment.runtimeStateRootOverride); SpeakSwiftly derives profiles/, \(ProfileStore.configurationFileName), and \(ProfileStore.textProfilesFileName) from that state root.\n",
+            )
+        }
         let persistedConfiguration = resolvedPersistedConfiguration(
             dependencies: bootstrapDependencies,
-            environment: environment,
+            runtimeStateRootOverridePath: stateRootOverridePath,
         )
         let configuredSpeechBackend = resolvedSpeechBackend(
             environment: environment,
@@ -84,7 +94,7 @@ extension SpeakSwiftly.Runtime {
         let profileStore = ProfileStore(
             rootURL: ProfileStore.defaultRootURL(
                 fileManager: dependencies.fileManager,
-                overridePath: environment[Environment.profileRootOverride],
+                stateRootOverride: stateRootOverridePath,
             ),
             fileManager: dependencies.fileManager,
         )
@@ -96,7 +106,7 @@ extension SpeakSwiftly.Runtime {
         )
         let textProfilesURL = ProfileStore.defaultTextProfilesURL(
             fileManager: dependencies.fileManager,
-            profileRootOverride: environment[Environment.profileRootOverride],
+            stateRootOverride: stateRootOverridePath,
         )
         let normalizer = configuration?.textNormalizer
             ?? makeDefaultNormalizer(
@@ -176,17 +186,17 @@ extension SpeakSwiftly.Runtime {
 
     private static func resolvedPersistedConfiguration(
         dependencies: WorkerDependencies,
-        environment: [String: String],
+        runtimeStateRootOverridePath: String?,
     ) -> SpeakSwiftly.Configuration? {
         do {
             return try SpeakSwiftly.Configuration.loadDefault(
                 fileManager: dependencies.fileManager,
-                profileRootOverride: environment[Environment.profileRootOverride],
+                stateRootOverride: runtimeStateRootOverridePath,
             )
         } catch {
             let configurationPath = SpeakSwiftly.Configuration.defaultPersistenceURL(
                 fileManager: dependencies.fileManager,
-                profileRootOverride: environment[Environment.profileRootOverride],
+                stateRootOverride: runtimeStateRootOverridePath,
             )
             .path
             let message = "SpeakSwiftly could not load persisted runtime configuration from '\(configurationPath)'. Falling back to the default runtime configuration. \(error.localizedDescription)\n"

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
@@ -9,7 +9,8 @@ public extension SpeakSwiftly {
         // MARK: Environment
 
         enum Environment {
-            static let profileRootOverride = ProfileStore.profileRootOverrideEnvironmentVariable
+            static let runtimeStateRootOverride = ProfileStore.runtimeStateRootOverrideEnvironmentVariable
+            static let deprecatedProfileRootOverride = ProfileStore.profileRootOverrideEnvironmentVariable
         }
 
         enum RequestObservationConfiguration {

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
@@ -4,7 +4,7 @@ Create one runtime, use its focused handles, and keep long-lived work attached t
 
 ## Overview
 
-The main entry point into SpeakSwiftly is ``SpeakSwiftly/liftoff(configuration:)``. That call starts a shared ``SpeakSwiftly/Runtime`` and applies startup-only choices from ``SpeakSwiftly/Configuration``, such as which speech backend to load and whether a custom ``SpeakSwiftly/Normalizer`` should be installed up front.
+The main entry point into SpeakSwiftly is ``SpeakSwiftly/liftoff(configuration:stateRootURL:)``. That call starts a shared ``SpeakSwiftly/Runtime`` and applies startup-only choices from ``SpeakSwiftly/Configuration``, such as which speech backend to load and whether a custom ``SpeakSwiftly/Normalizer`` should be installed up front. By default, SpeakSwiftly stores runtime state in the platform Application Support directory. Pass `stateRootURL` only when a host needs an isolated state directory for profiles, configuration, and text profiles.
 
 Once you have a runtime, the package expects you to work through narrow concern handles instead of one large method namespace. Use ``SpeakSwiftly/Runtime/generate`` to request speech or retained audio output, ``SpeakSwiftly/Runtime/player`` to inspect or control playback, ``SpeakSwiftly/Runtime/voices`` to manage stored voice profiles, and ``SpeakSwiftly/Runtime/jobs`` or ``SpeakSwiftly/Runtime/artifacts`` when you want to inspect work that stays around after generation finishes.
 
@@ -34,6 +34,14 @@ let runtime = await SpeakSwiftly.liftoff(
         speechBackend: .qwen3,
         textNormalizer: normalizer
     )
+)
+```
+
+When a host needs isolated persisted state, pass the state root at startup:
+
+```swift
+let runtime = await SpeakSwiftly.liftoff(
+    stateRootURL: URL(fileURLWithPath: "/tmp/SpeakSwiftly-Isolated")
 )
 ```
 

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/SpeakSwiftly.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/SpeakSwiftly.md
@@ -4,7 +4,7 @@ Generate live speech playback and retained audio artifacts from a shared runtime
 
 ## Overview
 
-SpeakSwiftly centers around a long-lived ``SpeakSwiftly/Runtime``. You create that runtime with ``SpeakSwiftly/liftoff(configuration:)`` and then interact with focused handles instead of one large method surface.
+SpeakSwiftly centers around a long-lived ``SpeakSwiftly/Runtime``. You create that runtime with ``SpeakSwiftly/liftoff(configuration:stateRootURL:)`` and then interact with focused handles instead of one large method surface.
 
 Use ``SpeakSwiftly/Runtime/generate`` when you want to synthesize speech, ``SpeakSwiftly/Runtime/player`` when you want to inspect or control playback, ``SpeakSwiftly/Runtime/voices`` when you want to manage stored voice profiles, and ``SpeakSwiftly/Runtime/jobs`` or ``SpeakSwiftly/Runtime/artifacts`` when you want to inspect retained generation output.
 
@@ -15,7 +15,7 @@ If you need custom text normalization behavior, create a ``SpeakSwiftly/Normaliz
 ### Essentials
 
 - ``SpeakSwiftly``
-- ``SpeakSwiftly/liftoff(configuration:)``
+- ``SpeakSwiftly/liftoff(configuration:stateRootURL:)``
 - ``SpeakSwiftly/Runtime``
 - ``SpeakSwiftly/Configuration``
 

--- a/Sources/SpeakSwiftly/SpeakSwiftly.swift
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.swift
@@ -3,7 +3,7 @@ import TextForSpeech
 
 /// The top-level namespace and startup entrypoint for the SpeakSwiftly library.
 ///
-/// Use ``liftoff(configuration:)`` to create a shared ``Runtime`` and then work
+/// Use ``liftoff(configuration:stateRootURL:)`` to create a shared ``Runtime`` and then work
 /// through the runtime's typed concern handles such as ``SpeakSwiftly/Runtime/generate``
 /// and ``SpeakSwiftly/Runtime/player``.
 public enum SpeakSwiftly {
@@ -230,13 +230,18 @@ public enum SpeakSwiftly {
 
     /// Starts a SpeakSwiftly runtime.
     ///
-    /// - Parameter configuration: Optional startup configuration for backend selection
-    ///   and text normalization.
+    /// - Parameters:
+    ///   - configuration: Optional startup configuration for backend selection
+    ///     and text normalization.
+    ///   - stateRootURL: Optional runtime state directory. When omitted,
+    ///     SpeakSwiftly uses the platform Application Support default unless a
+    ///     process-level compatibility override is set.
     /// - Returns: A live ``Runtime`` that owns request submission, playback, and stored resources.
     public static func liftoff(
         configuration: SpeakSwiftly.Configuration? = nil,
+        stateRootURL: URL? = nil,
     ) async -> Runtime {
-        await Runtime.liftoff(configuration: configuration)
+        await Runtime.liftoff(configuration: configuration, stateRootURL: stateRootURL)
     }
 }
 

--- a/Sources/SpeakSwiftly/Storage/ProfileStore.swift
+++ b/Sources/SpeakSwiftly/Storage/ProfileStore.swift
@@ -2,10 +2,21 @@ import Foundation
 import MLXAudioTTS
 
 struct ProfileStore: @unchecked Sendable {
+    struct RuntimeStateRootOverride: Equatable {
+        enum Source: Equatable {
+            case runtimeStateRoot
+            case deprecatedProfileRoot
+        }
+
+        let path: String
+        let source: Source
+    }
+
     static let directoryName = "SpeakSwiftly"
     static let profilesDirectoryName = "profiles"
     static let textProfilesFileName = "text-profiles.json"
     static let configurationFileName = "configuration.json"
+    static let runtimeStateRootOverrideEnvironmentVariable = "SPEAKSWIFTLY_STATE_ROOT"
     static let profileRootOverrideEnvironmentVariable = "SPEAKSWIFTLY_PROFILE_ROOT"
     static let manifestFileName = "profile.json"
     static let audioFileName = "reference.wav"
@@ -36,34 +47,61 @@ struct ProfileStore: @unchecked Sendable {
         self.decoder = decoder
     }
 
-    static func defaultRootURL(fileManager: FileManager = .default, overridePath: String? = nil) -> URL {
-        defaultBaseURL(fileManager: fileManager, profileRootOverride: overridePath)
+    static func defaultRootURL(fileManager: FileManager = .default, stateRootOverride: String? = nil) -> URL {
+        defaultBaseURL(fileManager: fileManager, stateRootOverride: stateRootOverride)
             .appendingPathComponent(profilesDirectoryName, isDirectory: true)
     }
 
     static func defaultConfigurationURL(
         fileManager: FileManager = .default,
-        profileRootOverride: String? = nil,
+        stateRootOverride: String? = nil,
     ) -> URL {
-        defaultBaseURL(fileManager: fileManager, profileRootOverride: profileRootOverride)
+        defaultBaseURL(fileManager: fileManager, stateRootOverride: stateRootOverride)
             .appendingPathComponent(configurationFileName, isDirectory: false)
     }
 
     static func defaultTextProfilesURL(
         fileManager: FileManager = .default,
-        profileRootOverride: String? = nil,
+        stateRootOverride: String? = nil,
     ) -> URL {
-        defaultBaseURL(fileManager: fileManager, profileRootOverride: profileRootOverride)
+        defaultBaseURL(fileManager: fileManager, stateRootOverride: stateRootOverride)
             .appendingPathComponent(textProfilesFileName, isDirectory: false)
+    }
+
+    static func runtimeStateRootOverride(in environment: [String: String]) -> RuntimeStateRootOverride? {
+        if let path = nonEmptyEnvironmentValue(
+            environment[runtimeStateRootOverrideEnvironmentVariable],
+        ) {
+            return RuntimeStateRootOverride(path: path, source: .runtimeStateRoot)
+        }
+
+        if let path = nonEmptyEnvironmentValue(
+            environment[profileRootOverrideEnvironmentVariable],
+        ) {
+            return RuntimeStateRootOverride(path: path, source: .deprecatedProfileRoot)
+        }
+
+        return nil
+    }
+
+    static func runtimeStateRootOverridePath(in environment: [String: String]) -> String? {
+        runtimeStateRootOverride(in: environment)?.path
+    }
+
+    private static func nonEmptyEnvironmentValue(_ value: String?) -> String? {
+        guard let value else { return nil }
+
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? nil : value
     }
 
     private static func defaultBaseURL(
         fileManager: FileManager = .default,
-        profileRootOverride: String? = nil,
+        stateRootOverride: String? = nil,
     ) -> URL {
-        if let profileRootOverride, !profileRootOverride.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if let stateRootOverride, !stateRootOverride.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return normalizedOverrideBaseURL(
-                profileRootOverride,
+                stateRootOverride,
                 fileManager: fileManager,
             )
         }
@@ -73,10 +111,10 @@ struct ProfileStore: @unchecked Sendable {
     }
 
     private static func normalizedOverrideBaseURL(
-        _ profileRootOverride: String,
+        _ stateRootOverride: String,
         fileManager: FileManager,
     ) -> URL {
-        let overrideURL = URL(fileURLWithPath: profileRootOverride, isDirectory: true)
+        let overrideURL = URL(fileURLWithPath: stateRootOverride, isDirectory: true)
             .standardizedFileURL
 
         guard overrideURL.lastPathComponent == profilesDirectoryName else {

--- a/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
+++ b/Sources/SpeakSwiftlyTesting/SpeakSwiftlyTesting.swift
@@ -21,12 +21,12 @@ struct SpeakSwiftlyTestingMain {
         var sourceText = "Hello there from SpeakSwiftly end-to-end coverage."
         var vibe = "femme"
         var voiceDescription: String
-        var profileRoot: String?
+        var stateRoot: String?
     }
 
     struct VolumeProbeOptions {
         var profileName = "default-femme"
-        var profileRoot: String?
+        var stateRoot: String?
         var textFile: String?
         var repeatCount = 10
         var windowSeconds = 2.0
@@ -56,7 +56,7 @@ struct SpeakSwiftlyTestingMain {
         let toolName: String
         let sourceSurface: String
         let profileName: String
-        let profileRoot: String?
+        let stateRoot: String?
         let textCharacters: Int
         let textWords: Int
         let textFingerprint: String
@@ -68,7 +68,7 @@ struct SpeakSwiftlyTestingMain {
         let schemaVersion: Int
         let toolName: String
         let profileName: String
-        let profileRoot: String?
+        let stateRoot: String?
         let textCharacters: Int
         let textWords: Int
         let textFingerprint: String
@@ -135,8 +135,6 @@ struct SpeakSwiftlyTestingMain {
             MLXArray(values).reshaped(shape)
         }
     }
-
-    static let profileRootOverrideEnvironmentVariable = "SPEAKSWIFTLY_PROFILE_ROOT"
 
     static func main() async {
         do {
@@ -213,9 +211,9 @@ struct SpeakSwiftlyTestingMain {
                 case "--vibe":
                     index += 1
                     options.vibe = try requireOptionValue(arguments, index: index, for: argument)
-                case "--profile-root":
+                case "--state-root":
                     index += 1
-                    options.profileRoot = try requireOptionValue(arguments, index: index, for: argument)
+                    options.stateRoot = try requireOptionValue(arguments, index: index, for: argument)
                 default:
                     throw UsageError.unknownCommand(argument)
             }
@@ -244,9 +242,9 @@ struct SpeakSwiftlyTestingMain {
                 case "--profile":
                     index += 1
                     options.profileName = try requireOptionValue(arguments, index: index, for: argument)
-                case "--profile-root":
+                case "--state-root":
                     index += 1
-                    options.profileRoot = try requireOptionValue(arguments, index: index, for: argument)
+                    options.stateRoot = try requireOptionValue(arguments, index: index, for: argument)
                 case "--text-file":
                     index += 1
                     options.textFile = try requireOptionValue(arguments, index: index, for: argument)
@@ -338,20 +336,17 @@ struct SpeakSwiftlyTestingMain {
     }
 
     static func runVolumeProbe(options: VolumeProbeOptions) async throws {
-        if let profileRoot = options.profileRoot {
-            setenv(profileRootOverrideEnvironmentVariable, profileRoot, 1)
-        }
-
         let text = try loadVolumeProbeText(options: options)
         let result = try await runStreamedProbe(
             profileName: options.profileName,
             text: text,
             windowSeconds: options.windowSeconds,
+            stateRootURL: stateRootURL(options: options),
         )
 
         print("profile_name: \(options.profileName)")
-        if let profileRoot = options.profileRoot {
-            print("profile_root: \(profileRoot)")
+        if let stateRoot = options.stateRoot {
+            print("state_root: \(stateRoot)")
         }
         print("text_characters: \(text.count)")
         print("text_words: \(text.split(whereSeparator: \.isWhitespace).count)")
@@ -366,7 +361,7 @@ struct SpeakSwiftlyTestingMain {
             toolName: "volume-probe",
             sourceSurface: "retained-file",
             profileName: options.profileName,
-            profileRoot: options.profileRoot,
+            stateRoot: options.stateRoot,
             textCharacters: text.count,
             textWords: text.split(whereSeparator: \.isWhitespace).count,
             textFingerprint: fingerprint(text),
@@ -378,12 +373,8 @@ struct SpeakSwiftlyTestingMain {
     }
 
     static func runCreateDesignProfile(options: CreateDesignProfileOptions) async throws {
-        if let profileRoot = options.profileRoot {
-            setenv(profileRootOverrideEnvironmentVariable, profileRoot, 1)
-        }
-
         let vibe = try parseVibe(options.vibe)
-        let runtime = await SpeakSwiftly.liftoff()
+        let runtime = await SpeakSwiftly.liftoff(stateRootURL: stateRootURL(options: options))
         await runtime.start()
         let handle = await runtime.voices.create(
             design: options.profileName,
@@ -398,22 +389,18 @@ struct SpeakSwiftlyTestingMain {
         print("source_text: \(options.sourceText)")
         print("voice_description: \(options.voiceDescription)")
         print("vibe: \(vibe.rawValue)")
-        if let profileRoot = options.profileRoot {
-            print("profile_root: \(profileRoot)")
+        if let stateRoot = options.stateRoot {
+            print("state_root: \(stateRoot)")
         }
     }
 
     static func runCompareVolume(options: VolumeProbeOptions) async throws {
-        if let profileRoot = options.profileRoot {
-            setenv(profileRootOverrideEnvironmentVariable, profileRoot, 1)
-        }
-
         let text = try loadVolumeProbeText(options: options)
         let comparison = try await compareVolume(options: options, text: text)
 
         print("profile_name: \(options.profileName)")
-        if let profileRoot = options.profileRoot {
-            print("profile_root: \(profileRoot)")
+        if let stateRoot = options.stateRoot {
+            print("state_root: \(stateRoot)")
         }
         print("text_characters: \(text.count)")
         print("text_words: \(text.split(whereSeparator: \.isWhitespace).count)")
@@ -456,7 +443,7 @@ struct SpeakSwiftlyTestingMain {
             schemaVersion: 1,
             toolName: "compare-volume",
             profileName: options.profileName,
-            profileRoot: options.profileRoot,
+            stateRoot: options.stateRoot,
             textCharacters: text.count,
             textWords: text.split(whereSeparator: \.isWhitespace).count,
             textFingerprint: fingerprint(text),
@@ -547,8 +534,9 @@ struct SpeakSwiftlyTestingMain {
         profileName: String,
         text: String,
         windowSeconds: Double,
+        stateRootURL: URL?,
     ) async throws -> CompareRun {
-        let runtime = await SpeakSwiftly.liftoff()
+        let runtime = await SpeakSwiftly.liftoff(stateRootURL: stateRootURL)
         await runtime.start()
 
         let handle = await runtime.generate.audio(
@@ -577,9 +565,10 @@ struct SpeakSwiftlyTestingMain {
             profileName: options.profileName,
             text: text,
             windowSeconds: options.windowSeconds,
+            stateRootURL: stateRootURL(options: options),
         )
-        let profileRootURL = profileRootURL(options: options)
-        let profileDirectoryURL = profileRootURL
+        let stateRootURL = resolvedStateRootURL(options: options)
+        let profileDirectoryURL = stateRootURL
             .appendingPathComponent("profiles", isDirectory: true)
             .appendingPathComponent(options.profileName, isDirectory: true)
         let manifest = try loadProfileManifest(from: profileDirectoryURL)
@@ -720,13 +709,21 @@ struct SpeakSwiftlyTestingMain {
         )
     }
 
-    static func profileRootURL(options: VolumeProbeOptions) -> URL {
-        if let profileRoot = options.profileRoot {
-            return URL(fileURLWithPath: profileRoot, isDirectory: true)
+    static func resolvedStateRootURL(options: VolumeProbeOptions) -> URL {
+        if let stateRoot = options.stateRoot {
+            return URL(fileURLWithPath: stateRoot, isDirectory: true)
         }
 
         return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("SpeakSwiftly", isDirectory: true)
+    }
+
+    static func stateRootURL(options: CreateDesignProfileOptions) -> URL? {
+        options.stateRoot.map { URL(fileURLWithPath: $0, isDirectory: true) }
+    }
+
+    static func stateRootURL(options: VolumeProbeOptions) -> URL? {
+        options.stateRoot.map { URL(fileURLWithPath: $0, isDirectory: true) }
     }
 
     static func loadProfileManifest(from profileDirectoryURL: URL) throws -> ProbeProfileManifest {
@@ -979,9 +976,9 @@ extension SpeakSwiftlyTestingMain {
               swift run SpeakSwiftlyTesting resources
               swift run SpeakSwiftlyTesting status
               swift run SpeakSwiftlyTesting smoke
-              swift run SpeakSwiftlyTesting create-design-profile --profile NAME --voice DESCRIPTION [--text SOURCE] [--vibe femme|masc|neutral] [--profile-root PATH]
-              swift run SpeakSwiftlyTesting volume-probe [--profile NAME] [--profile-root PATH] [--text-file PATH] [--repeat COUNT] [--window-seconds SECONDS]
-              swift run SpeakSwiftlyTesting compare-volume [--profile NAME] [--profile-root PATH] [--text-file PATH] [--repeat COUNT] [--window-seconds SECONDS] [--matched-duration refuse|trim-to-shorter]
+              swift run SpeakSwiftlyTesting create-design-profile --profile NAME --voice DESCRIPTION [--text SOURCE] [--vibe femme|masc|neutral] [--state-root PATH]
+              swift run SpeakSwiftlyTesting volume-probe [--profile NAME] [--state-root PATH] [--text-file PATH] [--repeat COUNT] [--window-seconds SECONDS]
+              swift run SpeakSwiftlyTesting compare-volume [--profile NAME] [--state-root PATH] [--text-file PATH] [--repeat COUNT] [--window-seconds SECONDS] [--matched-duration refuse|trim-to-shorter]
             """
         }
     }

--- a/Sources/SpeakSwiftlyTool/SpeakSwiftlyTool.swift
+++ b/Sources/SpeakSwiftlyTool/SpeakSwiftlyTool.swift
@@ -5,8 +5,33 @@ import SpeakSwiftly
 
 @main
 enum SpeakSwiftlyTool {
+    private enum ArgumentError: LocalizedError {
+        case unknown(String)
+        case missingValue(String)
+
+        var errorDescription: String? {
+            switch self {
+                case let .unknown(argument):
+                    "Unknown argument '\(argument)'. Supported options: --state-root PATH."
+                case let .missingValue(option):
+                    "Missing value for \(option)."
+            }
+        }
+    }
+
     static func main() async {
-        let runtime = await SpeakSwiftly.liftoff()
+        do {
+            let stateRootURL = try parseStateRootURL(arguments: Array(CommandLine.arguments.dropFirst()))
+            let runtime = await SpeakSwiftly.liftoff(stateRootURL: stateRootURL)
+            await run(runtime: runtime)
+        } catch {
+            let message = "SpeakSwiftlyTool could not start because its launch arguments were invalid. \(error.localizedDescription)\n"
+            try? FileHandle.standardError.write(contentsOf: Data(message.utf8))
+            exit(2)
+        }
+    }
+
+    private static func run(runtime: SpeakSwiftly.Runtime) async {
         await runtime.start()
 
         do {
@@ -42,5 +67,40 @@ enum SpeakSwiftlyTool {
         }
 
         await runtime.shutdown()
+    }
+
+    private static func parseStateRootURL(arguments: [String]) throws -> URL? {
+        guard !arguments.isEmpty else { return nil }
+
+        var stateRootURL: URL?
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+                case "--state-root":
+                    index += 1
+                    stateRootURL = try URL(
+                        fileURLWithPath: requireOptionValue(arguments, index: index, for: argument),
+                        isDirectory: true,
+                    )
+                default:
+                    throw ArgumentError.unknown(argument)
+            }
+            index += 1
+        }
+
+        return stateRootURL
+    }
+
+    private static func requireOptionValue(
+        _ arguments: [String],
+        index: Int,
+        for option: String,
+    ) throws -> String {
+        guard index < arguments.count else {
+            throw ArgumentError.missingValue(option)
+        }
+
+        return arguments[index]
     }
 }

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -147,11 +147,11 @@ import Darwin
     #expect(await (normalizer.persistence.url())?.lastPathComponent == "text-profiles.json")
 }
 
-@Test func `public normalizer default persistence honors profile root override`() async throws {
+@Test func `public normalizer default persistence honors state root override`() async throws {
     let overrideRoot = makeTempDirectoryURL()
     defer { try? FileManager.default.removeItem(at: overrideRoot) }
 
-    let environmentVariable = ProfileStore.profileRootOverrideEnvironmentVariable
+    let environmentVariable = ProfileStore.runtimeStateRootOverrideEnvironmentVariable
     let previousValue = ProcessInfo.processInfo.environment[environmentVariable]
     setenv(environmentVariable, overrideRoot.path, 1)
     defer {
@@ -168,28 +168,30 @@ import Darwin
     #expect(await normalizer.persistence.url()?.standardizedFileURL == expectedURL.standardizedFileURL)
 }
 
-@Test func `liftoff normalizer persistence matches the default text profile path`() async {
+@Test func `liftoff state root parameter drives runtime persistence without environment`() async {
     let overrideRoot = makeTempDirectoryURL()
     defer { try? FileManager.default.removeItem(at: overrideRoot) }
 
-    let environmentVariable = ProfileStore.profileRootOverrideEnvironmentVariable
-    let previousValue = ProcessInfo.processInfo.environment[environmentVariable]
-    setenv(environmentVariable, overrideRoot.path, 1)
-    defer {
-        if let previousValue {
-            setenv(environmentVariable, previousValue, 1)
-        } else {
-            unsetenv(environmentVariable)
-        }
-    }
-
-    let runtime = await SpeakSwiftly.liftoff()
+    let runtime = await SpeakSwiftly.liftoff(stateRootURL: overrideRoot)
     let expectedURL = ProfileStore.defaultTextProfilesURL(
         fileManager: .default,
-        profileRootOverride: overrideRoot.path,
+        stateRootOverride: overrideRoot.path,
     )
 
     #expect(await (runtime.normalizer.persistence.url())?.lastPathComponent == expectedURL.lastPathComponent)
+}
+
+@Test func `liftoff state root parameter preserves persisted configuration`() async throws {
+    let stateRoot = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    try SpeakSwiftly.Configuration(speechBackend: .marvis).saveDefault(
+        stateRootOverride: stateRoot.path,
+    )
+
+    let runtime = await SpeakSwiftly.liftoff(stateRootURL: stateRoot)
+
+    #expect(await runtime.speechBackend == .marvis)
 }
 
 // MARK: - Runtime Helpers
@@ -263,6 +265,9 @@ import Darwin
     }
     let liftoffWithConfiguration: @Sendable (SpeakSwiftly.Configuration) async -> SpeakSwiftly.Runtime = { configuration in
         await SpeakSwiftly.liftoff(configuration: configuration)
+    }
+    let liftoffWithStateRoot: @Sendable (URL) async -> SpeakSwiftly.Runtime = { stateRootURL in
+        await SpeakSwiftly.liftoff(stateRootURL: stateRootURL)
     }
     let activeStyle: @Sendable (SpeakSwiftly.Normalizer.Style) async -> TextForSpeech.BuiltInProfileStyle = { style in
         await style.getActive()
@@ -497,6 +502,7 @@ import Darwin
     _ = makeNormalizer
     _ = liftoffWithDefaults
     _ = liftoffWithConfiguration
+    _ = liftoffWithStateRoot
     _ = activeStyle
     _ = styleOptions
     _ = setActiveStyle

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
@@ -414,7 +414,7 @@ enum BenchmarkHarness {
         let normalizer = try SpeakSwiftly.Normalizer(
             persistenceURL: ProfileStore.defaultTextProfilesURL(
                 fileManager: dependencies.fileManager,
-                profileRootOverride: profileRootURL.path,
+                stateRootOverride: profileRootURL.path,
             ),
         )
         let playbackController = await PlaybackController(driver: dependencies.makePlaybackController())

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
@@ -766,7 +766,6 @@ final class JSONLineRecorder: @unchecked Sendable {
 final class WorkerProcess: @unchecked Sendable {
     private enum Environment {
         static let dyldFrameworkPath = "DYLD_FRAMEWORK_PATH"
-        static let profileRoot = "SPEAKSWIFTLY_PROFILE_ROOT"
         static let silentPlayback = "SPEAKSWIFTLY_SILENT_PLAYBACK"
         static let playbackTrace = "SPEAKSWIFTLY_PLAYBACK_TRACE"
         static let speechBackend = "SPEAKSWIFTLY_SPEECH_BACKEND"
@@ -795,7 +794,7 @@ final class WorkerProcess: @unchecked Sendable {
         let packageRootURL = try Self.packageRootURL()
         let buildConfiguration = "Debug"
         let runtimeConfiguration = configuration
-        let profileRootOverrideURL = Self.workerProfileRootOverrideURL(for: profileRootURL)
+        let workerStateRootURL = Self.workerStateRootURL(for: profileRootURL)
         try Self.publishWorkerRuntime(packageRootURL: packageRootURL, configuration: buildConfiguration)
 
         process = Process()
@@ -823,7 +822,7 @@ final class WorkerProcess: @unchecked Sendable {
             try runtimeConfiguration.save(
                 to: SpeakSwiftly.Configuration.defaultPersistenceURL(
                     fileManager: .default,
-                    profileRootOverride: profileRootOverrideURL.path,
+                    stateRootOverride: workerStateRootURL.path,
                 ),
             )
         }
@@ -833,10 +832,10 @@ final class WorkerProcess: @unchecked Sendable {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
         process.currentDirectoryURL = executableURL.deletingLastPathComponent()
+        process.arguments = ["--state-root", workerStateRootURL.path]
 
         var environment = ProcessInfo.processInfo.environment
         environment[Environment.dyldFrameworkPath] = executableURL.deletingLastPathComponent().path
-        environment[Environment.profileRoot] = profileRootOverrideURL.path
         if silentPlayback, !speakSwiftlyAudibleE2ETestsEnabled() {
             environment[Environment.silentPlayback] = "1"
         }
@@ -874,14 +873,14 @@ final class WorkerProcess: @unchecked Sendable {
         stderrTask.cancel()
     }
 
-    private static func workerProfileRootOverrideURL(for profileRootURL: URL) -> URL {
+    private static func workerStateRootURL(for profileRootURL: URL) -> URL {
         guard profileRootURL.lastPathComponent == ProfileStore.profilesDirectoryName else {
             return profileRootURL
         }
 
         // The E2E sandbox hands WorkerProcess the actual profile-store root.
-        // The runtime override env var, however, expects the broader state root
-        // so it can derive profiles/, configuration.json, and text-profiles.json
+        // The worker launch option expects the broader state root so it can
+        // derive profiles/, configuration.json, and text-profiles.json
         // consistently without nesting profiles/profiles/.
         return profileRootURL.deletingLastPathComponent()
     }

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeQueueingTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeQueueingTests.swift
@@ -361,15 +361,15 @@ import TextForSpeech
     let rootURL = makeTempDirectoryURL()
     defer { try? FileManager.default.removeItem(at: rootURL) }
 
-    let profileRoot = rootURL.appendingPathComponent("profiles", isDirectory: true)
+    let stateRoot = rootURL
     let dependencies = makeSpeechBackendResolutionDependencies()
     try SpeakSwiftly.Configuration(speechBackend: .qwen3).saveDefault(
-        profileRootOverride: profileRoot.path,
+        stateRootOverride: stateRoot.path,
     )
 
     let resolved = WorkerRuntime.resolvedSpeechBackend(
         dependencies: dependencies,
-        environment: ["SPEAKSWIFTLY_PROFILE_ROOT": profileRoot.path],
+        environment: [ProfileStore.runtimeStateRootOverrideEnvironmentVariable: stateRoot.path],
         configuration: SpeakSwiftly.Configuration(speechBackend: .marvis),
     )
 
@@ -380,16 +380,16 @@ import TextForSpeech
     let rootURL = makeTempDirectoryURL()
     defer { try? FileManager.default.removeItem(at: rootURL) }
 
-    let profileRoot = rootURL.appendingPathComponent("profiles", isDirectory: true)
+    let stateRoot = rootURL
     let dependencies = makeSpeechBackendResolutionDependencies()
     try SpeakSwiftly.Configuration(speechBackend: .qwen3).saveDefault(
-        profileRootOverride: profileRoot.path,
+        stateRootOverride: stateRoot.path,
     )
 
     let resolved = WorkerRuntime.resolvedSpeechBackend(
         dependencies: dependencies,
         environment: [
-            "SPEAKSWIFTLY_PROFILE_ROOT": profileRoot.path,
+            ProfileStore.runtimeStateRootOverrideEnvironmentVariable: stateRoot.path,
             SpeakSwiftly.SpeechBackend.environmentVariable: SpeakSwiftly.SpeechBackend.marvis.rawValue,
         ],
         configuration: nil,

--- a/Tests/SpeakSwiftlyTests/Storage/ProfileStoreTests.swift
+++ b/Tests/SpeakSwiftlyTests/Storage/ProfileStoreTests.swift
@@ -263,23 +263,23 @@ import Testing
     }
 }
 
-@Test func `profile root override accepts a base directory path`() {
+@Test func `state root override accepts a base directory path`() {
     let overrideRoot = URL(fileURLWithPath: "/tmp/speakswiftly-override-root", isDirectory: true)
 
-    #expect(ProfileStore.defaultRootURL(overridePath: overrideRoot.path) == overrideRoot.appendingPathComponent("profiles", isDirectory: true))
-    #expect(ProfileStore.defaultConfigurationURL(profileRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("configuration.json", isDirectory: false))
-    #expect(ProfileStore.defaultTextProfilesURL(profileRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("text-profiles.json", isDirectory: false))
+    #expect(ProfileStore.defaultRootURL(stateRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("profiles", isDirectory: true))
+    #expect(ProfileStore.defaultConfigurationURL(stateRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("configuration.json", isDirectory: false))
+    #expect(ProfileStore.defaultTextProfilesURL(stateRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("text-profiles.json", isDirectory: false))
 }
 
-@Test func `profile root override preserves a literal base directory named profiles`() {
+@Test func `state root override preserves a literal base directory named profiles`() {
     let overrideRoot = URL(fileURLWithPath: "/tmp/speakswiftly-override-root/profiles", isDirectory: true)
 
-    #expect(ProfileStore.defaultRootURL(overridePath: overrideRoot.path) == overrideRoot.appendingPathComponent("profiles", isDirectory: true))
-    #expect(ProfileStore.defaultConfigurationURL(profileRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("configuration.json", isDirectory: false))
-    #expect(ProfileStore.defaultTextProfilesURL(profileRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("text-profiles.json", isDirectory: false))
+    #expect(ProfileStore.defaultRootURL(stateRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("profiles", isDirectory: true))
+    #expect(ProfileStore.defaultConfigurationURL(stateRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("configuration.json", isDirectory: false))
+    #expect(ProfileStore.defaultTextProfilesURL(stateRootOverride: overrideRoot.path) == overrideRoot.appendingPathComponent("text-profiles.json", isDirectory: false))
 }
 
-@Test func `profile root override preserves compatibility with an existing legacy profiles directory path`() throws {
+@Test func `state root override preserves compatibility with an existing legacy profiles directory path`() throws {
     let fileManager = FileManager.default
     let overrideRoot = makeTempDirectoryURL()
     defer { try? fileManager.removeItem(at: overrideRoot) }
@@ -288,12 +288,12 @@ import Testing
     try fileManager.createDirectory(at: legacyProfilesURL, withIntermediateDirectories: true)
     try Data("{}".utf8).write(to: overrideRoot.appendingPathComponent(ProfileStore.configurationFileName))
 
-    #expect(ProfileStore.defaultRootURL(fileManager: fileManager, overridePath: legacyProfilesURL.path) == legacyProfilesURL)
-    #expect(ProfileStore.defaultConfigurationURL(fileManager: fileManager, profileRootOverride: legacyProfilesURL.path) == overrideRoot.appendingPathComponent("configuration.json", isDirectory: false))
-    #expect(ProfileStore.defaultTextProfilesURL(fileManager: fileManager, profileRootOverride: legacyProfilesURL.path) == overrideRoot.appendingPathComponent("text-profiles.json", isDirectory: false))
+    #expect(ProfileStore.defaultRootURL(fileManager: fileManager, stateRootOverride: legacyProfilesURL.path) == legacyProfilesURL)
+    #expect(ProfileStore.defaultConfigurationURL(fileManager: fileManager, stateRootOverride: legacyProfilesURL.path) == overrideRoot.appendingPathComponent("configuration.json", isDirectory: false))
+    #expect(ProfileStore.defaultTextProfilesURL(fileManager: fileManager, stateRootOverride: legacyProfilesURL.path) == overrideRoot.appendingPathComponent("text-profiles.json", isDirectory: false))
 }
 
-@Test func `profile root override preserves compatibility with a profiles-only legacy store`() throws {
+@Test func `state root override preserves compatibility with a profiles-only legacy store`() throws {
     let fileManager = FileManager.default
     let overrideRoot = makeTempDirectoryURL()
     defer { try? fileManager.removeItem(at: overrideRoot) }
@@ -310,9 +310,34 @@ import Testing
         canonicalAudioData: Data([0x01, 0x02]),
     )
 
-    #expect(ProfileStore.defaultRootURL(fileManager: fileManager, overridePath: legacyProfilesURL.path) == legacyProfilesURL)
-    #expect(ProfileStore.defaultConfigurationURL(fileManager: fileManager, profileRootOverride: legacyProfilesURL.path) == overrideRoot.appendingPathComponent("configuration.json", isDirectory: false))
-    #expect(ProfileStore.defaultTextProfilesURL(fileManager: fileManager, profileRootOverride: legacyProfilesURL.path) == overrideRoot.appendingPathComponent("text-profiles.json", isDirectory: false))
+    #expect(ProfileStore.defaultRootURL(fileManager: fileManager, stateRootOverride: legacyProfilesURL.path) == legacyProfilesURL)
+    #expect(ProfileStore.defaultConfigurationURL(fileManager: fileManager, stateRootOverride: legacyProfilesURL.path) == overrideRoot.appendingPathComponent("configuration.json", isDirectory: false))
+    #expect(ProfileStore.defaultTextProfilesURL(fileManager: fileManager, stateRootOverride: legacyProfilesURL.path) == overrideRoot.appendingPathComponent("text-profiles.json", isDirectory: false))
+}
+
+@Test func `runtime state root environment override supersedes deprecated profile root alias`() {
+    let environment = [
+        ProfileStore.runtimeStateRootOverrideEnvironmentVariable: "/tmp/speakswiftly-state-root",
+        ProfileStore.profileRootOverrideEnvironmentVariable: "/tmp/speakswiftly-profile-root",
+    ]
+
+    #expect(ProfileStore.runtimeStateRootOverride(in: environment) == ProfileStore.RuntimeStateRootOverride(
+        path: "/tmp/speakswiftly-state-root",
+        source: .runtimeStateRoot,
+    ))
+    #expect(ProfileStore.runtimeStateRootOverridePath(in: environment) == "/tmp/speakswiftly-state-root")
+}
+
+@Test func `deprecated profile root environment alias remains compatible`() {
+    let environment = [
+        ProfileStore.profileRootOverrideEnvironmentVariable: "/tmp/speakswiftly-profile-root",
+    ]
+
+    #expect(ProfileStore.runtimeStateRootOverride(in: environment) == ProfileStore.RuntimeStateRootOverride(
+        path: "/tmp/speakswiftly-profile-root",
+        source: .deprecatedProfileRoot,
+    ))
+    #expect(ProfileStore.runtimeStateRootOverridePath(in: environment) == "/tmp/speakswiftly-profile-root")
 }
 
 // MARK: - Listing and Validation


### PR DESCRIPTION
## Summary

- keep Application Support as the default runtime-state location
- add typed `SpeakSwiftly.liftoff(stateRootURL:)` for Swift callers that need isolated persisted state
- add `SpeakSwiftlyTool --state-root PATH` and update E2E/test harnesses away from `SPEAKSWIFTLY_PROFILE_ROOT`
- keep `SPEAKSWIFTLY_STATE_ROOT` as the process-level fallback and `SPEAKSWIFTLY_PROFILE_ROOT` only as a deprecated compatibility alias
- update README, DocC, CONTRIBUTING, ROADMAP, and tests for the state-root vocabulary

Closes #21.

## Validation

- `swift build`
- `swift test`
- `bash scripts/repo-maintenance/validate-all.sh`
- commit hook reran SwiftFormat and `bash scripts/repo-maintenance/validate-all.sh`
