### PR TITLE
runtime: expose storage paths in overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,12 +76,17 @@ Resident runtime state is now explicitly observable as:
 - `speech_backend`
 - `resident_state`
 - `stage`
+- `runtime_overview.storage.state_root_path`
+- `runtime_overview.storage.profile_store_root_path`
+- `runtime_overview.storage.configuration_path`
+- `runtime_overview.storage.text_profiles_path`
 
 That split matters:
 
 - `speech_backend` says which backend family is selected
 - `resident_state` says whether resident models are loaded, warming, unloaded, or failed
 - `stage` is the worker-status event label currently emitted on the wire
+- `runtime_overview.storage` says which persisted state family this runtime owns, so parent processes can verify service health and storage isolation without scraping logs
 
 ## Naming Conventions
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,7 +120,7 @@ In Progress
 ### Tickets
 
 - [ ] Revisit `output_path` resolution so relative paths cannot silently depend on the worker launch directory.
-- [ ] Extend the existing `get_runtime_overview` / `runtime.overview()` inspection story where parent processes still need service-health fields such as profile root, runtime-state root, or richer resident state.
+- [x] Extend the existing `get_runtime_overview` / `runtime.overview()` inspection story so parent processes can inspect runtime-state, profile-store, configuration, text-profile, generated-file, and generation-job paths without log scraping.
 - [ ] Add a runtime-level playback and overview event stream so hosts can keep playback state current without opportunistic polling. ([#45](https://github.com/gaelic-ghost/SpeakSwiftly/issues/45))
 - [x] Add native state-root startup controls so Application Support stays the default while Swift callers use `stateRootURL`, worker hosts use `--state-root`, and `SPEAKSWIFTLY_PROFILE_ROOT` remains only as a deprecated compatibility alias. ([#21](https://github.com/gaelic-ghost/SpeakSwiftly/issues/21))
 - [ ] Make profile listing resilient to stray files, partial directories, and damaged entries without poisoning the full operation when recovery is possible.

--- a/Sources/SpeakSwiftly/Runtime/WorkerResponses+RuntimeOverview.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerResponses+RuntimeOverview.swift
@@ -68,6 +68,7 @@ public extension SpeakSwiftly {
     struct RuntimeOverview: Encodable, Sendable, Equatable {
         public let status: StatusEvent?
         public let speechBackend: SpeechBackend
+        public let storage: RuntimeStorageSnapshot
         public let generationQueue: QueueSnapshot
         public let playbackQueue: QueueSnapshot
         public let playbackState: PlaybackStateSnapshot
@@ -75,6 +76,7 @@ public extension SpeakSwiftly {
         enum CodingKeys: String, CodingKey {
             case status
             case speechBackend = "speech_backend"
+            case storage
             case generationQueue = "generation_queue"
             case playbackQueue = "playback_queue"
             case playbackState = "playback_state"
@@ -83,15 +85,51 @@ public extension SpeakSwiftly {
         public init(
             status: StatusEvent?,
             speechBackend: SpeechBackend,
+            storage: RuntimeStorageSnapshot,
             generationQueue: QueueSnapshot,
             playbackQueue: QueueSnapshot,
             playbackState: PlaybackStateSnapshot,
         ) {
             self.status = status
             self.speechBackend = speechBackend
+            self.storage = storage
             self.generationQueue = generationQueue
             self.playbackQueue = playbackQueue
             self.playbackState = playbackState
+        }
+    }
+
+    struct RuntimeStorageSnapshot: Codable, Sendable, Equatable {
+        public let stateRootPath: String
+        public let profileStoreRootPath: String
+        public let configurationPath: String
+        public let textProfilesPath: String
+        public let generatedFilesRootPath: String
+        public let generationJobsRootPath: String
+
+        enum CodingKeys: String, CodingKey {
+            case stateRootPath = "state_root_path"
+            case profileStoreRootPath = "profile_store_root_path"
+            case configurationPath = "configuration_path"
+            case textProfilesPath = "text_profiles_path"
+            case generatedFilesRootPath = "generated_files_root_path"
+            case generationJobsRootPath = "generation_jobs_root_path"
+        }
+
+        public init(
+            stateRootPath: String,
+            profileStoreRootPath: String,
+            configurationPath: String,
+            textProfilesPath: String,
+            generatedFilesRootPath: String,
+            generationJobsRootPath: String,
+        ) {
+            self.stateRootPath = stateRootPath
+            self.profileStoreRootPath = profileStoreRootPath
+            self.configurationPath = configurationPath
+            self.textProfilesPath = textProfilesPath
+            self.generatedFilesRootPath = generatedFilesRootPath
+            self.generationJobsRootPath = generationJobsRootPath
         }
     }
 

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Emission.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Emission.swift
@@ -201,9 +201,26 @@ extension SpeakSwiftly.Runtime {
         await SpeakSwiftly.RuntimeOverview(
             status: currentStatusSnapshot(),
             speechBackend: speechBackend,
+            storage: runtimeStorageSnapshot(),
             generationQueue: queueSnapshot(for: .generation),
             playbackQueue: queueSnapshot(for: .playback),
             playbackState: playbackController.stateSnapshot(),
+        )
+    }
+
+    func runtimeStorageSnapshot() -> SpeakSwiftly.RuntimeStorageSnapshot {
+        let stateRootURL = profileStore.stateRootURL.standardizedFileURL
+        return SpeakSwiftly.RuntimeStorageSnapshot(
+            stateRootPath: stateRootURL.path,
+            profileStoreRootPath: profileStore.rootURL.standardizedFileURL.path,
+            configurationPath: stateRootURL
+                .appendingPathComponent(ProfileStore.configurationFileName, isDirectory: false)
+                .path,
+            textProfilesPath: stateRootURL
+                .appendingPathComponent(ProfileStore.textProfilesFileName, isDirectory: false)
+                .path,
+            generatedFilesRootPath: generatedFileStore.rootURL.standardizedFileURL.path,
+            generationJobsRootPath: generationJobStore.rootURL.standardizedFileURL.path,
         )
     }
 

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
@@ -87,7 +87,7 @@ for try await update in runtime.updates(for: handle.id) {
 }
 ```
 
-When you want the broader runtime view instead of one request, use ``SpeakSwiftly/Player/state()`` for playback and ``SpeakSwiftly/Jobs/list()`` for retained generation-job snapshots.
+When you want the broader runtime view instead of one request, use ``SpeakSwiftly/Runtime/overview()`` for a service-health snapshot that includes resident state, queue state, playback telemetry, and resolved storage paths. Use ``SpeakSwiftly/Player/state()`` for the smaller playback-only view and ``SpeakSwiftly/Jobs/list()`` for retained generation-job snapshots.
 
 ## Where To Look Next
 

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/WorkerContract.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/WorkerContract.md
@@ -41,6 +41,7 @@ Representative operations include:
 - `generate_batch` for grouped retained artifacts.
 - `create_voice_profile_from_description`, `create_voice_profile_from_audio`, `list_voice_profiles`, and related voice-management operations.
 - `get_status`, `reload_models`, and `unload_models` for runtime control.
+- `get_runtime_overview` for one service-health snapshot that includes resident state, queue state, playback telemetry, and storage paths.
 - `list_generation_queue`, `clear_generation_queue`, and `cancel_generation` for generation-queue inspection and control.
 - `list_playback_queue`, `clear_playback_queue`, and `cancel_playback` for playback-queue inspection and control.
 
@@ -58,6 +59,8 @@ The worker emits both status events and request-scoped events. For example:
 
 Status events describe the shared runtime. Request-scoped events and terminal payloads describe one submitted operation.
 During startup warmup, queued work uses `waiting_for_resident_model`. After an explicit unload, parked work uses `waiting_for_resident_models`.
+
+`get_runtime_overview` returns a `runtime_overview.storage` object for parent processes that need to verify which persisted state they are supervising. The storage snapshot reports the resolved state root, profile-store root, persisted configuration path, text-profile archive path, generated-file root, and generation-job root. By default, those paths live under the platform Application Support directory; `stateRootURL` and `--state-root` intentionally move the whole storage family together.
 
 ## Choose Between Swift And JSONL
 

--- a/Sources/SpeakSwiftly/Storage/ProfileStore.swift
+++ b/Sources/SpeakSwiftly/Storage/ProfileStore.swift
@@ -35,6 +35,14 @@ struct ProfileStore: @unchecked Sendable {
     let encoder: JSONEncoder
     let decoder: JSONDecoder
 
+    var stateRootURL: URL {
+        guard rootURL.lastPathComponent == Self.profilesDirectoryName else {
+            return rootURL
+        }
+
+        return rootURL.deletingLastPathComponent()
+    }
+
     init(
         rootURL: URL,
         fileManager: FileManager = .default,

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -638,12 +638,26 @@ import Darwin
     let successStatus: KeyPath<SpeakSwiftly.Success, SpeakSwiftly.StatusEvent?> = \.status
     let successSpeechBackend: KeyPath<SpeakSwiftly.Success, SpeakSwiftly.SpeechBackend?> = \.speechBackend
     let successActiveRequests: KeyPath<SpeakSwiftly.Success, [SpeakSwiftly.ActiveRequest]?> = \.activeRequests
+    let overviewStorage: KeyPath<SpeakSwiftly.RuntimeOverview, SpeakSwiftly.RuntimeStorageSnapshot> = \.storage
+    let stateRootPath: KeyPath<SpeakSwiftly.RuntimeStorageSnapshot, String> = \.stateRootPath
+    let profileStoreRootPath: KeyPath<SpeakSwiftly.RuntimeStorageSnapshot, String> = \.profileStoreRootPath
+    let configurationPath: KeyPath<SpeakSwiftly.RuntimeStorageSnapshot, String> = \.configurationPath
+    let textProfilesPath: KeyPath<SpeakSwiftly.RuntimeStorageSnapshot, String> = \.textProfilesPath
+    let generatedFilesRootPath: KeyPath<SpeakSwiftly.RuntimeStorageSnapshot, String> = \.generatedFilesRootPath
+    let generationJobsRootPath: KeyPath<SpeakSwiftly.RuntimeStorageSnapshot, String> = \.generationJobsRootPath
 
     _ = speechBackend
     _ = residentState
     _ = successStatus
     _ = successSpeechBackend
     _ = successActiveRequests
+    _ = overviewStorage
+    _ = stateRootPath
+    _ = profileStoreRootPath
+    _ = configurationPath
+    _ = textProfilesPath
+    _ = generatedFilesRootPath
+    _ = generationJobsRootPath
 }
 
 @Test func `public text normalization surface exposes profile metadata`() {

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
@@ -629,6 +629,14 @@ import TextForSpeech
             runtimeOverview: SpeakSwiftly.RuntimeOverview(
                 status: SpeakSwiftly.StatusEvent(stage: .residentModelReady, residentState: .ready, speechBackend: .qwen3),
                 speechBackend: .qwen3,
+                storage: SpeakSwiftly.RuntimeStorageSnapshot(
+                    stateRootPath: "/tmp/SpeakSwiftly",
+                    profileStoreRootPath: "/tmp/SpeakSwiftly/profiles",
+                    configurationPath: "/tmp/SpeakSwiftly/configuration.json",
+                    textProfilesPath: "/tmp/SpeakSwiftly/text-profiles.json",
+                    generatedFilesRootPath: "/tmp/SpeakSwiftly/profiles/generated-files",
+                    generationJobsRootPath: "/tmp/SpeakSwiftly/profiles/generation-jobs",
+                ),
                 generationQueue: SpeakSwiftly.QueueSnapshot(
                     queueType: "generation",
                     activeRequest: SpeakSwiftly.ActiveRequest(id: "req-active", kind: .generateSpeech, voiceProfile: "default-femme", requestContext: nil),
@@ -668,6 +676,8 @@ import TextForSpeech
     #expect((success["playback_state"] as? [String: Any])?["is_stable_for_concurrent_generation"] as? Bool == true)
     #expect((success["playback_state"] as? [String: Any])?["stable_buffered_audio_ms"] as? Int == 840)
     #expect((success["runtime_overview"] as? [String: Any])?["speech_backend"] as? String == "qwen3")
+    #expect(((success["runtime_overview"] as? [String: Any])?["storage"] as? [String: Any])?["state_root_path"] as? String == "/tmp/SpeakSwiftly")
+    #expect(((success["runtime_overview"] as? [String: Any])?["storage"] as? [String: Any])?["profile_store_root_path"] as? String == "/tmp/SpeakSwiftly/profiles")
     #expect((((success["runtime_overview"] as? [String: Any])?["generation_queue"] as? [String: Any])?["active_requests"] as? [[String: Any]])?.count == 2)
     #expect((success["status"] as? [String: Any])?["resident_state"] as? String == "ready")
     #expect((success["status"] as? [String: Any])?["speech_backend"] as? String == "qwen3")

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
@@ -228,6 +228,7 @@ import TextForSpeech
                 $0["id"] as? String == overviewID,
                 $0["ok"] as? Bool == true,
                 let overview = $0["runtime_overview"] as? [String: Any],
+                let storage = overview["storage"] as? [String: Any],
                 let generationQueue = overview["generation_queue"] as? [String: Any],
                 let activeRequests = generationQueue["active_requests"] as? [[String: Any]],
                 let queuedRequests = generationQueue["queue"] as? [[String: Any]],
@@ -240,6 +241,12 @@ import TextForSpeech
             let activeIDs = Set(activeRequests.compactMap { $0["id"] as? String })
             let queuedIDs = Set(queuedRequests.compactMap { $0["id"] as? String })
             return overview["speech_backend"] as? String == "marvis"
+                && storage["state_root_path"] as? String == storeRoot.standardizedFileURL.path
+                && storage["profile_store_root_path"] as? String == storeRoot.standardizedFileURL.path
+                && storage["configuration_path"] as? String == storeRoot.appendingPathComponent("configuration.json").path
+                && storage["text_profiles_path"] as? String == storeRoot.appendingPathComponent("text-profiles.json").path
+                && storage["generated_files_root_path"] as? String == storeRoot.appendingPathComponent("generated-files").path
+                && storage["generation_jobs_root_path"] as? String == storeRoot.appendingPathComponent("generation-jobs").path
                 && activeIDs == Set([firstHandle.id])
                 && queuedIDs == Set([secondHandle.id])
                 && playbackState["state"] as? String == "playing"


### PR DESCRIPTION
## Summary

- add `runtime_overview.storage` as the service-health storage snapshot
- report resolved state root, profile-store root, configuration path, text-profile archive, generated-file root, and generation-job root
- document overview storage inspection for Swift and JSONL hosts
- mark the runtime overview storage inspection roadmap item complete

## Validation

- `swift test --filter WorkerProtocolTests`
- `swift test --filter WorkerRuntimeControlSurfaceTests`
- `swift test --filter LibrarySurfaceTests`
- `swift build`
- `swift test`
- `bash scripts/repo-maintenance/validate-all.sh`
- commit hook reran SwiftFormat and `bash scripts/repo-maintenance/validate-all.sh`
