### PR TITLE
release: sync repo maintenance toolkit

### DIFF
--- a/.github/workflows/validate-repo-maintenance.yml
+++ b/.github/workflows/validate-repo-maintenance.yml
@@ -12,9 +12,13 @@ on:
 jobs:
   validate:
     name: validate
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
+      - name: Report selected Xcode
+        run: xcode-select --print-path
+      - name: Report Swift toolchain
+        run: xcrun swift --version
       - name: Install Swift repo-maintenance tools
         run: brew install swiftformat swiftlint
       - name: Run repo-maintenance validation

--- a/scripts/repo-maintenance/config/release.env
+++ b/scripts/repo-maintenance/config/release.env
@@ -1,3 +1,16 @@
 # Repo-maintenance release defaults.
 REPO_MAINTENANCE_DEFAULT_RELEASE_MODE=standard
 REPO_MAINTENANCE_RELEASE_BRANCH=main
+REPO_MAINTENANCE_REMOTE_CI_MODE=full
+
+# GitHub can accept branch, tag, PR, check, review, and release mutations before
+# those surfaces are immediately readable. These defaults keep release scripts
+# explicit about intentional waits instead of failing on transient indexing gaps.
+REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS=120
+REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS=5
+
+# Keep full local validation as the default release gate. For repositories whose
+# GitHub CI is intentionally heavy, use --remote-ci-mode defer so release.sh
+# pauses after branch push, PR creation, and initial check discovery. Codex can
+# then use a native thread Timer/Wakeup or heartbeat automation to resume later
+# instead of leaving a long-running shell process open just to poll GitHub.

--- a/scripts/repo-maintenance/lib/common.sh
+++ b/scripts/repo-maintenance/lib/common.sh
@@ -38,6 +38,104 @@ load_profile_env() {
   load_env_file "$REPO_MAINTENANCE_ROOT/config/profile.env"
 }
 
+positive_integer_or_default() {
+  value="$1"
+  default_value="$2"
+
+  case "$value" in
+    ''|*[!0-9]*)
+      printf '%s\n' "$default_value"
+      ;;
+    0)
+      printf '%s\n' "$default_value"
+      ;;
+    *)
+      printf '%s\n' "$value"
+      ;;
+  esac
+}
+
+github_wait_timeout() {
+  value="$1"
+  default_timeout="$(positive_integer_or_default "${REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS:-120}" 120)"
+  positive_integer_or_default "$value" "$default_timeout"
+}
+
+github_wait_poll_seconds() {
+  value="$1"
+  default_poll_seconds="$(positive_integer_or_default "${REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS:-5}" 5)"
+  positive_integer_or_default "$value" "$default_poll_seconds"
+}
+
+wait_for_remote_branch() {
+  branch_name="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_REMOTE_BRANCH_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_REMOTE_BRANCH_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+
+  log "Waiting up to ${timeout_seconds}s for remote branch origin/$branch_name to become visible."
+
+  while :; do
+    if git -C "$REPO_ROOT" ls-remote --exit-code --heads origin "$branch_name" >/dev/null 2>&1; then
+      log "Remote branch origin/$branch_name is visible."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "Remote branch origin/$branch_name was not visible after ${timeout_seconds}s. Confirm the branch push succeeded and that the origin remote is reachable before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
+wait_for_remote_tag() {
+  tag_name="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_REMOTE_TAG_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_REMOTE_TAG_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+
+  log "Waiting up to ${timeout_seconds}s for remote tag $tag_name to become visible."
+
+  while :; do
+    if git -C "$REPO_ROOT" ls-remote --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1; then
+      log "Remote tag $tag_name is visible."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "Remote tag $tag_name was not visible after ${timeout_seconds}s. Confirm the tag push succeeded and that GitHub has indexed the tag before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
+wait_for_github_release() {
+  tag_name="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_GH_RELEASE_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_GH_RELEASE_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+
+  log "Waiting up to ${timeout_seconds}s for GitHub release $tag_name to become readable."
+
+  while :; do
+    if gh release view "$tag_name" >/dev/null 2>&1; then
+      log "GitHub release $tag_name is readable."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "GitHub release $tag_name was not readable after ${timeout_seconds}s. Confirm release creation succeeded and GitHub has indexed the release before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
 ensure_git_repo() {
   git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "maintain-project-repo must run inside a git worktree rooted at $REPO_ROOT."
 }

--- a/scripts/repo-maintenance/release.sh
+++ b/scripts/repo-maintenance/release.sh
@@ -17,6 +17,7 @@ base_branch="${REPO_MAINTENANCE_RELEASE_BRANCH:-main}"
 review_comments_addressed="false"
 skip_branch_cleanup="false"
 dry_run="false"
+remote_ci_mode="${REPO_MAINTENANCE_REMOTE_CI_MODE:-full}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -48,6 +49,10 @@ while [ "$#" -gt 0 ]; do
       review_comments_addressed="true"
       shift
       ;;
+    --remote-ci-mode)
+      remote_ci_mode="${2:-}"
+      shift 2
+      ;;
     --skip-branch-cleanup)
       skip_branch_cleanup="true"
       shift
@@ -59,7 +64,7 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
       cat <<'USAGE'
 Usage:
-  release.sh --mode standard --version <vX.Y.Z> [--base-branch main] [--skip-validate] [--skip-version-bump] [--skip-gh-release] [--review-comments-addressed] [--skip-branch-cleanup] [--dry-run]
+  release.sh --mode standard --version <vX.Y.Z> [--base-branch main] [--skip-validate] [--skip-version-bump] [--skip-gh-release] [--review-comments-addressed] [--remote-ci-mode full|defer] [--skip-branch-cleanup] [--dry-run]
   release.sh --mode submodule --version <vX.Y.Z> [--skip-validate] [--skip-gh-release] [--dry-run]
 USAGE
       exit 0
@@ -76,6 +81,7 @@ export REPO_MAINTENANCE_RELEASE_MODE="$mode"
 export RELEASE_TAG="$release_tag"
 export REPO_MAINTENANCE_SKIP_GH_RELEASE="$skip_gh_release"
 export REPO_MAINTENANCE_DRY_RUN="$dry_run"
+export REPO_MAINTENANCE_REMOTE_CI_MODE="$remote_ci_mode"
 
 ensure_clean_worktree() {
   status_output="$(git -C "$REPO_ROOT" status --porcelain)"
@@ -96,6 +102,16 @@ ensure_semver_tag() {
   esac
 }
 
+ensure_remote_ci_mode() {
+  case "$REPO_MAINTENANCE_REMOTE_CI_MODE" in
+    full|defer)
+      ;;
+    *)
+      die "Remote CI mode must be either full or defer. Use full to watch GitHub checks in this script, or defer to pause after initial check discovery and continue from a Codex wakeup."
+      ;;
+  esac
+}
+
 current_branch() {
   git -C "$REPO_ROOT" symbolic-ref --quiet --short HEAD || true
 }
@@ -110,9 +126,15 @@ ensure_branch_release_context() {
 run_version_bump() {
   release_version="${RELEASE_TAG#v}"
   version_bump_script="$SELF_DIR/version-bump.sh"
+  head_subject="$(git -C "$REPO_ROOT" log -1 --format=%s 2>/dev/null || true)"
 
   if [ "$skip_version_bump" = "true" ]; then
     log "Skipping repo version bump because --skip-version-bump was requested."
+    return 0
+  fi
+
+  if [ "$head_subject" = "release: bump versions for $RELEASE_TAG" ]; then
+    log "Version bump commit for $RELEASE_TAG is already at HEAD; continuing the release resume path."
     return 0
   fi
 
@@ -154,17 +176,28 @@ create_release_tag() {
   log "Created annotated tag $RELEASE_TAG."
 }
 
-push_branch_and_tag() {
+push_release_branch() {
   branch_name="$1"
 
   if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
-    log "Would push branch $branch_name and tag $RELEASE_TAG to origin."
+    log "Would push branch $branch_name to origin."
     return 0
   fi
 
   git -C "$REPO_ROOT" push -u origin "$branch_name"
+  log "Pushed branch $branch_name."
+  wait_for_remote_branch "$branch_name"
+}
+
+push_release_tag() {
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would push tag $RELEASE_TAG to origin."
+    return 0
+  fi
+
   git -C "$REPO_ROOT" push origin "$RELEASE_TAG"
-  log "Pushed branch $branch_name and tag $RELEASE_TAG."
+  log "Pushed tag $RELEASE_TAG."
+  wait_for_remote_tag "$RELEASE_TAG"
 }
 
 create_or_update_pr() {
@@ -185,11 +218,11 @@ create_or_update_pr() {
 
 - prepares $RELEASE_TAG from branch \`$branch_name\`
 - keeps protected \`$base_branch\` updates behind pull request review and CI
-- release tag \`$RELEASE_TAG\` was created locally before this PR so the reviewed release candidate is preserved exactly
+- release tag \`$RELEASE_TAG\` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged
 
 ## Review Loop
 
-Before merge, \`scripts/repo-maintenance/release.sh\` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with \`--review-comments-addressed\`.
+Before merge and tagging, \`scripts/repo-maintenance/release.sh\` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with \`--review-comments-addressed\`.
 EOF
 
   pr_number="$(gh pr list --head "$branch_name" --base "$base_branch" --json number --jq '.[0].number // empty' --limit 1)"
@@ -225,6 +258,86 @@ watch_ci() {
   log "CI is green for PR #$pr_number."
 }
 
+defer_remote_ci_if_requested() {
+  pr_number="$1"
+  branch_name="$2"
+
+  [ "$REPO_MAINTENANCE_REMOTE_CI_MODE" = "defer" ] || return 1
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would defer remote CI after PR #$pr_number reports initial checks."
+    return 0
+  fi
+
+  pr_url="$(gh pr view "$pr_number" --json url --jq '.url')"
+  log "Remote CI mode is defer, so release.sh is pausing after local validation, branch push, PR creation, and initial check discovery."
+  log "Release is not complete yet. Let GitHub finish CI for PR #$pr_number, then continue from branch $branch_name with:"
+  log "  bash scripts/repo-maintenance/release.sh --mode standard --version $RELEASE_TAG"
+  log "Codex should use a native thread Timer/Wakeup or heartbeat automation for this wait when available, then resume by checking $pr_url and rerunning the command above instead of leaving a shell script open to poll GitHub."
+  return 0
+}
+
+wait_for_initial_pr_checks() {
+  pr_number="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_INITIAL_CHECK_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_INITIAL_CHECK_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+  last_state="no check data returned yet"
+
+  log "Waiting up to ${timeout_seconds}s for GitHub to report initial checks on PR #$pr_number."
+
+  while :; do
+    last_state="$(gh pr checks "$pr_number" --json name,state,workflow --jq 'map(.name + ":" + .state) | join(", ")' 2>/dev/null || printf 'no checks reported')"
+    check_count="$(gh pr checks "$pr_number" --json name,state,workflow --jq 'length' 2>/dev/null || printf '0')"
+    case "$check_count" in
+      ''|*[!0-9]*)
+        check_count="0"
+        ;;
+    esac
+
+    if [ "$check_count" -gt 0 ]; then
+      log "Found $check_count initial check(s) for PR #$pr_number."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "No checks were reported for PR #$pr_number after ${timeout_seconds}s. Last observed state: $last_state. Confirm the GitHub Actions workflow triggers for the release branch, Actions is enabled, and the branch push succeeded before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
+wait_for_pr_review_state() {
+  pr_number="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_PR_REVIEW_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_PR_REVIEW_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+  last_state="PR review/comment state has not been read yet"
+
+  log "Waiting up to ${timeout_seconds}s for GitHub review/comment state on PR #$pr_number."
+
+  while :; do
+    last_state="$(gh pr view "$pr_number" --json reviewDecision,comments,reviews --jq '"reviewDecision=" + (.reviewDecision // "") + ", comments=" + ((.comments | length) | tostring) + ", reviews=" + ((.reviews | length) | tostring)' 2>/dev/null || printf 'GitHub did not return PR review/comment state')"
+    case "$last_state" in
+      "GitHub did not return PR review/comment state")
+        ;;
+      *)
+        log "GitHub review/comment state is readable for PR #$pr_number: $last_state."
+        return 0
+        ;;
+    esac
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "GitHub review/comment state for PR #$pr_number was not readable after ${timeout_seconds}s. Last observed state: $last_state. Confirm the PR exists and GitHub is returning review data before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
 check_pr_comments() {
   pr_number="$1"
 
@@ -233,8 +346,10 @@ check_pr_comments() {
     return 0
   fi
 
+  wait_for_pr_review_state "$pr_number"
+
   review_decision="$(gh pr view "$pr_number" --json reviewDecision --jq '.reviewDecision // ""')"
-  comment_count="$(gh pr view "$pr_number" --json comments,reviews --jq '([.comments[]?, .reviews[]?] | length)')"
+  comment_count="$(gh pr view "$pr_number" --json comments,reviews --jq '([.comments[]?, (.reviews[]? | select(.state == "COMMENTED"))] | length)')"
 
   if [ "$review_decision" = "CHANGES_REQUESTED" ]; then
     gh pr view "$pr_number" --comments
@@ -272,7 +387,7 @@ fast_forward_base_branch() {
     git -C "$REPO_ROOT" pull --ff-only origin "$base_branch"
     log "Fast-forwarded local $base_branch."
   else
-    warn "Could not check out local $base_branch, likely because another worktree owns it. Fast-forward $base_branch from origin/$base_branch in that checkout before cleanup."
+    die "Could not check out local $base_branch, likely because another worktree owns it. Fast-forward $base_branch from origin/$base_branch in that checkout, then rerun release.sh so the release tag is created from the reviewed base branch."
   fi
 }
 
@@ -294,6 +409,7 @@ create_github_release() {
 
   gh release create "$RELEASE_TAG" --verify-tag --generate-notes
   log "Created GitHub release $RELEASE_TAG."
+  wait_for_github_release "$RELEASE_TAG"
 }
 
 cleanup_merged_branches() {
@@ -326,6 +442,7 @@ run_standard_release() {
   ensure_git_repo
   ensure_gh_cli
   ensure_semver_tag
+  ensure_remote_ci_mode
   branch_name="$(ensure_branch_release_context)"
   ensure_clean_worktree
 
@@ -335,14 +452,20 @@ run_standard_release() {
 
   run_version_bump
   ensure_clean_worktree
-  create_release_tag
-  push_branch_and_tag "$branch_name"
+  push_release_branch "$branch_name"
   create_or_update_pr "$branch_name"
   pr_number="$PR_NUMBER"
+  wait_for_initial_pr_checks "$pr_number"
+  if defer_remote_ci_if_requested "$pr_number" "$branch_name"; then
+    log "Standard release flow paused before remote CI watch for $RELEASE_TAG."
+    return 0
+  fi
   watch_ci "$pr_number"
   check_pr_comments "$pr_number"
   merge_pr "$pr_number"
   fast_forward_base_branch
+  create_release_tag
+  push_release_tag
   create_github_release
   cleanup_merged_branches "$branch_name"
   log "Standard release flow completed successfully for $RELEASE_TAG."

--- a/scripts/repo-maintenance/release/30-push-release.sh
+++ b/scripts/repo-maintenance/release/30-push-release.sh
@@ -13,5 +13,7 @@ if [ "${REPO_MAINTENANCE_DRY_RUN:-false}" = "true" ]; then
 fi
 
 git -C "$REPO_ROOT" push -u origin "$branch_name"
+wait_for_remote_branch "$branch_name"
 git -C "$REPO_ROOT" push origin "$RELEASE_TAG"
+wait_for_remote_tag "$RELEASE_TAG"
 log "Pushed branch $branch_name and tag $RELEASE_TAG."

--- a/scripts/repo-maintenance/release/40-github-release.sh
+++ b/scripts/repo-maintenance/release/40-github-release.sh
@@ -27,3 +27,4 @@ fi
 
 gh release create "$RELEASE_TAG" --verify-tag --generate-notes
 log "Created GitHub release $RELEASE_TAG."
+wait_for_github_release "$RELEASE_TAG"


### PR DESCRIPTION
## Summary

- refresh the installed repo-maintenance toolkit from the current maintain-project-repo skill
- add current standard release behavior: deferred remote CI mode, GitHub indexing waits, and post-review release tagging
- update the repo-maintenance validation workflow wrapper to the current managed macOS 26 / checkout v6 shape

## Verification

- uv run /Users/galew/.codex/plugins/cache/socket/productivity-skills/6.7.11/skills/maintain-project-repo/scripts/run_workflow.py --repo-root /Users/galew/Workspace/gaelic-ghost/speak-swiftly/SpeakSwiftly --operation refresh --profile swift-package --dry-run
- uv run /Users/galew/.codex/plugins/cache/socket/productivity-skills/6.7.11/skills/maintain-project-repo/scripts/run_workflow.py --repo-root /Users/galew/Workspace/gaelic-ghost/speak-swiftly/SpeakSwiftly --operation refresh --profile swift-package
- sh scripts/repo-maintenance/validate-all.sh
- sh -n scripts/repo-maintenance/release.sh
- sh -n scripts/repo-maintenance/lib/common.sh
- sh -n scripts/repo-maintenance/release/30-push-release.sh
- sh -n scripts/repo-maintenance/release/40-github-release.sh
- git diff --check

## Socket issue check

No Socket issue opened: this sync confirms the current managed Socket asset already contains the annotated-tag rerun fix and newer release behavior; SpeakSwiftly was stale.