### PR TITLE
release: prepare v5.0.0

### DIFF
--- a/docs/releases/v5-0-0-release-notes.md
+++ b/docs/releases/v5-0-0-release-notes.md
@@ -1,0 +1,46 @@
+# v5.0.0 Release Notes
+
+## What Changed
+
+- Raised the `TextForSpeech` dependency floor to `0.19.0`.
+- Simplified the typed Swift generation surface around `sourceFormat` and
+  `requestContext`.
+- Removed the public `SpeakSwiftly.InputTextContext` type.
+- Routed live playback, retained audio generation, generated-file manifests,
+  generation jobs, generated batches, request observation, and JSONL emission
+  through the simplified source/request context model.
+- Kept `source_format` as the JSONL whole-source selector and
+  `request_context` as the JSONL metadata and path-context container.
+- Rejected removed JSONL generation-context keys with explicit diagnostics
+  instead of silently ignoring stale caller payloads.
+- Merged batch-item top-level `cwd` and `repo_root` fields into nested
+  `request_context` the same way single generation requests do.
+- Updated release E2E live-service helpers to prefer the current
+  `SpeakSwiftlyServer` `/models/unload` and `/models/reload` routes while
+  retaining fallback support for the older `/runtime/models/...` routes.
+
+## Breaking Changes
+
+- Swift callers must replace `inputTextContext:` with `sourceFormat:` and
+  `requestContext:`.
+- `SpeakSwiftly.InputTextContext` is removed.
+- JSONL generation callers must stop sending `input_text_context`,
+  `text_format`, and `nested_source_format`.
+- Mixed prose, Markdown, HTML, logs, CLI output, and agent text should omit
+  source hints and let `TextForSpeech` detect structure internally.
+
+## Migration Notes
+
+- Use `sourceFormat: .swift` or JSONL `source_format: "swift_source"` only when
+  the entire input is source code.
+- Use `requestContext` or JSONL `request_context` for app, agent, project,
+  topic, `cwd`, and `repo_root` metadata.
+- Keep using `voice_profile` and `text_profile` on new JSONL callers.
+  Compatibility aliases `profile_name` and `text_profile_id` remain accepted.
+
+## Verification
+
+- `swift build`
+- `swift test`
+- `bash scripts/repo-maintenance/validate-all.sh`
+- `sh scripts/repo-maintenance/run-e2e-full.sh`

--- a/docs/releases/v5-0-0-release-prep.md
+++ b/docs/releases/v5-0-0-release-prep.md
@@ -1,0 +1,56 @@
+# v5.0.0 Release Prep
+
+Date: 2026-05-04
+
+This final release stabilizes the `v5.0.0-rc.1` public API and JSONL wire-shape
+simplification for downstream adopters.
+
+## Scope
+
+- Publish the final `v5.0.0` tag from the reviewed release branch.
+- Keep the `TextForSpeech` dependency floor at `0.19.0`.
+- Keep the simplified `sourceFormat` and `requestContext` typed Swift surface.
+- Keep the current JSONL generation shape centered on `source_format` and
+  `request_context`.
+- Preserve the stale-key rejection behavior introduced in the release
+  candidate.
+- Align the release E2E live-service unload/reload helpers with the current
+  `SpeakSwiftlyServer` control routes while keeping fallback support for the
+  older route shape.
+
+## Not Included
+
+- A backend default change.
+- A voice-profile storage migration.
+- A coordinated `speak-to-user` monorepo submodule bump.
+
+## SemVer Framing
+
+- Release this final as `v5.0.0`.
+- This is a major release because it removes the public
+  `SpeakSwiftly.InputTextContext` Swift API and rejects removed JSONL
+  generation-context keys.
+
+## Validation Target
+
+Run the checks serially:
+
+```bash
+swift build
+swift test
+bash scripts/repo-maintenance/validate-all.sh
+sh scripts/repo-maintenance/run-e2e-full.sh
+```
+
+## Verification Performed
+
+- `bash scripts/repo-maintenance/validate-all.sh` passed.
+- `sh scripts/repo-maintenance/run-e2e-full.sh` passed.
+
+## Release Command
+
+After validation and full E2E pass:
+
+```bash
+sh scripts/repo-maintenance/release.sh --mode standard --version v5.0.0 --skip-version-bump
+```

--- a/scripts/repo-maintenance/reload-live-service-resident-models.sh
+++ b/scripts/repo-maintenance/reload-live-service-resident-models.sh
@@ -19,7 +19,7 @@ fi
 
 base_url="${SPEAKSWIFTLY_LIVE_SERVICE_BASE_URL:-http://127.0.0.1:7337}"
 health_url="$base_url/healthz"
-reload_url="$base_url/runtime/models/reload"
+reload_paths="${SPEAKSWIFTLY_LIVE_SERVICE_RELOAD_PATHS:-/models/reload /runtime/models/reload}"
 
 if ! curl -fsS --max-time 2 "$health_url" >/dev/null 2>&1; then
   warn "No reachable SpeakSwiftlyServer live service at '$base_url'; continuing without resident-model reload."
@@ -31,9 +31,16 @@ trap 'rm -f "$response_file"' EXIT INT TERM
 
 log "Requesting resident-model reload from the live SpeakSwiftlyServer service at '$base_url'."
 
-if ! curl -fsS --max-time 180 -X POST "$reload_url" -H 'accept: application/json' -o "$response_file"; then
-  die "SpeakSwiftly live-service resident-model reload failed while POSTing to '$reload_url'. The live service is reachable, but it did not accept the reload request."
-fi
+reload_url=""
+for reload_path in $reload_paths; do
+  candidate_url="$base_url$reload_path"
+  if curl -fsS --max-time 180 -X POST "$candidate_url" -H 'accept: application/json' -o "$response_file"; then
+    reload_url="$candidate_url"
+    break
+  fi
+done
+
+[ -n "$reload_url" ] || die "SpeakSwiftly live-service resident-model reload failed after trying paths '$reload_paths' at '$base_url'. The live service is reachable, but it did not accept any reload request."
 
 if grep -Eq '"resident_state"[[:space:]]*:[[:space:]]*"ready"|"worker_stage"[[:space:]]*:[[:space:]]*"resident_model_ready"|resident_model_ready' "$response_file"; then
   log "Live SpeakSwiftlyServer resident models are reloaded after E2E."

--- a/scripts/repo-maintenance/unload-live-service-resident-models.sh
+++ b/scripts/repo-maintenance/unload-live-service-resident-models.sh
@@ -19,8 +19,8 @@ fi
 
 base_url="${SPEAKSWIFTLY_LIVE_SERVICE_BASE_URL:-http://127.0.0.1:7337}"
 health_url="$base_url/healthz"
-unload_url="$base_url/runtime/models/unload"
 unload_timeout="${SPEAKSWIFTLY_LIVE_SERVICE_UNLOAD_TIMEOUT_SECONDS:-600}"
+unload_paths="${SPEAKSWIFTLY_LIVE_SERVICE_UNLOAD_PATHS:-/models/unload /runtime/models/unload}"
 
 if ! curl -fsS --max-time 2 "$health_url" >/dev/null 2>&1; then
   warn "No reachable SpeakSwiftlyServer live service at '$base_url'; continuing without resident-model unload preflight."
@@ -32,9 +32,16 @@ trap 'rm -f "$response_file"' EXIT INT TERM
 
 log "Requesting resident-model unload from the live SpeakSwiftlyServer service at '$base_url'."
 
-if ! curl -fsS --max-time "$unload_timeout" -X POST "$unload_url" -H 'accept: application/json' -o "$response_file"; then
-  die "SpeakSwiftly live-service resident-model unload preflight failed while POSTing to '$unload_url' after waiting up to ${unload_timeout}s. The live service is reachable, but it did not accept or finish the unload request. If generation or playback is active, unload_models is expected to wait behind that work; rerun after the active request drains or increase SPEAKSWIFTLY_LIVE_SERVICE_UNLOAD_TIMEOUT_SECONDS."
-fi
+unload_url=""
+for unload_path in $unload_paths; do
+  candidate_url="$base_url$unload_path"
+  if curl -fsS --max-time "$unload_timeout" -X POST "$candidate_url" -H 'accept: application/json' -o "$response_file"; then
+    unload_url="$candidate_url"
+    break
+  fi
+done
+
+[ -n "$unload_url" ] || die "SpeakSwiftly live-service resident-model unload preflight failed after trying paths '$unload_paths' at '$base_url' for up to ${unload_timeout}s each. The live service is reachable, but it did not accept or finish any unload request. If generation or playback is active, unload_models is expected to wait behind that work; rerun after the active request drains or increase SPEAKSWIFTLY_LIVE_SERVICE_UNLOAD_TIMEOUT_SECONDS."
 
 if grep -Eq '"resident_state"[[:space:]]*:[[:space:]]*"unloaded"|"worker_stage"[[:space:]]*:[[:space:]]*"resident_models_unloaded"|resident_models_unloaded' "$response_file"; then
   log "Live SpeakSwiftlyServer resident models are unloaded; E2E has memory headroom without uninstalling the service."


### PR DESCRIPTION
## Release

- prepares v5.0.0 from branch `release/v5-0-0`
- keeps protected `main` updates behind pull request review and CI
- release tag `v5.0.0` was created locally before this PR so the reviewed release candidate is preserved exactly

## Review Loop

Before merge, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
