### PR TITLE
release: prepare v7.2.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,6 +51,9 @@ let package = Package(
                 .copy("Resources/mlx-swift_Cmlx.bundle"),
                 .copy("Resources/SystemProfiles"),
             ],
+            linkerSettings: [
+                .linkedFramework("CoreGraphics", .when(platforms: [.macOS])),
+            ],
         ),
         .executableTarget(
             name: "SpeakSwiftlyTool",

--- a/Sources/SpeakSwiftly/Generation/SpeechModelFactory.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechModelFactory.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import Metal
 @preconcurrency import MLX
 import MLXAudioSTT
 import MLXAudioTTS
@@ -64,8 +65,17 @@ enum ModelFactory {
         backend.residentModelRepo
     }
 
-    static func loadProfileModel() async throws -> AnySpeechModel {
-        try await loadModel(modelRepo: profileModelRepo)
+    static func loadProfileModel(
+        hasDefaultMetalDevice: @Sendable () -> Bool = defaultMetalDeviceIsAvailable,
+    ) async throws -> AnySpeechModel {
+        guard hasDefaultMetalDevice() else {
+            throw WorkerError(
+                code: .modelLoading,
+                message: "SpeakSwiftly could not load the voice-design profile model because Metal did not provide a default GPU device for this process. On macOS, command-line hosts must link Core Graphics before requesting the default Metal device; if this is running from a service, make sure the process is launched in a user session with Metal access.",
+            )
+        }
+
+        return try await loadModel(modelRepo: profileModelRepo)
     }
 
     static func loadCloneTranscriptionModel() async throws -> AnyCloneTranscriptionModel {
@@ -76,5 +86,9 @@ enum ModelFactory {
     private static func loadModel(modelRepo: String) async throws -> AnySpeechModel {
         let model = try await TTS.loadModel(modelRepo: modelRepo)
         return AnySpeechModel(model: model)
+    }
+
+    private static func defaultMetalDeviceIsAvailable() -> Bool {
+        MTLCreateSystemDefaultDevice() != nil
     }
 }

--- a/Tests/SpeakSwiftlyTests/Generation/SpeechModelClientTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/SpeechModelClientTests.swift
@@ -24,6 +24,19 @@ Hello from the real resident SpeakSwiftly playback path. This end to end test no
     #expect(ModelFactory.residentModelRepo(for: .marvis) == ModelFactory.marvisResidentModelRepo)
 }
 
+@Test func `profile model load reports missing metal device before mlx model load`() async throws {
+    do {
+        _ = try await ModelFactory.loadProfileModel(hasDefaultMetalDevice: { false })
+        Issue.record("Expected profile model loading to fail before MLX loads the voice-design model.")
+    } catch let error as WorkerError {
+        #expect(error.code == .modelLoading)
+        #expect(error.message.contains("Metal did not provide a default GPU device"))
+        #expect(error.message.contains("Core Graphics"))
+    } catch {
+        Issue.record("Expected WorkerError, got \(error).")
+    }
+}
+
 @Test func `adaptive playback thresholds seed from text complexity classes`() {
     let compact = PlaybackThresholdController(text: "Hello there.").thresholds
     let balanced = PlaybackThresholdController(


### PR DESCRIPTION
## Release

- prepares v7.2.2 from branch `fix/68-profile-model-device-crash`
- keeps protected `main` updates behind pull request review and CI
- release tag `v7.2.2` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when device resources are unavailable, providing clearer diagnostics.
  * Improved platform-specific initialization and compatibility on macOS.

* **Tests**
  * Added test coverage for error handling in resource initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->