### PR TITLE
storage: publish profiles from staged writes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,7 @@ The same namespace split applies to the default profile store and `text-profiles
 For compatibility, SpeakSwiftly still recognizes the older trailing `.../profiles` form when it detects an existing legacy layout with adjacent `configuration.json` or `text-profiles.json` state.
 Profile listing is deliberately tolerant of profile-root noise: `list_voice_profiles` skips stray files, partial profile directories, and unreadable manifests so one damaged or in-progress entry does not make healthy profiles disappear from the listing. Direct profile loading still reports a targeted error when the named profile exists but its manifest cannot be read.
 Profile writes use a per-profile-root advisory lock file before creating, removing, renaming, replacing, or extending stored profile directories. Keep new profile-store mutations inside `ProfileStore` so cross-process coordination stays at one filesystem boundary instead of being duplicated in runtime scheduling or voice-operation callers.
+Profile creation writes reference audio and manifest data into a hidden staged directory first, removes abandoned staged data for the same profile name, and publishes the completed profile by moving the staged directory into the final profile name only after the profile is complete.
 
 Backend resolution precedence is:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,7 +93,7 @@ Planned
 ### Tickets
 
 - [x] Add cross-process coordination for profile creation and removal so concurrent workers cannot partially stomp each other.
-- [ ] Keep profile writes atomic across manifest and reference-audio creation, including cleanup of abandoned temp data after failed writes.
+- [x] Keep profile writes atomic across manifest and reference-audio creation, including cleanup of abandoned temp data after failed writes.
 - [ ] Make profile listing and loading resilient to in-flight writes from another process without producing misleading corruption failures.
 - [ ] Add clear operator-facing diagnostics for lock contention, stale temp directories, and cross-process filesystem races.
 - [ ] Add automated coverage for concurrent create/load/remove access against the shared profile root.

--- a/Sources/SpeakSwiftly/Storage/ProfileStore+TemporaryDirectories.swift
+++ b/Sources/SpeakSwiftly/Storage/ProfileStore+TemporaryDirectories.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// MARK: - ProfileStore Temporary Directories
+
+extension ProfileStore {
+    func temporaryProfileDirectoryURL(
+        for profileName: String,
+        purpose: String,
+    ) -> URL {
+        rootURL.appendingPathComponent(
+            ".\(profileName).\(purpose)-\(UUID().uuidString)",
+            isDirectory: true,
+        )
+    }
+
+    func cleanupStagedProfileDirectories(for profileName: String) throws {
+        let urls: [URL]
+        do {
+            urls = try fileManager.contentsOfDirectory(
+                at: rootURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+            )
+        } catch {
+            throw WorkerError(
+                code: .filesystemError,
+                message: "SpeakSwiftly could not inspect the profile store at '\(rootURL.path)' for abandoned staged data before writing profile '\(profileName)'. \(error.localizedDescription)",
+            )
+        }
+
+        for url in urls {
+            guard
+                (try? isDirectory(url)) == true,
+                isStagedProfileDirectoryName(url.lastPathComponent, profileName: profileName)
+            else {
+                continue
+            }
+
+            do {
+                try fileManager.removeItem(at: url)
+            } catch {
+                throw WorkerError(
+                    code: .filesystemError,
+                    message: "SpeakSwiftly could not remove abandoned staged profile data at '\(url.path)' before writing profile '\(profileName)'. \(error.localizedDescription)",
+                )
+            }
+        }
+    }
+
+    private func isStagedProfileDirectoryName(
+        _ directoryName: String,
+        profileName: String,
+    ) -> Bool {
+        directoryName.hasPrefix(".\(profileName).create-")
+            || directoryName.hasPrefix(".\(profileName).stage-")
+    }
+}

--- a/Sources/SpeakSwiftly/Storage/ProfileStore.swift
+++ b/Sources/SpeakSwiftly/Storage/ProfileStore.swift
@@ -291,7 +291,7 @@ struct ProfileStore: @unchecked Sendable {
                 )
             }
 
-            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: false)
+            try cleanupStagedProfileDirectories(for: profileName)
 
             let createdAt = Date()
             let manifest = ProfileManifest(
@@ -319,12 +319,15 @@ struct ProfileStore: @unchecked Sendable {
                 },
                 qwenConditioningArtifacts: [],
             )
+            let stagedDirectoryURL = temporaryProfileDirectoryURL(for: profileName, purpose: "create")
 
             do {
-                try writeMaterializationFiles(materializations, to: directoryURL)
-                try writeManifest(manifest, to: directoryURL)
+                try fileManager.createDirectory(at: stagedDirectoryURL, withIntermediateDirectories: false)
+                try writeMaterializationFiles(materializations, to: stagedDirectoryURL)
+                try writeManifest(manifest, to: stagedDirectoryURL)
+                try fileManager.moveItem(at: stagedDirectoryURL, to: directoryURL)
             } catch {
-                try? fileManager.removeItem(at: directoryURL)
+                try? fileManager.removeItem(at: stagedDirectoryURL)
                 throw WorkerError(
                     code: .filesystemError,
                     message: "Profile '\(profileName)' could not be written to disk. \(error.localizedDescription)",
@@ -647,15 +650,10 @@ struct ProfileStore: @unchecked Sendable {
             }
 
             try requireUserMutableProfile(loadProfile(named: profileName), operation: "rerolled in place")
+            try cleanupStagedProfileDirectories(for: profileName)
 
-            let stagedDirectoryURL = rootURL.appendingPathComponent(
-                ".\(profileName).stage-\(UUID().uuidString)",
-                isDirectory: true,
-            )
-            let backupDirectoryURL = rootURL.appendingPathComponent(
-                ".\(profileName).backup-\(UUID().uuidString)",
-                isDirectory: true,
-            )
+            let stagedDirectoryURL = temporaryProfileDirectoryURL(for: profileName, purpose: "stage")
+            let backupDirectoryURL = temporaryProfileDirectoryURL(for: profileName, purpose: "backup")
             let manifest = ProfileManifest(
                 version: Self.manifestVersion,
                 profileName: profileName,

--- a/Tests/SpeakSwiftlyTests/Storage/ProfileStoreTests.swift
+++ b/Tests/SpeakSwiftlyTests/Storage/ProfileStoreTests.swift
@@ -427,6 +427,35 @@ import Testing
     #expect(listed.map(\.profileName) == ["healthy"])
 }
 
+@Test func `create profile publishes completed directory and clears abandoned staged data`() throws {
+    let fileManager = FileManager.default
+    let tempRoot = makeTempDirectoryURL()
+    defer { try? fileManager.removeItem(at: tempRoot) }
+
+    let store = ProfileStore(rootURL: tempRoot, fileManager: fileManager)
+    try store.ensureRootExists()
+
+    let abandonedStage = tempRoot.appendingPathComponent(".fresh.create-abandoned", isDirectory: true)
+    try fileManager.createDirectory(at: abandonedStage, withIntermediateDirectories: false)
+    try Data("stale".utf8).write(to: abandonedStage.appendingPathComponent("partial.txt"))
+
+    let stored = try store.createProfile(
+        profileName: "fresh",
+        vibe: .femme,
+        modelRepo: "test-model",
+        voiceDescription: "Fresh voice.",
+        sourceText: "Fresh transcript",
+        sampleRate: 24000,
+        canonicalAudioData: Data([0x01]),
+    )
+
+    #expect(stored.directoryURL == store.profileDirectoryURL(for: "fresh"))
+    #expect(fileManager.fileExists(atPath: store.manifestURL(for: stored.directoryURL).path))
+    #expect(fileManager.fileExists(atPath: store.referenceAudioURL(for: stored.directoryURL).path))
+    #expect(!fileManager.fileExists(atPath: abandonedStage.path))
+    #expect(try store.listProfiles().map(\.profileName) == ["fresh"])
+}
+
 @Test func `upgrades legacy manifest into backend materializations`() throws {
     let fileManager = FileManager.default
     let tempRoot = makeTempDirectoryURL()


### PR DESCRIPTION
## Summary

- publish new voice profiles from hidden staged directories after reference audio and manifest data are both written
- clean abandoned create/stage directories for the same profile name before profile creation or reroll replacement
- reuse the same temporary-directory helper for reroll staging and backup names
- document staged publication behavior and mark the atomic profile-write roadmap item complete

## Validation

- `swift test --filter ProfileStoreTests`
- `swift build`
- `swift test`
- `bash scripts/repo-maintenance/validate-all.sh`
- commit hook reran SwiftFormat and `bash scripts/repo-maintenance/validate-all.sh`
