### PR TITLE
release: fix annotated tag reruns

### DIFF
--- a/scripts/repo-maintenance/release.sh
+++ b/scripts/repo-maintenance/release.sh
@@ -139,7 +139,8 @@ create_release_tag() {
   tag_sha="$(git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$RELEASE_TAG" 2>/dev/null || true)"
 
   if [ -n "$tag_sha" ]; then
-    [ "$tag_sha" = "$head_sha" ] || die "Tag $RELEASE_TAG already exists and does not point at HEAD."
+    tag_commit_sha="$(git -C "$REPO_ROOT" rev-list -n 1 "$RELEASE_TAG")"
+    [ "$tag_commit_sha" = "$head_sha" ] || die "Tag $RELEASE_TAG already exists and does not point at HEAD."
     log "Tag $RELEASE_TAG already points at HEAD."
     return 0
   fi


### PR DESCRIPTION
## Summary

- compare existing release tags by peeled commit instead of tag object
- allow annotated release tags to pass the rerun guard when they already point at HEAD

## Verification

- sh -n scripts/repo-maintenance/release.sh
- sh scripts/repo-maintenance/validate-all.sh

## Socket issue check

The current installed Socket productivity-skills asset already contains the peeled tag comparison, so this is a stale SpeakSwiftly copy rather than inaccurate current maintain-project-repo guidance.