### PR TITLE
release: prepare v7.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,12 +72,36 @@ Useful environment variables include:
 
 System voice profiles are package-owned bundled resources, not ordinary end-user library creations. The only supported authoring workflow is:
 
-1. Build or launch `SpeakSwiftlyTool` with `--system-profile-resource-root PATH`.
+1. Run the `create-system-voice-profile` SwiftPM command plugin from the consumer package checkout, or build/launch `SpeakSwiftlyTool` with `--system-profile-resource-root PATH` for lower-level maintainer work.
 2. Submit `create_system_voice_profile_from_description` through the tool JSONL surface or `SpeakSwiftly.Tool.createBuiltInVoiceProfile(...)`.
-3. Review the generated profile under `PATH/profiles/<profile-name>/`.
-4. Bundle the reviewed profile directory under `Sources/SpeakSwiftly/Resources/SystemProfiles/profiles/`.
+3. Review the generated profile under `Resources/SystemProfiles/profiles/<profile-name>/` in the consumer target, or under `PATH/profiles/<profile-name>/` when using the tool directly.
+4. Bundle the reviewed profile directory with the target that owns it by declaring `.copy("Resources/SystemProfiles")` in that target's package manifest entry.
+5. Pass that target's bundled root into SpeakSwiftly at startup with `SpeakSwiftly.Configuration(systemProfileResourceRoots:)`, usually from `SpeakSwiftly.SupportResources.systemProfileRootURL(in: .module)`.
 
-At runtime, SpeakSwiftly loads bundled system profiles from the package resource bundle and seeds them into the writable profile store. Do not expose system-profile creation through `runtime.voices` or any ordinary public end-user API. If `create_system_voice_profile_from_description` is used without `--system-profile-resource-root`, the request must fail instead of writing package-owned profiles into ordinary runtime state.
+For example, a consumer package target can generate a bundled system profile with:
+
+```bash
+swift package plugin --allow-writing-to-package-directory create-system-voice-profile \
+  --target SpeakSwiftlyServer \
+  --name server-announcer \
+  --text "A clear server status voice." \
+  --vibe femme \
+  --voice-description "Clear, bright, steady, and concise."
+```
+
+Then the consuming target should pass its bundled system-profile root during startup:
+
+```swift
+let systemProfileRoots = [
+    SpeakSwiftly.SupportResources.systemProfileRootURL(in: .module),
+].compactMap(\.self)
+
+let runtime = await SpeakSwiftly.liftoff(
+    configuration: .init(systemProfileResourceRoots: systemProfileRoots)
+)
+```
+
+At runtime, SpeakSwiftly loads bundled system profiles from its own package resource bundle and from configured consumer resource roots, then seeds them into the writable profile store. Do not expose system-profile creation through `runtime.voices` or any ordinary public end-user API. If `create_system_voice_profile_from_description` is used without `--system-profile-resource-root`, the request must fail instead of writing package-owned profiles into ordinary runtime state.
 
 ### Runtime Behavior
 

--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,23 @@ let package = Package(
                 .product(name: "TextForSpeech", package: "TextForSpeech"),
             ],
         ),
+        .plugin(
+            name: "CreateSystemVoiceProfile",
+            capability: .command(
+                intent: .custom(
+                    verb: "create-system-voice-profile",
+                    description: "Generate a SpeakSwiftly system voice profile into a target resource bundle",
+                ),
+                permissions: [
+                    .writeToPackageDirectory(
+                        reason: "Generated system voice profiles are durable package resources owned by the consumer target.",
+                    ),
+                ],
+            ),
+            dependencies: [
+                "SpeakSwiftlyTool",
+            ],
+        ),
         .testTarget(
             name: "SpeakSwiftlyTests",
             dependencies: [

--- a/Plugins/CreateSystemVoiceProfile/CreateSystemVoiceProfile.swift
+++ b/Plugins/CreateSystemVoiceProfile/CreateSystemVoiceProfile.swift
@@ -50,6 +50,17 @@ struct CreateSystemVoiceProfilePlugin: CommandPlugin {
         let output = Pipe()
         process.standardInput = input
         process.standardOutput = output
+
+        var inputIsOpen = true
+        defer {
+            if inputIsOpen {
+                try? input.fileHandleForWriting.close()
+            }
+            if process.isRunning {
+                process.waitUntilExit()
+            }
+        }
+
         try process.run()
 
         let requestLine = try request.encodedLine()
@@ -57,7 +68,11 @@ struct CreateSystemVoiceProfilePlugin: CommandPlugin {
 
         let result = try waitForToolResult(requestID: request.id, output: output)
         try input.fileHandleForWriting.close()
-        process.waitUntilExit()
+        inputIsOpen = false
+
+        if process.isRunning {
+            process.waitUntilExit()
+        }
 
         guard process.terminationStatus == 0 else {
             throw PluginError.toolFailed(status: process.terminationStatus)

--- a/Plugins/CreateSystemVoiceProfile/CreateSystemVoiceProfile.swift
+++ b/Plugins/CreateSystemVoiceProfile/CreateSystemVoiceProfile.swift
@@ -1,0 +1,268 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct CreateSystemVoiceProfilePlugin: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        let options = try Options(arguments: arguments)
+        guard let target = context.package.targets.first(where: { $0.name == options.target }) else {
+            throw PluginError.unknownTarget(options.target)
+        }
+
+        let resourceRootURL = target.directoryURL
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("SystemProfiles", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: resourceRootURL, withIntermediateDirectories: true)
+
+        let request = ToolRequest(
+            id: "create-system-voice-profile-\(UUID().uuidString)",
+            profileName: options.name,
+            text: options.text,
+            vibe: options.vibe,
+            voiceDescription: options.voiceDescription,
+            seedID: options.seedID,
+            seedVersion: options.seedVersion,
+            sourcePackage: context.package.displayName,
+            sourceVersion: options.sourceVersion,
+        )
+        let tool = try context.tool(named: "SpeakSwiftlyTool")
+        try runTool(at: tool.url, resourceRootURL: resourceRootURL, request: request)
+
+        Diagnostics.remark(
+            "Created SpeakSwiftly system voice profile '\(options.name)' under \(resourceRootURL.path)/profiles. Ensure target '\(options.target)' declares .copy(\"Resources/SystemProfiles\") and passes SpeakSwiftly.SupportResources.systemProfileRootURL(in: .module) through SpeakSwiftly.Configuration(systemProfileResourceRoots:).",
+        )
+    }
+
+    private func runTool(
+        at toolURL: URL,
+        resourceRootURL: URL,
+        request: ToolRequest,
+    ) throws {
+        let process = Process()
+        process.executableURL = toolURL
+        process.arguments = [
+            "--system-profile-resource-root",
+            resourceRootURL.path,
+        ]
+
+        let input = Pipe()
+        let output = Pipe()
+        process.standardInput = input
+        process.standardOutput = output
+        try process.run()
+
+        let requestLine = try request.encodedLine()
+        try input.fileHandleForWriting.write(contentsOf: Data((requestLine + "\n").utf8))
+
+        let result = try waitForToolResult(requestID: request.id, output: output)
+        try input.fileHandleForWriting.close()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw PluginError.toolFailed(status: process.terminationStatus)
+        }
+        guard result.ok else {
+            throw PluginError.requestFailed(message: result.message)
+        }
+    }
+
+    private func waitForToolResult(requestID: String, output: Pipe) throws -> ToolResult {
+        var bufferedOutput = Data()
+
+        while true {
+            let chunk = output.fileHandleForReading.availableData
+            guard !chunk.isEmpty else {
+                throw PluginError.toolClosedBeforeResponse(requestID)
+            }
+
+            bufferedOutput.append(chunk)
+
+            while let newline = bufferedOutput.firstIndex(of: 0x0A) {
+                let lineData = bufferedOutput[..<newline]
+                bufferedOutput.removeSubrange(...newline)
+                guard !lineData.isEmpty else {
+                    continue
+                }
+
+                let decoded = try JSONSerialization.jsonObject(with: Data(lineData))
+                guard let payload = decoded as? [String: Any],
+                      payload["id"] as? String == requestID
+                else {
+                    continue
+                }
+
+                return ToolResult(
+                    ok: payload["ok"] as? Bool == true,
+                    message: payload["message"] as? String
+                        ?? payload["error"] as? String
+                        ?? "SpeakSwiftlyTool returned a failure response for request '\(requestID)'.",
+                )
+            }
+        }
+    }
+}
+
+private struct ToolResult {
+    let ok: Bool
+    let message: String
+}
+
+private struct Options {
+    let target: String
+    let name: String
+    let text: String
+    let vibe: String
+    let voiceDescription: String
+    let seedID: String
+    let seedVersion: String
+    let sourceVersion: String?
+
+    init(arguments: [String]) throws {
+        var target: String?
+        var name: String?
+        var text: String?
+        var vibe = "femme"
+        var voiceDescription: String?
+        var seedID: String?
+        var seedVersion = "1"
+        var sourceVersion: String?
+
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+                case "--target":
+                    index += 1
+                    target = try Self.value(arguments, at: index, for: argument)
+                case "--name":
+                    index += 1
+                    name = try Self.value(arguments, at: index, for: argument)
+                case "--text":
+                    index += 1
+                    text = try Self.value(arguments, at: index, for: argument)
+                case "--vibe":
+                    index += 1
+                    vibe = try Self.value(arguments, at: index, for: argument)
+                case "--voice-description":
+                    index += 1
+                    voiceDescription = try Self.value(arguments, at: index, for: argument)
+                case "--seed-id":
+                    index += 1
+                    seedID = try Self.value(arguments, at: index, for: argument)
+                case "--seed-version":
+                    index += 1
+                    seedVersion = try Self.value(arguments, at: index, for: argument)
+                case "--source-version":
+                    index += 1
+                    sourceVersion = try Self.value(arguments, at: index, for: argument)
+                case "--help", "-h":
+                    throw PluginError.helpRequested
+                default:
+                    throw PluginError.unknownArgument(argument)
+            }
+            index += 1
+        }
+
+        self.target = try Self.required(target, name: "--target")
+        self.name = try Self.required(name, name: "--name")
+        self.text = try Self.required(text, name: "--text")
+        self.vibe = vibe
+        self.voiceDescription = try Self.required(voiceDescription, name: "--voice-description")
+        self.seedID = seedID ?? self.name
+        self.seedVersion = seedVersion
+        self.sourceVersion = sourceVersion
+    }
+
+    private static func value(_ arguments: [String], at index: Int, for option: String) throws -> String {
+        guard index < arguments.count else {
+            throw PluginError.missingValue(option)
+        }
+
+        return arguments[index]
+    }
+
+    private static func required(_ value: String?, name: String) throws -> String {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            throw PluginError.missingRequiredOption(name)
+        }
+
+        return value
+    }
+}
+
+private struct ToolRequest: Encodable {
+    let id: String
+    let op = "create_system_voice_profile_from_description"
+    let profileName: String
+    let text: String
+    let vibe: String
+    let voiceDescription: String
+    let seedID: String
+    let seedVersion: String
+    let sourcePackage: String
+    let sourceVersion: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case op
+        case profileName = "profile_name"
+        case text
+        case vibe
+        case voiceDescription = "voice_description"
+        case seedID = "seed_id"
+        case seedVersion = "seed_version"
+        case sourcePackage = "source_package"
+        case sourceVersion = "source_version"
+    }
+
+    func encodedLine() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(self)
+        guard let line = String(data: data, encoding: .utf8) else {
+            throw PluginError.requestEncodingFailed
+        }
+
+        return line
+    }
+}
+
+private enum PluginError: Error, CustomStringConvertible {
+    case helpRequested
+    case missingRequiredOption(String)
+    case missingValue(String)
+    case unknownTarget(String)
+    case unknownArgument(String)
+    case requestEncodingFailed
+    case toolClosedBeforeResponse(String)
+    case toolFailed(status: Int32)
+    case requestFailed(message: String)
+
+    var description: String {
+        switch self {
+            case .helpRequested:
+                """
+                Usage: swift package plugin --allow-writing-to-package-directory create-system-voice-profile --target TARGET --name PROFILE_NAME --text TEXT --vibe femme|masc --voice-description DESCRIPTION [--seed-id ID] [--seed-version VERSION] [--source-version VERSION]
+                """
+            case let .missingRequiredOption(option):
+                "Missing required option \(option). Run with --help for usage."
+            case let .missingValue(option):
+                "Missing value for \(option). Run with --help for usage."
+            case let .unknownTarget(target):
+                "No target named '\(target)' exists in this package. Pass the consumer target that will own Resources/SystemProfiles."
+            case let .unknownArgument(argument):
+                "Unknown argument '\(argument)'. Run with --help for usage."
+            case .requestEncodingFailed:
+                "CreateSystemVoiceProfile could not encode the JSONL request for SpeakSwiftlyTool."
+            case let .toolClosedBeforeResponse(requestID):
+                "SpeakSwiftlyTool exited before returning a result for system-profile request '\(requestID)'."
+            case let .toolFailed(status):
+                "SpeakSwiftlyTool exited with status \(status) while creating the system voice profile."
+            case let .requestFailed(message):
+                message
+        }
+    }
+}

--- a/Sources/SpeakSwiftly/API/Configuration.swift
+++ b/Sources/SpeakSwiftly/API/Configuration.swift
@@ -67,6 +67,8 @@ public extension SpeakSwiftly {
         public let marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy
         /// The stored voice profile used when callers do not choose one explicitly.
         public let defaultVoiceProfile: SpeakSwiftly.Name
+        /// Extra bundled system-profile roots supplied by host packages at startup.
+        public let systemProfileResourceRoots: [URL]
         /// An optional text normalizer to reuse instead of creating the default one.
         public let textNormalizer: SpeakSwiftly.Normalizer?
 
@@ -76,12 +78,14 @@ public extension SpeakSwiftly {
             qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy = .preparedConditioning,
             marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy = .dualResidentSerialized,
             defaultVoiceProfile: SpeakSwiftly.Name = SpeakSwiftly.DefaultVoiceProfiles.signal,
+            systemProfileResourceRoots: [URL] = [],
             textNormalizer: SpeakSwiftly.Normalizer? = nil,
         ) {
             self.speechBackend = speechBackend
             self.qwenConditioningStrategy = qwenConditioningStrategy
             self.marvisResidentPolicy = marvisResidentPolicy
             self.defaultVoiceProfile = Self.normalizedDefaultVoiceProfile(defaultVoiceProfile)
+            self.systemProfileResourceRoots = systemProfileResourceRoots.map(\.standardizedFileURL)
             self.textNormalizer = textNormalizer
         }
 
@@ -110,6 +114,7 @@ public extension SpeakSwiftly {
                     forKey: .defaultVoiceProfile,
                 ),
             )
+            systemProfileResourceRoots = []
             textNormalizer = nil
         }
 

--- a/Sources/SpeakSwiftly/API/SupportResources.swift
+++ b/Sources/SpeakSwiftly/API/SupportResources.swift
@@ -30,6 +30,31 @@ public extension SpeakSwiftly {
 
         package static let systemProfileResourcesDirectoryName = "SystemProfiles"
 
+        /// Returns the system-profile resource root inside a package or app bundle.
+        ///
+        /// Pass the host target's `Bundle.module` when a consumer package bundles
+        /// its own generated system profiles.
+        public static func systemProfileRootURL(
+            in bundle: Bundle,
+            fileManager: FileManager = .default,
+        ) -> URL? {
+            guard let resourceURL = bundle.resourceURL else { return nil }
+
+            let rootURL = resourceURL
+                .appendingPathComponent(systemProfileResourcesDirectoryName, isDirectory: true)
+                .appendingPathComponent(ProfileStore.profilesDirectoryName, isDirectory: true)
+                .standardizedFileURL
+
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: rootURL.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue
+            else {
+                return nil
+            }
+
+            return rootURL
+        }
+
         /// Returns the vendored MLX bundle URL.
         public static func mlxBundleURL() throws -> URL {
             let expectedURL = bundle.resourceURL?
@@ -75,21 +100,7 @@ public extension SpeakSwiftly {
         }
 
         package static func bundledSystemProfileRootURL(fileManager: FileManager = .default) -> URL? {
-            guard let resourceURL = bundle.resourceURL else { return nil }
-
-            let rootURL = resourceURL
-                .appendingPathComponent(systemProfileResourcesDirectoryName, isDirectory: true)
-                .appendingPathComponent(ProfileStore.profilesDirectoryName, isDirectory: true)
-                .standardizedFileURL
-
-            var isDirectory: ObjCBool = false
-            guard fileManager.fileExists(atPath: rootURL.path, isDirectory: &isDirectory),
-                  isDirectory.boolValue
-            else {
-                return nil
-            }
-
-            return rootURL
+            systemProfileRootURL(in: bundle, fileManager: fileManager)
         }
     }
 }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Bootstrap.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+Bootstrap.swift
@@ -87,6 +87,7 @@ extension SpeakSwiftly.Runtime {
             configuration: configuration
                 ?? persistedConfiguration,
         )
+        let configuredSystemProfileResourceRoots = configuration?.systemProfileResourceRoots ?? []
         let dependencies = WorkerDependencies.live(
             marvisResidentPolicy: configuredMarvisResidentPolicy,
         )
@@ -97,7 +98,11 @@ extension SpeakSwiftly.Runtime {
             ),
             fileManager: dependencies.fileManager,
         )
-        seedBundledSystemProfilesIfAvailable(into: profileStore, dependencies: dependencies)
+        seedSystemProfilesIfAvailable(
+            from: configuredSystemProfileResourceRoots,
+            into: profileStore,
+            dependencies: dependencies,
+        )
         let systemProfileResourceStore = systemProfileResourceRootURL.map {
             ProfileStore(
                 rootURL: ProfileStore.systemProfileResourceRootURL(from: $0),
@@ -138,26 +143,51 @@ extension SpeakSwiftly.Runtime {
         return runtime
     }
 
-    private static func seedBundledSystemProfilesIfAvailable(
+    private static func seedSystemProfilesIfAvailable(
+        from configuredResourceRootURLs: [URL],
         into profileStore: ProfileStore,
         dependencies: WorkerDependencies,
     ) {
-        guard let resourceRootURL = SpeakSwiftly.SupportResources.bundledSystemProfileRootURL(
+        var seedRoots: [(source: String, url: URL)] = []
+
+        if let bundledRootURL = SpeakSwiftly.SupportResources.bundledSystemProfileRootURL(
             fileManager: dependencies.fileManager,
-        ) else {
-            return
+        ) {
+            seedRoots.append(("SpeakSwiftly bundled", bundledRootURL))
         }
 
+        seedRoots.append(
+            contentsOf: configuredResourceRootURLs.map {
+                ("configured", ProfileStore.systemProfileResourceRootURL(from: $0))
+            },
+        )
+
+        for seedRoot in seedRoots {
+            seedSystemProfilesIfAvailable(
+                from: seedRoot.url,
+                source: seedRoot.source,
+                into: profileStore,
+                dependencies: dependencies,
+            )
+        }
+    }
+
+    private static func seedSystemProfilesIfAvailable(
+        from resourceRootURL: URL,
+        source: String,
+        into profileStore: ProfileStore,
+        dependencies: WorkerDependencies,
+    ) {
         do {
             let summary = try profileStore.seedSystemProfiles(from: resourceRootURL)
             guard summary.changedCount > 0 else { return }
 
             dependencies.writeStderr(
-                "SpeakSwiftly seeded \(summary.installedCount) bundled system voice profile(s) and refreshed \(summary.replacedCount) bundled system voice profile(s) from '\(resourceRootURL.path)'.\n",
+                "SpeakSwiftly seeded \(summary.installedCount) \(source) system voice profile(s) and refreshed \(summary.replacedCount) \(source) system voice profile(s) from '\(resourceRootURL.path)'.\n",
             )
         } catch {
             dependencies.writeStderr(
-                "SpeakSwiftly could not seed bundled system voice profiles from '\(resourceRootURL.path)'. SpeakSwiftly will continue with the existing writable profile store. \(error.localizedDescription)\n",
+                "SpeakSwiftly could not seed \(source) system voice profiles from '\(resourceRootURL.path)'. SpeakSwiftly will continue with the existing writable profile store. \(error.localizedDescription)\n",
             )
         }
     }

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
@@ -50,6 +50,23 @@ let runtime = await SpeakSwiftly.liftoff(
 )
 ```
 
+When a host package owns generated system profiles, bundle them under that
+host target's resources and pass the bundled root at startup:
+
+```swift
+let systemProfileRoots = [
+    SpeakSwiftly.SupportResources.systemProfileRootURL(in: .module),
+].compactMap(\.self)
+
+let runtime = await SpeakSwiftly.liftoff(
+    configuration: .init(systemProfileResourceRoots: systemProfileRoots)
+)
+```
+
+SpeakSwiftly seeds those bundled system profiles into its writable profile store
+during liftoff. After startup, callers use them by name like any other available
+voice profile.
+
 `SPEAKSWIFTLY_PROFILE_ROOT` remains accepted only as a deprecated compatibility
 alias for older hosts. New hosts should pass `stateRootURL`, pass `--state-root`
 to the worker executable, or use `SPEAKSWIFTLY_STATE_ROOT` when startup

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/VoiceProfileCreation.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/VoiceProfileCreation.md
@@ -63,6 +63,30 @@ library creation surface. Ordinary rename, delete, and in-place reroll operation
 reject them with explicit errors. If a user rerolls a system profile, SpeakSwiftly
 creates a user-owned copy instead so the built-in default remains stable.
 
+Consumer packages can author system profiles with the SwiftPM command plugin:
+
+```bash
+swift package plugin --allow-writing-to-package-directory create-system-voice-profile \
+  --target SpeakSwiftlyServer \
+  --name server-announcer \
+  --text "A clear server status voice." \
+  --vibe femme \
+  --voice-description "Clear, bright, steady, and concise."
+```
+
+The target that owns those generated resources should declare
+`.copy("Resources/SystemProfiles")` and pass its bundled root into liftoff:
+
+```swift
+let systemProfileRoots = [
+    SpeakSwiftly.SupportResources.systemProfileRootURL(in: .module),
+].compactMap(\.self)
+
+let runtime = await SpeakSwiftly.liftoff(
+    configuration: .init(systemProfileResourceRoots: systemProfileRoots)
+)
+```
+
 ## Observe Completion
 
 Both creation paths return a request handle, so completion is observed the same way as speech generation:

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -63,6 +63,14 @@ import Darwin
     #expect(configuration.defaultVoiceProfile == SpeakSwiftly.DefaultVoiceProfiles.signal)
 }
 
+@Test func `public configuration carries startup system profile resource roots`() {
+    let rootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let configuration = SpeakSwiftly.Configuration(systemProfileResourceRoots: [rootURL])
+
+    #expect(configuration.systemProfileResourceRoots == [rootURL.standardizedFileURL])
+}
+
 @Test func `public configuration round trips to disk`() throws {
     let rootURL = URL(fileURLWithPath: NSTemporaryDirectory())
         .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -83,6 +91,7 @@ import Darwin
     #expect(loaded.qwenConditioningStrategy == configuration.qwenConditioningStrategy)
     #expect(loaded.marvisResidentPolicy == configuration.marvisResidentPolicy)
     #expect(loaded.defaultVoiceProfile == configuration.defaultVoiceProfile)
+    #expect(loaded.systemProfileResourceRoots.isEmpty)
     #expect(loaded.textNormalizer == nil)
 }
 
@@ -241,6 +250,48 @@ import Darwin
     let runtime = await SpeakSwiftly.liftoff(stateRootURL: stateRoot)
 
     #expect(await runtime.speechBackend == .marvis)
+}
+
+@Test func `liftoff seeds configured system profile resource roots`() async throws {
+    let fileManager = FileManager.default
+    let tempRoot = makeTempDirectoryURL()
+    defer { try? fileManager.removeItem(at: tempRoot) }
+
+    let stateRoot = tempRoot.appendingPathComponent("RuntimeState", isDirectory: true)
+    let resourceRoot = tempRoot.appendingPathComponent("SystemProfiles", isDirectory: true)
+    let resourceProfileRoot = resourceRoot.appendingPathComponent("profiles", isDirectory: true)
+    let resourceStore = ProfileStore(rootURL: resourceProfileRoot, fileManager: fileManager)
+
+    _ = try resourceStore.createProfile(
+        profileName: "server-system-profile",
+        vibe: .femme,
+        modelRepo: "test-model",
+        voiceDescription: "Clear and bright.",
+        sourceText: "Hello there",
+        author: .system,
+        seed: SpeakSwiftly.ProfileSeed(
+            seedID: "server.system",
+            seedVersion: "1",
+            intendedProfileName: "server-system-profile",
+            sourcePackage: "SpeakSwiftlyServerTests",
+        ),
+        sampleRate: 24000,
+        canonicalAudioData: Data([0x52, 0x49, 0x46, 0x46]),
+    )
+
+    _ = await SpeakSwiftly.liftoff(
+        configuration: SpeakSwiftly.Configuration(systemProfileResourceRoots: [resourceRoot]),
+        stateRootURL: stateRoot,
+    )
+
+    let writableStore = ProfileStore(
+        rootURL: stateRoot.appendingPathComponent("profiles", isDirectory: true),
+        fileManager: fileManager,
+    )
+    let installedProfile = try writableStore.loadProfile(named: "server-system-profile")
+
+    #expect(installedProfile.manifest.author == .system)
+    #expect(installedProfile.manifest.seed?.seedID == "server.system")
 }
 
 // MARK: - Runtime Helpers

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeLibraryControlSurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeLibraryControlSurfaceTests.swift
@@ -367,14 +367,11 @@ import TextForSpeech
     )
 
     #expect(await waitUntil {
-        FileManager.default.fileExists(
-            atPath: systemResourceStore.profileDirectoryURL(for: "swift-signal").path,
-        )
-    })
-    #expect(output.containsJSONObject {
-        $0["id"] as? String == "req-system"
-            && $0["ok"] as? Bool == true
-            && $0["profile_name"] as? String == "swift-signal"
+        output.containsJSONObject {
+            $0["id"] as? String == "req-system"
+                && $0["ok"] as? Bool == true
+                && $0["profile_name"] as? String == "swift-signal"
+        }
     })
 
     let created = try systemResourceStore.loadProfile(named: "swift-signal")


### PR DESCRIPTION
## Release

- prepares v7.2.0 from branch `runtime/consumer-system-profile-resources`
- keeps protected `main` updates behind pull request review and CI
- release tag `v7.2.0` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command plugin to create system voice profiles and bundle them with your app's resources.
  * Configuration now accepts system profile resource root paths for custom profile bundles.

* **Documentation**
  * Updated guides explaining how to use the new profile creation workflow and configure resource bundles at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->