### PR TITLE
docs: record profile listing resilience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,7 @@ Default persisted configuration path:
 
 The same namespace split applies to the default profile store and `text-profiles.json`, so debug builds, local package tests, and production runs do not reuse the same local storage root unless you explicitly point them at one state root. Prefer the typed Swift `stateRootURL` startup parameter for library callers and `--state-root` for the standalone worker. `SPEAKSWIFTLY_STATE_ROOT` remains available as a process-level fallback for hosts that cannot pass startup arguments. `SPEAKSWIFTLY_PROFILE_ROOT` is a deprecated compatibility alias for the same state-root behavior.
 For compatibility, SpeakSwiftly still recognizes the older trailing `.../profiles` form when it detects an existing legacy layout with adjacent `configuration.json` or `text-profiles.json` state.
+Profile listing is deliberately tolerant of profile-root noise: `list_voice_profiles` skips stray files, partial profile directories, and unreadable manifests so one damaged or in-progress entry does not make healthy profiles disappear from the listing. Direct profile loading still reports a targeted error when the named profile exists but its manifest cannot be read.
 
 Backend resolution precedence is:
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ sh scripts/repo-maintenance/publish-runtime.sh --configuration Debug
 
 At startup the worker begins warming the resident backend and emits JSONL status events on `stdout`.
 By default, runtime state lives under the platform Application Support directory. Use `SpeakSwiftly.liftoff(stateRootURL:)` from Swift or launch the worker with `--state-root PATH` only when a host needs an isolated state root for `profiles/`, `configuration.json`, and `text-profiles.json`.
+Voice-profile listing treats each profile directory as an independent read: stray files, partial profile directories, and unreadable manifests are ignored so one damaged or in-progress entry does not hide healthy stored profiles.
 
 ### Consumer Test Harness
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,7 +123,7 @@ In Progress
 - [x] Extend the existing `get_runtime_overview` / `runtime.overview()` inspection story so parent processes can inspect runtime-state, profile-store, configuration, text-profile, generated-file, and generation-job paths without log scraping.
 - [ ] Add a runtime-level playback and overview event stream so hosts can keep playback state current without opportunistic polling. ([#45](https://github.com/gaelic-ghost/SpeakSwiftly/issues/45))
 - [x] Add native state-root startup controls so Application Support stays the default while Swift callers use `stateRootURL`, worker hosts use `--state-root`, and `SPEAKSWIFTLY_PROFILE_ROOT` remains only as a deprecated compatibility alias. ([#21](https://github.com/gaelic-ghost/SpeakSwiftly/issues/21))
-- [ ] Make profile listing resilient to stray files, partial directories, and damaged entries without poisoning the full operation when recovery is possible.
+- [x] Make profile listing resilient to stray files, partial directories, and damaged entries without poisoning the full operation when recovery is possible.
 - [ ] Add a first-class default-profile concept so downstream callers are not forced to treat names like `default-femme` as hidden conventions.
 - [ ] Persist a little more voice-profile source provenance from creation flows so rerolls, diagnostics, and later profile introspection have stable grounding.
 - [ ] Investigate whether startup-side playback preload or environment observation is still correlated with `freed pointer was not the last allocation`. ([#7](https://github.com/gaelic-ghost/SpeakSwiftly/issues/7))

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/WorkerContract.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/WorkerContract.md
@@ -47,6 +47,8 @@ Representative operations include:
 
 The broad compatibility operations `clear_queue` and `cancel_request` still exist for hosts that intentionally want to affect any queued work, but new operators should prefer the queue-specific operations when the target queue is known.
 
+`list_voice_profiles` treats profile directories independently. Stray files, partial directories, and unreadable manifests are skipped so the operation can still return healthy profiles while a separate cleanup or coordination pass deals with damaged entries.
+
 ## Read Events And Results
 
 The worker emits both status events and request-scoped events. For example:


### PR DESCRIPTION
## Summary

- document the existing tolerant `list_voice_profiles` behavior for stray files, partial directories, and unreadable manifests
- mark the narrower Milestone 9 listing-resilience ticket complete
- leave the broader Milestone 6 in-flight write/loading coordination item open for the next slice

## Validation

- `swift test --filter ProfileStoreTests`
- `swift build`
- `swift test`
- `bash scripts/repo-maintenance/validate-all.sh`
- commit hook reran SwiftFormat and `bash scripts/repo-maintenance/validate-all.sh`
