### PR TITLE
storage: coordinate profile store writes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,7 @@ Default persisted configuration path:
 The same namespace split applies to the default profile store and `text-profiles.json`, so debug builds, local package tests, and production runs do not reuse the same local storage root unless you explicitly point them at one state root. Prefer the typed Swift `stateRootURL` startup parameter for library callers and `--state-root` for the standalone worker. `SPEAKSWIFTLY_STATE_ROOT` remains available as a process-level fallback for hosts that cannot pass startup arguments. `SPEAKSWIFTLY_PROFILE_ROOT` is a deprecated compatibility alias for the same state-root behavior.
 For compatibility, SpeakSwiftly still recognizes the older trailing `.../profiles` form when it detects an existing legacy layout with adjacent `configuration.json` or `text-profiles.json` state.
 Profile listing is deliberately tolerant of profile-root noise: `list_voice_profiles` skips stray files, partial profile directories, and unreadable manifests so one damaged or in-progress entry does not make healthy profiles disappear from the listing. Direct profile loading still reports a targeted error when the named profile exists but its manifest cannot be read.
+Profile writes use a per-profile-root advisory lock file before creating, removing, renaming, replacing, or extending stored profile directories. Keep new profile-store mutations inside `ProfileStore` so cross-process coordination stays at one filesystem boundary instead of being duplicated in runtime scheduling or voice-operation callers.
 
 Backend resolution precedence is:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,7 +92,7 @@ Planned
 
 ### Tickets
 
-- [ ] Add cross-process coordination for profile creation and removal so concurrent workers cannot partially stomp each other.
+- [x] Add cross-process coordination for profile creation and removal so concurrent workers cannot partially stomp each other.
 - [ ] Keep profile writes atomic across manifest and reference-audio creation, including cleanup of abandoned temp data after failed writes.
 - [ ] Make profile listing and loading resilient to in-flight writes from another process without producing misleading corruption failures.
 - [ ] Add clear operator-facing diagnostics for lock contention, stale temp directories, and cross-process filesystem races.

--- a/Sources/SpeakSwiftly/Storage/ProfileStore+Coordination.swift
+++ b/Sources/SpeakSwiftly/Storage/ProfileStore+Coordination.swift
@@ -1,0 +1,46 @@
+import Darwin
+import Foundation
+
+// MARK: - ProfileStore Coordination
+
+extension ProfileStore {
+    private static let coordinationLockFileName = ".profile-store.lock"
+
+    private var coordinationLockURL: URL {
+        rootURL.appendingPathComponent(Self.coordinationLockFileName, isDirectory: false)
+    }
+
+    func withExclusiveStoreAccess<T>(
+        operation: String,
+        _ body: () throws -> T,
+    ) throws -> T {
+        try ensureRootExists()
+
+        let lockPath = coordinationLockURL.path
+        let descriptor = open(lockPath, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            throw WorkerError(
+                code: .filesystemError,
+                message: "SpeakSwiftly could not open the profile-store coordination lock at '\(lockPath)' before \(operation). \(String(cString: strerror(errno)))",
+            )
+        }
+
+        defer {
+            _ = close(descriptor)
+        }
+
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            let lockError = String(cString: strerror(errno))
+            throw WorkerError(
+                code: .filesystemError,
+                message: "SpeakSwiftly could not acquire the profile-store coordination lock at '\(lockPath)' before \(operation). \(lockError)",
+            )
+        }
+
+        defer {
+            _ = flock(descriptor, LOCK_UN)
+        }
+
+        return try body()
+    }
+}

--- a/Sources/SpeakSwiftly/Storage/ProfileStore.swift
+++ b/Sources/SpeakSwiftly/Storage/ProfileStore.swift
@@ -275,62 +275,64 @@ struct ProfileStore: @unchecked Sendable {
         try ensureRootExists()
         try validateProfileName(profileName)
 
-        guard !materializations.isEmpty else {
-            throw WorkerError(
-                code: .internalError,
-                message: "Profile '\(profileName)' could not be created because no backend materializations were supplied. This indicates a SpeakSwiftly runtime bug.",
-            )
-        }
-
-        let directoryURL = profileDirectoryURL(for: profileName)
-        guard !fileManager.fileExists(atPath: directoryURL.path) else {
-            throw WorkerError(
-                code: .profileAlreadyExists,
-                message: "Profile '\(profileName)' already exists in the SpeakSwiftly profile store and cannot be overwritten.",
-            )
-        }
-
-        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: false)
-
-        let createdAt = Date()
-        let manifest = ProfileManifest(
-            version: Self.manifestVersion,
-            profileName: profileName,
-            vibe: vibe,
-            createdAt: createdAt,
-            sourceKind: sourceKind,
-            modelRepo: sourceModelRepo,
-            voiceDescription: voiceDescription,
-            sourceText: sourceText,
-            transcriptProvenance: transcriptProvenance,
-            author: author,
-            seed: seed,
-            sampleRate: sampleRate,
-            backendMaterializations: materializations.map {
-                ProfileMaterializationManifest(
-                    backend: $0.backend,
-                    modelRepo: $0.modelRepo,
-                    createdAt: createdAt,
-                    referenceAudioFile: $0.referenceAudioFile,
-                    referenceText: $0.referenceText,
-                    sampleRate: $0.sampleRate,
+        return try withExclusiveStoreAccess(operation: "creating profile '\(profileName)'") {
+            guard !materializations.isEmpty else {
+                throw WorkerError(
+                    code: .internalError,
+                    message: "Profile '\(profileName)' could not be created because no backend materializations were supplied. This indicates a SpeakSwiftly runtime bug.",
                 )
-            },
-            qwenConditioningArtifacts: [],
-        )
+            }
 
-        do {
-            try writeMaterializationFiles(materializations, to: directoryURL)
-            try writeManifest(manifest, to: directoryURL)
-        } catch {
-            try? fileManager.removeItem(at: directoryURL)
-            throw WorkerError(
-                code: .filesystemError,
-                message: "Profile '\(profileName)' could not be written to disk. \(error.localizedDescription)",
+            let directoryURL = profileDirectoryURL(for: profileName)
+            guard !fileManager.fileExists(atPath: directoryURL.path) else {
+                throw WorkerError(
+                    code: .profileAlreadyExists,
+                    message: "Profile '\(profileName)' already exists in the SpeakSwiftly profile store and cannot be overwritten.",
+                )
+            }
+
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: false)
+
+            let createdAt = Date()
+            let manifest = ProfileManifest(
+                version: Self.manifestVersion,
+                profileName: profileName,
+                vibe: vibe,
+                createdAt: createdAt,
+                sourceKind: sourceKind,
+                modelRepo: sourceModelRepo,
+                voiceDescription: voiceDescription,
+                sourceText: sourceText,
+                transcriptProvenance: transcriptProvenance,
+                author: author,
+                seed: seed,
+                sampleRate: sampleRate,
+                backendMaterializations: materializations.map {
+                    ProfileMaterializationManifest(
+                        backend: $0.backend,
+                        modelRepo: $0.modelRepo,
+                        createdAt: createdAt,
+                        referenceAudioFile: $0.referenceAudioFile,
+                        referenceText: $0.referenceText,
+                        sampleRate: $0.sampleRate,
+                    )
+                },
+                qwenConditioningArtifacts: [],
             )
-        }
 
-        return try loadProfile(named: profileName)
+            do {
+                try writeMaterializationFiles(materializations, to: directoryURL)
+                try writeManifest(manifest, to: directoryURL)
+            } catch {
+                try? fileManager.removeItem(at: directoryURL)
+                throw WorkerError(
+                    code: .filesystemError,
+                    message: "Profile '\(profileName)' could not be written to disk. \(error.localizedDescription)",
+                )
+            }
+
+            return try loadProfile(named: profileName)
+        }
     }
 
     func loadProfile(named profileName: String) throws -> StoredProfile {
@@ -468,23 +470,25 @@ struct ProfileStore: @unchecked Sendable {
         try ensureRootExists()
         try validateProfileName(profileName)
 
-        let directoryURL = profileDirectoryURL(for: profileName)
-        guard fileManager.fileExists(atPath: directoryURL.path) else {
-            throw WorkerError(
-                code: .profileNotFound,
-                message: "Profile '\(profileName)' was not found in the SpeakSwiftly profile store.",
-            )
-        }
+        try withExclusiveStoreAccess(operation: "removing profile '\(profileName)'") {
+            let directoryURL = profileDirectoryURL(for: profileName)
+            guard fileManager.fileExists(atPath: directoryURL.path) else {
+                throw WorkerError(
+                    code: .profileNotFound,
+                    message: "Profile '\(profileName)' was not found in the SpeakSwiftly profile store.",
+                )
+            }
 
-        try requireUserMutableProfile(loadProfile(named: profileName), operation: "deleted")
+            try requireUserMutableProfile(loadProfile(named: profileName), operation: "deleted")
 
-        do {
-            try fileManager.removeItem(at: directoryURL)
-        } catch {
-            throw WorkerError(
-                code: .filesystemError,
-                message: "Profile '\(profileName)' could not be removed from disk. \(error.localizedDescription)",
-            )
+            do {
+                try fileManager.removeItem(at: directoryURL)
+            } catch {
+                throw WorkerError(
+                    code: .filesystemError,
+                    message: "Profile '\(profileName)' could not be removed from disk. \(error.localizedDescription)",
+                )
+            }
         }
     }
 
@@ -496,74 +500,76 @@ struct ProfileStore: @unchecked Sendable {
         try validateProfileName(profileName)
         try validateProfileName(newProfileName)
 
-        guard profileName != newProfileName else {
-            throw WorkerError(
-                code: .invalidProfileName,
-                message: "Profile '\(profileName)' is already named '\(newProfileName)'. Choose a different target name before requesting a rename.",
-            )
-        }
-
-        let directoryURL = profileDirectoryURL(for: profileName)
-        guard fileManager.fileExists(atPath: directoryURL.path) else {
-            throw WorkerError(
-                code: .profileNotFound,
-                message: "Profile '\(profileName)' was not found in the SpeakSwiftly profile store.",
-            )
-        }
-
-        let newDirectoryURL = profileDirectoryURL(for: newProfileName)
-        guard !fileManager.fileExists(atPath: newDirectoryURL.path) else {
-            throw WorkerError(
-                code: .profileAlreadyExists,
-                message: "Profile '\(newProfileName)' already exists in the SpeakSwiftly profile store and cannot be replaced by renaming '\(profileName)'.",
-            )
-        }
-
-        let storedProfile = try loadProfile(named: profileName)
-        try requireUserMutableProfile(storedProfile, operation: "renamed")
-        let renamedManifest = ProfileManifest(
-            version: storedProfile.manifest.version,
-            profileName: newProfileName,
-            vibe: storedProfile.manifest.vibe,
-            createdAt: storedProfile.manifest.createdAt,
-            sourceKind: storedProfile.manifest.sourceKind,
-            modelRepo: storedProfile.manifest.modelRepo,
-            voiceDescription: storedProfile.manifest.voiceDescription,
-            sourceText: storedProfile.manifest.sourceText,
-            transcriptProvenance: storedProfile.manifest.transcriptProvenance,
-            author: storedProfile.manifest.author,
-            seed: storedProfile.manifest.seed,
-            sampleRate: storedProfile.manifest.sampleRate,
-            backendMaterializations: storedProfile.manifest.backendMaterializations,
-            qwenConditioningArtifacts: storedProfile.manifest.qwenConditioningArtifacts,
-        )
-
-        do {
-            try fileManager.moveItem(at: directoryURL, to: newDirectoryURL)
-            do {
-                try writeManifest(renamedManifest, to: newDirectoryURL)
-            } catch let manifestWriteError {
-                do {
-                    try fileManager.moveItem(at: newDirectoryURL, to: directoryURL)
-                } catch let rollbackError {
-                    throw WorkerError(
-                        code: .filesystemError,
-                        message: "Profile '\(profileName)' was moved to '\(newProfileName)', but SpeakSwiftly could not restore the original directory after the manifest rewrite failed. Manifest error: \(manifestWriteError.localizedDescription) Rollback error: \(rollbackError.localizedDescription)",
-                    )
-                }
-
-                throw manifestWriteError
+        return try withExclusiveStoreAccess(operation: "renaming profile '\(profileName)' to '\(newProfileName)'") {
+            guard profileName != newProfileName else {
+                throw WorkerError(
+                    code: .invalidProfileName,
+                    message: "Profile '\(profileName)' is already named '\(newProfileName)'. Choose a different target name before requesting a rename.",
+                )
             }
-        } catch let workerError as WorkerError {
-            throw workerError
-        } catch {
-            throw WorkerError(
-                code: .filesystemError,
-                message: "Profile '\(profileName)' could not be renamed to '\(newProfileName)'. \(error.localizedDescription)",
-            )
-        }
 
-        return try loadProfile(named: newProfileName)
+            let directoryURL = profileDirectoryURL(for: profileName)
+            guard fileManager.fileExists(atPath: directoryURL.path) else {
+                throw WorkerError(
+                    code: .profileNotFound,
+                    message: "Profile '\(profileName)' was not found in the SpeakSwiftly profile store.",
+                )
+            }
+
+            let newDirectoryURL = profileDirectoryURL(for: newProfileName)
+            guard !fileManager.fileExists(atPath: newDirectoryURL.path) else {
+                throw WorkerError(
+                    code: .profileAlreadyExists,
+                    message: "Profile '\(newProfileName)' already exists in the SpeakSwiftly profile store and cannot be replaced by renaming '\(profileName)'.",
+                )
+            }
+
+            let storedProfile = try loadProfile(named: profileName)
+            try requireUserMutableProfile(storedProfile, operation: "renamed")
+            let renamedManifest = ProfileManifest(
+                version: storedProfile.manifest.version,
+                profileName: newProfileName,
+                vibe: storedProfile.manifest.vibe,
+                createdAt: storedProfile.manifest.createdAt,
+                sourceKind: storedProfile.manifest.sourceKind,
+                modelRepo: storedProfile.manifest.modelRepo,
+                voiceDescription: storedProfile.manifest.voiceDescription,
+                sourceText: storedProfile.manifest.sourceText,
+                transcriptProvenance: storedProfile.manifest.transcriptProvenance,
+                author: storedProfile.manifest.author,
+                seed: storedProfile.manifest.seed,
+                sampleRate: storedProfile.manifest.sampleRate,
+                backendMaterializations: storedProfile.manifest.backendMaterializations,
+                qwenConditioningArtifacts: storedProfile.manifest.qwenConditioningArtifacts,
+            )
+
+            do {
+                try fileManager.moveItem(at: directoryURL, to: newDirectoryURL)
+                do {
+                    try writeManifest(renamedManifest, to: newDirectoryURL)
+                } catch let manifestWriteError {
+                    do {
+                        try fileManager.moveItem(at: newDirectoryURL, to: directoryURL)
+                    } catch let rollbackError {
+                        throw WorkerError(
+                            code: .filesystemError,
+                            message: "Profile '\(profileName)' was moved to '\(newProfileName)', but SpeakSwiftly could not restore the original directory after the manifest rewrite failed. Manifest error: \(manifestWriteError.localizedDescription) Rollback error: \(rollbackError.localizedDescription)",
+                        )
+                    }
+
+                    throw manifestWriteError
+                }
+            } catch let workerError as WorkerError {
+                throw workerError
+            } catch {
+                throw WorkerError(
+                    code: .filesystemError,
+                    message: "Profile '\(profileName)' could not be renamed to '\(newProfileName)'. \(error.localizedDescription)",
+                )
+            }
+
+            return try loadProfile(named: newProfileName)
+        }
     }
 
     func replaceProfile(
@@ -624,80 +630,88 @@ struct ProfileStore: @unchecked Sendable {
         try ensureRootExists()
         try validateProfileName(profileName)
 
-        guard !materializations.isEmpty else {
-            throw WorkerError(
-                code: .internalError,
-                message: "Profile '\(profileName)' could not be replaced because no backend materializations were supplied. This indicates a SpeakSwiftly runtime bug.",
-            )
-        }
-
-        let directoryURL = profileDirectoryURL(for: profileName)
-        guard fileManager.fileExists(atPath: directoryURL.path) else {
-            throw WorkerError(
-                code: .profileNotFound,
-                message: "Profile '\(profileName)' was not found in the SpeakSwiftly profile store.",
-            )
-        }
-
-        try requireUserMutableProfile(loadProfile(named: profileName), operation: "rerolled in place")
-
-        let stagedDirectoryURL = rootURL.appendingPathComponent(".\(profileName).stage-\(UUID().uuidString)", isDirectory: true)
-        let backupDirectoryURL = rootURL.appendingPathComponent(".\(profileName).backup-\(UUID().uuidString)", isDirectory: true)
-        let manifest = ProfileManifest(
-            version: Self.manifestVersion,
-            profileName: profileName,
-            vibe: vibe,
-            createdAt: createdAt,
-            sourceKind: sourceKind,
-            modelRepo: sourceModelRepo,
-            voiceDescription: voiceDescription,
-            sourceText: sourceText,
-            transcriptProvenance: transcriptProvenance,
-            author: author,
-            seed: seed,
-            sampleRate: sampleRate,
-            backendMaterializations: materializations.map {
-                ProfileMaterializationManifest(
-                    backend: $0.backend,
-                    modelRepo: $0.modelRepo,
-                    createdAt: createdAt,
-                    referenceAudioFile: $0.referenceAudioFile,
-                    referenceText: $0.referenceText,
-                    sampleRate: $0.sampleRate,
-                )
-            },
-            qwenConditioningArtifacts: [],
-        )
-
-        do {
-            try fileManager.createDirectory(at: stagedDirectoryURL, withIntermediateDirectories: false)
-            try writeMaterializationFiles(materializations, to: stagedDirectoryURL)
-            try writeManifest(manifest, to: stagedDirectoryURL)
-            try fileManager.moveItem(at: directoryURL, to: backupDirectoryURL)
-
-            do {
-                try fileManager.moveItem(at: stagedDirectoryURL, to: directoryURL)
-            } catch let moveInError {
-                try? fileManager.moveItem(at: backupDirectoryURL, to: directoryURL)
+        return try withExclusiveStoreAccess(operation: "replacing profile '\(profileName)'") {
+            guard !materializations.isEmpty else {
                 throw WorkerError(
-                    code: .filesystemError,
-                    message: "Profile '\(profileName)' could not be replaced with the rerolled assets after staging succeeded. \(moveInError.localizedDescription)",
+                    code: .internalError,
+                    message: "Profile '\(profileName)' could not be replaced because no backend materializations were supplied. This indicates a SpeakSwiftly runtime bug.",
                 )
             }
 
-            try fileManager.removeItem(at: backupDirectoryURL)
-        } catch let workerError as WorkerError {
-            try? fileManager.removeItem(at: stagedDirectoryURL)
-            throw workerError
-        } catch {
-            try? fileManager.removeItem(at: stagedDirectoryURL)
-            throw WorkerError(
-                code: .filesystemError,
-                message: "Profile '\(profileName)' could not be replaced in place. \(error.localizedDescription)",
-            )
-        }
+            let directoryURL = profileDirectoryURL(for: profileName)
+            guard fileManager.fileExists(atPath: directoryURL.path) else {
+                throw WorkerError(
+                    code: .profileNotFound,
+                    message: "Profile '\(profileName)' was not found in the SpeakSwiftly profile store.",
+                )
+            }
 
-        return try loadProfile(named: profileName)
+            try requireUserMutableProfile(loadProfile(named: profileName), operation: "rerolled in place")
+
+            let stagedDirectoryURL = rootURL.appendingPathComponent(
+                ".\(profileName).stage-\(UUID().uuidString)",
+                isDirectory: true,
+            )
+            let backupDirectoryURL = rootURL.appendingPathComponent(
+                ".\(profileName).backup-\(UUID().uuidString)",
+                isDirectory: true,
+            )
+            let manifest = ProfileManifest(
+                version: Self.manifestVersion,
+                profileName: profileName,
+                vibe: vibe,
+                createdAt: createdAt,
+                sourceKind: sourceKind,
+                modelRepo: sourceModelRepo,
+                voiceDescription: voiceDescription,
+                sourceText: sourceText,
+                transcriptProvenance: transcriptProvenance,
+                author: author,
+                seed: seed,
+                sampleRate: sampleRate,
+                backendMaterializations: materializations.map {
+                    ProfileMaterializationManifest(
+                        backend: $0.backend,
+                        modelRepo: $0.modelRepo,
+                        createdAt: createdAt,
+                        referenceAudioFile: $0.referenceAudioFile,
+                        referenceText: $0.referenceText,
+                        sampleRate: $0.sampleRate,
+                    )
+                },
+                qwenConditioningArtifacts: [],
+            )
+
+            do {
+                try fileManager.createDirectory(at: stagedDirectoryURL, withIntermediateDirectories: false)
+                try writeMaterializationFiles(materializations, to: stagedDirectoryURL)
+                try writeManifest(manifest, to: stagedDirectoryURL)
+                try fileManager.moveItem(at: directoryURL, to: backupDirectoryURL)
+
+                do {
+                    try fileManager.moveItem(at: stagedDirectoryURL, to: directoryURL)
+                } catch let moveInError {
+                    try? fileManager.moveItem(at: backupDirectoryURL, to: directoryURL)
+                    throw WorkerError(
+                        code: .filesystemError,
+                        message: "Profile '\(profileName)' could not be replaced with the rerolled assets after staging succeeded. \(moveInError.localizedDescription)",
+                    )
+                }
+
+                try fileManager.removeItem(at: backupDirectoryURL)
+            } catch let workerError as WorkerError {
+                try? fileManager.removeItem(at: stagedDirectoryURL)
+                throw workerError
+            } catch {
+                try? fileManager.removeItem(at: stagedDirectoryURL)
+                throw WorkerError(
+                    code: .filesystemError,
+                    message: "Profile '\(profileName)' could not be replaced in place. \(error.localizedDescription)",
+                )
+            }
+
+            return try loadProfile(named: profileName)
+        }
     }
 
     func exportCanonicalAudio(for profile: StoredProfile, to outputURL: URL) throws {
@@ -726,60 +740,65 @@ struct ProfileStore: @unchecked Sendable {
         conditioning: Qwen3TTSModel.Qwen3TTSReferenceConditioning,
         createdAt: Date = Date(),
     ) throws -> StoredProfile {
-        let storedProfile = try loadProfile(named: profileName)
-        let artifactFile = Self.qwenConditioningArtifactFileName(for: backend, modelRepo: modelRepo)
-        let persistedArtifact = PersistedQwenConditioningArtifact(conditioning: conditioning)
-        let updatedArtifactManifest = QwenConditioningArtifactManifest(
-            backend: backend,
-            modelRepo: modelRepo,
-            createdAt: createdAt,
-            artifactVersion: PersistedQwenConditioningArtifact.currentVersion,
-            artifactFile: artifactFile,
-        )
-        let updatedArtifacts = (
-            storedProfile.manifest.qwenConditioningArtifacts.filter {
-                $0.backend != backend || $0.modelRepo != modelRepo
-            } + [updatedArtifactManifest],
-        )
-        .sorted {
-            if $0.backend.rawValue == $1.backend.rawValue {
-                return $0.modelRepo < $1.modelRepo
+        try ensureRootExists()
+        try validateProfileName(profileName)
+
+        return try withExclusiveStoreAccess(operation: "storing Qwen conditioning for profile '\(profileName)'") {
+            let storedProfile = try loadProfile(named: profileName)
+            let artifactFile = Self.qwenConditioningArtifactFileName(for: backend, modelRepo: modelRepo)
+            let persistedArtifact = PersistedQwenConditioningArtifact(conditioning: conditioning)
+            let updatedArtifactManifest = QwenConditioningArtifactManifest(
+                backend: backend,
+                modelRepo: modelRepo,
+                createdAt: createdAt,
+                artifactVersion: PersistedQwenConditioningArtifact.currentVersion,
+                artifactFile: artifactFile,
+            )
+            let updatedArtifacts = (
+                storedProfile.manifest.qwenConditioningArtifacts.filter {
+                    $0.backend != backend || $0.modelRepo != modelRepo
+                } + [updatedArtifactManifest],
+            )
+            .sorted {
+                if $0.backend.rawValue == $1.backend.rawValue {
+                    return $0.modelRepo < $1.modelRepo
+                }
+
+                return $0.backend.rawValue < $1.backend.rawValue
+            }
+            let updatedManifest = ProfileManifest(
+                version: Self.manifestVersion,
+                profileName: storedProfile.manifest.profileName,
+                vibe: storedProfile.manifest.vibe,
+                createdAt: storedProfile.manifest.createdAt,
+                sourceKind: storedProfile.manifest.sourceKind,
+                modelRepo: storedProfile.manifest.modelRepo,
+                voiceDescription: storedProfile.manifest.voiceDescription,
+                sourceText: storedProfile.manifest.sourceText,
+                transcriptProvenance: storedProfile.manifest.transcriptProvenance,
+                author: storedProfile.manifest.author,
+                seed: storedProfile.manifest.seed,
+                sampleRate: storedProfile.manifest.sampleRate,
+                backendMaterializations: storedProfile.manifest.backendMaterializations,
+                qwenConditioningArtifacts: updatedArtifacts,
+            )
+
+            do {
+                try writeQwenConditioningArtifact(
+                    persistedArtifact,
+                    to: storedProfile.directoryURL,
+                    fileName: artifactFile,
+                )
+                try writeManifest(updatedManifest, to: storedProfile.directoryURL)
+            } catch {
+                throw WorkerError(
+                    code: .filesystemError,
+                    message: "Profile '\(profileName)' could not persist the prepared Qwen conditioning artifact for the '\(backend.rawValue)' backend. \(error.localizedDescription)",
+                )
             }
 
-            return $0.backend.rawValue < $1.backend.rawValue
+            return try loadProfile(named: profileName)
         }
-        let updatedManifest = ProfileManifest(
-            version: Self.manifestVersion,
-            profileName: storedProfile.manifest.profileName,
-            vibe: storedProfile.manifest.vibe,
-            createdAt: storedProfile.manifest.createdAt,
-            sourceKind: storedProfile.manifest.sourceKind,
-            modelRepo: storedProfile.manifest.modelRepo,
-            voiceDescription: storedProfile.manifest.voiceDescription,
-            sourceText: storedProfile.manifest.sourceText,
-            transcriptProvenance: storedProfile.manifest.transcriptProvenance,
-            author: storedProfile.manifest.author,
-            seed: storedProfile.manifest.seed,
-            sampleRate: storedProfile.manifest.sampleRate,
-            backendMaterializations: storedProfile.manifest.backendMaterializations,
-            qwenConditioningArtifacts: updatedArtifacts,
-        )
-
-        do {
-            try writeQwenConditioningArtifact(
-                persistedArtifact,
-                to: storedProfile.directoryURL,
-                fileName: artifactFile,
-            )
-            try writeManifest(updatedManifest, to: storedProfile.directoryURL)
-        } catch {
-            throw WorkerError(
-                code: .filesystemError,
-                message: "Profile '\(profileName)' could not persist the prepared Qwen conditioning artifact for the '\(backend.rawValue)' backend. \(error.localizedDescription)",
-            )
-        }
-
-        return try loadProfile(named: profileName)
     }
 
     func loadQwenConditioningArtifact(


### PR DESCRIPTION
## Summary

- add a single profile-store coordination boundary backed by a per-profile-root advisory lock file
- wrap profile create, remove, rename, replace, and Qwen conditioning writes inside that store-level lock
- document that new profile-store mutations should stay inside `ProfileStore` so coordination does not spread into runtime scheduling or voice operations
- mark the cross-process creation/removal coordination roadmap ticket complete while leaving atomic cleanup and lock diagnostics open

## Validation

- `swift test --filter ProfileStoreTests`
- `swift build`
- `swift test`
- `bash scripts/repo-maintenance/validate-all.sh`
- commit hook reran SwiftFormat and `bash scripts/repo-maintenance/validate-all.sh`
