### PR TITLE
plugin: wait for terminal tool responses

### DIFF
--- a/Plugins/UpsertSystemVoiceProfile/UpsertSystemVoiceProfile.swift
+++ b/Plugins/UpsertSystemVoiceProfile/UpsertSystemVoiceProfile.swift
@@ -106,9 +106,12 @@ struct UpsertSystemVoiceProfilePlugin: CommandPlugin {
                 else {
                     continue
                 }
+                guard let ok = payload["ok"] as? Bool else {
+                    continue
+                }
 
                 return ToolResult(
-                    ok: payload["ok"] as? Bool == true,
+                    ok: ok,
                     message: payload["message"] as? String
                         ?? payload["error"] as? String
                         ?? "SpeakSwiftlyTool returned a failure response for request '\(requestID)'.",


### PR DESCRIPTION
Patch release fix for the UpsertSystemVoiceProfile command plugin. The plugin now ignores matching lifecycle JSONL events until SpeakSwiftlyTool emits a terminal response envelope with an ok field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice profile processing to handle system tool responses with stricter validation, enhancing reliability in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->