### PR TITLE
release: prepare v7.2.6

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,6 +7,13 @@ on:
     tags:
       - 'v*'
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run_ios_smoke:
+        description: Run the iOS compile-and-smoke lane
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-and-test:
@@ -86,6 +93,7 @@ jobs:
 
   ios-compile-and-smoke:
     name: iOS compile and smoke on macOS 26
+    if: github.event_name == 'workflow_dispatch' && inputs.run_ios_smoke
     runs-on: macos-26
     env:
       SPEAKSWIFTLY_IOS_CI_DERIVED_DATA: .local/xcode/derived-data/ios-ci

--- a/Sources/SpeakSwiftly/API/PlaybackObservation.swift
+++ b/Sources/SpeakSwiftly/API/PlaybackObservation.swift
@@ -13,6 +13,16 @@ public extension SpeakSwiftly {
     /// A meaningful event in the live playback surface.
     enum PlaybackEvent: Codable, Sendable, Equatable {
         case stateChanged(PlaybackState)
+        case started(requestID: String)
+        case activeRequestChanged(ActiveRequest?)
+        case queueChanged(activeRequest: ActiveRequest?, queuedRequests: [QueuedRequest])
+        case firstChunk(requestID: String)
+        case prerollReady(requestID: String, bufferedAudioMS: Int, startupBufferTargetMS: Int)
+        case rebufferStarted(requestID: String, queuedAudioMS: Int, resumeBufferTargetMS: Int)
+        case rebufferResumed(requestID: String, bufferedAudioMS: Int, resumeBufferTargetMS: Int)
+        case completed(requestID: String)
+        case outputDeviceChanged(previousDevice: String?, currentDevice: String?)
+        case interruptionChanged(isInterrupted: Bool, shouldResume: Bool?)
     }
 
     /// A sequenced playback-state publication.

--- a/Sources/SpeakSwiftly/Playback/PlaybackHooks.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackHooks.swift
@@ -1,6 +1,10 @@
 struct PlaybackHooks {
     let handleEvent: @Sendable (PlaybackEvent, LiveSpeechRequestState) async -> Void
     let handleEnvironmentEvent: @Sendable (PlaybackEnvironmentEvent, ActiveWorkerRequestSummary?) async -> Void
+    let playbackStarted: @Sendable (String) async -> Void
+    let playbackCompleted: @Sendable (String) async -> Void
+    let activeRequestChanged: @Sendable () async -> Void
+    let queueChanged: @Sendable () async -> Void
     let logEngineReady: @Sendable (LiveSpeechRequestState, Double) async -> Void
     let logFinished: @Sendable (LiveSpeechRequestState, PlaybackSummary, Double) async -> Void
     let completeJob: @Sendable (LiveSpeechRequestState, Result<SpeakSwiftly.Runtime.WorkerSuccessPayload, WorkerError>) async -> Void

--- a/Sources/SpeakSwiftly/Playback/PlaybackQueue+Execution.swift
+++ b/Sources/SpeakSwiftly/Playback/PlaybackQueue+Execution.swift
@@ -16,6 +16,9 @@ extension PlaybackQueue {
         activePlaybackFragileOverlapWindowProgress = nil
         activePlaybackIsRebuffering = false
         playbackState.execution.playbackTask = task
+        await hooks.playbackStarted(requestID)
+        await hooks.activeRequestChanged()
+        await hooks.queueChanged()
     }
 
     private func runPlayback(
@@ -86,6 +89,9 @@ extension PlaybackQueue {
         playbackState.execution.generationTask = nil
         playbackState.execution.playbackTask = nil
         await hooks.completeJob(playbackState.request, result)
+        await hooks.playbackCompleted(requestID)
+        await hooks.activeRequestChanged()
+        await hooks.queueChanged()
         await hooks.resumeQueue()
     }
 }

--- a/Sources/SpeakSwiftly/Playback/RuntimePlaybackEvents.swift
+++ b/Sources/SpeakSwiftly/Playback/RuntimePlaybackEvents.swift
@@ -10,9 +10,17 @@ extension SpeakSwiftly.Runtime {
 
         switch event {
             case .firstChunk:
+                await publishPlaybackUpdate(event: .firstChunk(requestID: id))
                 await emitProgress(id: id, stage: .bufferingAudio)
                 await logRequestEvent("playback_first_chunk", requestID: id, op: op, profileName: profileName)
             case let .prerollReady(startupBufferedAudioMS, thresholds):
+                await publishPlaybackUpdate(
+                    event: .prerollReady(
+                        requestID: id,
+                        bufferedAudioMS: startupBufferedAudioMS,
+                        startupBufferTargetMS: thresholds.startupBufferTargetMS,
+                    ),
+                )
                 await emitProgress(id: id, stage: .prerollReady)
                 await logRequestEvent(
                     "playback_preroll_ready",
@@ -50,6 +58,13 @@ extension SpeakSwiftly.Runtime {
                     details: ["queued_audio_ms": .int(queuedAudioMS)],
                 )
             case let .rebufferStarted(queuedAudioMS, thresholds):
+                await publishPlaybackUpdate(
+                    event: .rebufferStarted(
+                        requestID: id,
+                        queuedAudioMS: queuedAudioMS,
+                        resumeBufferTargetMS: thresholds.resumeBufferTargetMS,
+                    ),
+                )
                 await logRequestEvent(
                     "playback_rebuffer_started",
                     requestID: id,
@@ -63,6 +78,13 @@ extension SpeakSwiftly.Runtime {
                     .merging(memoryDetails(), uniquingKeysWith: { _, new in new }),
                 )
             case let .rebufferResumed(bufferedAudioMS, thresholds):
+                await publishPlaybackUpdate(
+                    event: .rebufferResumed(
+                        requestID: id,
+                        bufferedAudioMS: bufferedAudioMS,
+                        resumeBufferTargetMS: thresholds.resumeBufferTargetMS,
+                    ),
+                )
                 await logRequestEvent(
                     "playback_rebuffer_resumed",
                     requestID: id,
@@ -110,6 +132,9 @@ extension SpeakSwiftly.Runtime {
                     ],
                 )
             case let .outputDeviceChanged(previousDevice, currentDevice):
+                await publishPlaybackUpdate(
+                    event: .outputDeviceChanged(previousDevice: previousDevice, currentDevice: currentDevice),
+                )
                 await logRequestEvent(
                     "playback_output_device_changed",
                     requestID: id,
@@ -191,6 +216,9 @@ extension SpeakSwiftly.Runtime {
                     ],
                 )
             case let .outputDeviceChanged(previousDevice, currentDevice):
+                await publishPlaybackUpdate(
+                    event: .outputDeviceChanged(previousDevice: previousDevice, currentDevice: currentDevice),
+                )
                 await logEvent(
                     "playback_output_device_changed",
                     requestID: requestID,
@@ -214,6 +242,9 @@ extension SpeakSwiftly.Runtime {
                     ],
                 )
             case let .interruptionStateChanged(isInterrupted, shouldResume):
+                await publishPlaybackUpdate(
+                    event: .interruptionChanged(isInterrupted: isInterrupted, shouldResume: shouldResume),
+                )
                 var details: [String: LogValue] = [
                     "is_interrupted": .bool(isInterrupted),
                     "had_active_request": .bool(activeRequest != nil),

--- a/Sources/SpeakSwiftly/Playback/RuntimePlaybackQueueCommands.swift
+++ b/Sources/SpeakSwiftly/Playback/RuntimePlaybackQueueCommands.swift
@@ -147,6 +147,5 @@ extension SpeakSwiftly.Runtime {
         result: Result<WorkerSuccessPayload, WorkerError>,
     ) async {
         await completeRequest(request: speechRequest.request, result: result)
-        await publishPlaybackUpdate()
     }
 }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+ControlRequests.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+ControlRequests.swift
@@ -344,6 +344,7 @@ extension SpeakSwiftly.Runtime {
                     )
 
                 case let .clearQueue(id, queueType):
+                    let previousPlaybackSnapshot = await playbackSnapshot()
                     let clearedCount = await clearQueuedRequests(
                         queueType: queueType,
                         cancelledByRequestID: id,
@@ -353,36 +354,22 @@ extension SpeakSwiftly.Runtime {
                         case .generation:
                             await publishGenerateUpdate()
                         case .playback:
-                            await publishPlaybackUpdate(eventFromSnapshot: { snapshot in
-                                .queueChanged(
-                                    activeRequest: snapshot.activeRequest,
-                                    queuedRequests: snapshot.queuedRequests,
-                                )
-                            })
+                            await publishPlaybackQueueChangedIfNeeded(since: previousPlaybackSnapshot)
                         case nil:
                             await publishGenerateUpdate()
-                            await publishPlaybackUpdate(eventFromSnapshot: { snapshot in
-                                .queueChanged(
-                                    activeRequest: snapshot.activeRequest,
-                                    queuedRequests: snapshot.queuedRequests,
-                                )
-                            })
+                            await publishPlaybackQueueChangedIfNeeded(since: previousPlaybackSnapshot)
                     }
                     result = .success(WorkerSuccessPayload(id: id, clearedCount: clearedCount))
 
                 case let .cancelRequest(id, targetRequestID, queueType):
+                    let previousPlaybackSnapshot = await playbackSnapshot()
                     let cancelledRequestID = try await cancelRequestNow(
                         targetRequestID,
                         queueType: queueType,
                         cancelledByRequestID: id,
                     )
                     await publishGenerateUpdate()
-                    await publishPlaybackUpdate(eventFromSnapshot: { snapshot in
-                        .queueChanged(
-                            activeRequest: snapshot.activeRequest,
-                            queuedRequests: snapshot.queuedRequests,
-                        )
-                    })
+                    await publishPlaybackQueueChangedIfNeeded(since: previousPlaybackSnapshot)
                     result = .success(WorkerSuccessPayload(id: id, cancelledRequestID: cancelledRequestID))
 
                 case .queueSpeech,

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+ControlRequests.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+ControlRequests.swift
@@ -353,10 +353,20 @@ extension SpeakSwiftly.Runtime {
                         case .generation:
                             await publishGenerateUpdate()
                         case .playback:
-                            await publishPlaybackUpdate()
+                            await publishPlaybackUpdate(eventFromSnapshot: { snapshot in
+                                .queueChanged(
+                                    activeRequest: snapshot.activeRequest,
+                                    queuedRequests: snapshot.queuedRequests,
+                                )
+                            })
                         case nil:
                             await publishGenerateUpdate()
-                            await publishPlaybackUpdate()
+                            await publishPlaybackUpdate(eventFromSnapshot: { snapshot in
+                                .queueChanged(
+                                    activeRequest: snapshot.activeRequest,
+                                    queuedRequests: snapshot.queuedRequests,
+                                )
+                            })
                     }
                     result = .success(WorkerSuccessPayload(id: id, clearedCount: clearedCount))
 
@@ -367,7 +377,12 @@ extension SpeakSwiftly.Runtime {
                         cancelledByRequestID: id,
                     )
                     await publishGenerateUpdate()
-                    await publishPlaybackUpdate()
+                    await publishPlaybackUpdate(eventFromSnapshot: { snapshot in
+                        .queueChanged(
+                            activeRequest: snapshot.activeRequest,
+                            queuedRequests: snapshot.queuedRequests,
+                        )
+                    })
                     result = .success(WorkerSuccessPayload(id: id, cancelledRequestID: cancelledRequestID))
 
                 case .queueSpeech,

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+RequestObservation.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+RequestObservation.swift
@@ -310,6 +310,26 @@ extension SpeakSwiftly.Runtime {
         playbackObservationBroker.broadcast(update)
     }
 
+    func publishPlaybackQueueChangedIfNeeded(
+        since previousSnapshot: SpeakSwiftly.PlaybackSnapshot,
+    ) async {
+        let snapshot = await playbackSnapshot()
+        guard snapshot.activeRequest != previousSnapshot.activeRequest
+            || snapshot.queuedRequests != previousSnapshot.queuedRequests
+        else {
+            return
+        }
+
+        let update = makePlaybackUpdate(
+            snapshot: snapshot,
+            event: .queueChanged(
+                activeRequest: snapshot.activeRequest,
+                queuedRequests: snapshot.queuedRequests,
+            ),
+        )
+        playbackObservationBroker.broadcast(update)
+    }
+
     func makeGenerateUpdate(
         state: SpeakSwiftly.GenerateState,
         advanceSequence: Bool = true,

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+RequestObservation.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+RequestObservation.swift
@@ -277,7 +277,7 @@ extension SpeakSwiftly.Runtime {
         let latestUpdate = if let latestPlaybackUpdate = playbackObservationBroker.latestUpdate {
             latestPlaybackUpdate
         } else {
-            makePlaybackUpdate(state: snapshot.state, advanceSequence: false)
+            makePlaybackUpdate(snapshot: snapshot, advanceSequence: false)
         }
 
         return AsyncStream { continuation in
@@ -296,8 +296,17 @@ extension SpeakSwiftly.Runtime {
         generateObservationBroker.broadcast(update)
     }
 
-    func publishPlaybackUpdate() async {
-        let update = await makePlaybackUpdate(state: playbackSnapshot().state)
+    func publishPlaybackUpdate(event: SpeakSwiftly.PlaybackEvent? = nil) async {
+        let snapshot = await playbackSnapshot()
+        let update = makePlaybackUpdate(snapshot: snapshot, event: event)
+        playbackObservationBroker.broadcast(update)
+    }
+
+    func publishPlaybackUpdate(
+        eventFromSnapshot buildEvent: (SpeakSwiftly.PlaybackSnapshot) -> SpeakSwiftly.PlaybackEvent,
+    ) async {
+        let snapshot = await playbackSnapshot()
+        let update = makePlaybackUpdate(snapshot: snapshot, event: buildEvent(snapshot))
         playbackObservationBroker.broadcast(update)
     }
 
@@ -315,16 +324,17 @@ extension SpeakSwiftly.Runtime {
         }
     }
 
-    func makePlaybackUpdate(
-        state: SpeakSwiftly.PlaybackState,
+    private func makePlaybackUpdate(
+        snapshot: SpeakSwiftly.PlaybackSnapshot,
+        event: SpeakSwiftly.PlaybackEvent? = nil,
         advanceSequence: Bool = true,
     ) -> SpeakSwiftly.PlaybackUpdate {
         playbackObservationBroker.makeUpdate(advanceSequence: advanceSequence) { sequence in
             SpeakSwiftly.PlaybackUpdate(
                 sequence: sequence,
                 date: dependencies.now(),
-                state: state,
-                event: .stateChanged(state),
+                state: snapshot.state,
+                event: event ?? .stateChanged(snapshot.state),
             )
         }
     }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntimeLifecycle.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntimeLifecycle.swift
@@ -15,6 +15,25 @@ extension SpeakSwiftly.Runtime {
                 handleEnvironmentEvent: { [weak self] event, activeRequest in
                     await self?.handlePlaybackEnvironmentEvent(event, activeRequest: activeRequest)
                 },
+                playbackStarted: { [weak self] requestID in
+                    await self?.publishPlaybackUpdate(event: .started(requestID: requestID))
+                },
+                playbackCompleted: { [weak self] requestID in
+                    await self?.publishPlaybackUpdate(event: .completed(requestID: requestID))
+                },
+                activeRequestChanged: { [weak self] in
+                    await self?.publishPlaybackUpdate(eventFromSnapshot: { snapshot in
+                        .activeRequestChanged(snapshot.activeRequest)
+                    })
+                },
+                queueChanged: { [weak self] in
+                    await self?.publishPlaybackUpdate(eventFromSnapshot: { snapshot in
+                        .queueChanged(
+                            activeRequest: snapshot.activeRequest,
+                            queuedRequests: snapshot.queuedRequests,
+                        )
+                    })
+                },
                 logEngineReady: { [weak self] job, sampleRate in
                     await self?.logPlaybackEngineReady(for: job, sampleRate: sampleRate)
                 },
@@ -309,7 +328,12 @@ extension SpeakSwiftly.Runtime {
                 return
             }
             await playbackQueue.enqueue(speechJob)
-            await publishPlaybackUpdate()
+            await publishPlaybackUpdate(eventFromSnapshot: { snapshot in
+                .queueChanged(
+                    activeRequest: snapshot.activeRequest,
+                    queuedRequests: snapshot.queuedRequests,
+                )
+            })
             guard await generationQueue.markReady(token: job.token) != nil else {
                 _ = await playbackQueue.discard(requestID: request.id)
                 return

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
@@ -123,10 +123,12 @@ for try await update in runtime.updates(for: handle.id) {
 
 When you want the broader runtime view instead of one request, use ``SpeakSwiftly/Runtime/snapshot()`` for resident state, backend, default voice profile, and resolved storage paths. Use ``SpeakSwiftly/Generate/snapshot()`` for generation queue state and ``SpeakSwiftly/Playback/snapshot()`` for playback state and queued playback work.
 
+For live playback milestones, subscribe to ``SpeakSwiftly/Playback/updates()`` and branch on ``SpeakSwiftly/PlaybackUpdate/event``. ``SpeakSwiftly/PlaybackEvent`` reports stable operator-facing milestones such as active request changes, queue changes, first chunk, preroll readiness, rebuffer start and recovery, completion, output-device changes, and interruption changes. Detailed trace diagnostics remain internal logs.
+
 ## Where To Look Next
 
 After the runtime is up, the next question is usually whether you care about live playback or retained output:
 
-- For live queue control, continue with ``SpeakSwiftly/Playback`` and ``SpeakSwiftly/PlaybackState``.
+- For live queue control and playback milestones, continue with ``SpeakSwiftly/Playback``, ``SpeakSwiftly/PlaybackState``, and ``SpeakSwiftly/PlaybackEvent``.
 - For stored output and later inspection, continue with <doc:RetainedArtifacts>.
 - For stored voice-profile management, continue with ``SpeakSwiftly/Voices``.

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/SpeakSwiftly.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/SpeakSwiftly.md
@@ -44,7 +44,9 @@ If you need custom text normalization behavior, create a ``SpeakSwiftly/Normaliz
 ### Playback And Observation
 
 - ``SpeakSwiftly/Playback``
+- ``SpeakSwiftly/PlaybackEvent``
 - ``SpeakSwiftly/PlaybackState``
+- ``SpeakSwiftly/PlaybackUpdate``
 - ``SpeakSwiftly/GenerateSnapshot``
 - ``SpeakSwiftly/PlaybackSnapshot``
 - ``SpeakSwiftly/RuntimeSnapshot``

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -969,6 +969,7 @@ import Darwin
     let generateSnapshotQueued: KeyPath<SpeakSwiftly.GenerateSnapshot, [SpeakSwiftly.QueuedRequest]> = \.queuedRequests
     let playbackUpdateSequence: KeyPath<SpeakSwiftly.PlaybackUpdate, Int> = \.sequence
     let playbackUpdateState: KeyPath<SpeakSwiftly.PlaybackUpdate, SpeakSwiftly.PlaybackState> = \.state
+    let playbackUpdateEvent: KeyPath<SpeakSwiftly.PlaybackUpdate, SpeakSwiftly.PlaybackEvent> = \.event
     let playbackSnapshotActive: KeyPath<SpeakSwiftly.PlaybackSnapshot, SpeakSwiftly.ActiveRequest?> = \.activeRequest
     let playbackSnapshotQueued: KeyPath<SpeakSwiftly.PlaybackSnapshot, [SpeakSwiftly.QueuedRequest]> = \.queuedRequests
     let runtimeUpdateSequence: KeyPath<SpeakSwiftly.RuntimeUpdate, Int> = \.sequence
@@ -989,6 +990,7 @@ import Darwin
     _ = generateSnapshotQueued
     _ = playbackUpdateSequence
     _ = playbackUpdateState
+    _ = playbackUpdateEvent
     _ = playbackSnapshotActive
     _ = playbackSnapshotQueued
     _ = runtimeUpdateSequence
@@ -1002,6 +1004,40 @@ import Darwin
     _ = textProfilesPath
     _ = generatedFilesRootPath
     _ = generationJobsRootPath
+}
+
+@Test func `public playback events expose stable operator milestones`() {
+    let activeRequest = SpeakSwiftly.ActiveRequest(
+        id: "active-1",
+        kind: .generateSpeech,
+        voiceProfile: "testing-profile",
+        requestContext: nil,
+    )
+    let queuedRequest = SpeakSwiftly.QueuedRequest(
+        id: "queued-1",
+        kind: .generateSpeech,
+        voiceProfile: "testing-profile",
+        requestContext: nil,
+        queuePosition: 1,
+    )
+
+    let events: [SpeakSwiftly.PlaybackEvent] = [
+        .stateChanged(.playing),
+        .started(requestID: activeRequest.id),
+        .activeRequestChanged(activeRequest),
+        .activeRequestChanged(nil),
+        .queueChanged(activeRequest: activeRequest, queuedRequests: [queuedRequest]),
+        .firstChunk(requestID: activeRequest.id),
+        .prerollReady(requestID: activeRequest.id, bufferedAudioMS: 500, startupBufferTargetMS: 480),
+        .rebufferStarted(requestID: activeRequest.id, queuedAudioMS: 120, resumeBufferTargetMS: 320),
+        .rebufferResumed(requestID: activeRequest.id, bufferedAudioMS: 340, resumeBufferTargetMS: 320),
+        .completed(requestID: activeRequest.id),
+        .outputDeviceChanged(previousDevice: "Built-in Output", currentDevice: "External Headphones"),
+        .interruptionChanged(isInterrupted: true, shouldResume: nil),
+        .interruptionChanged(isInterrupted: false, shouldResume: true),
+    ]
+
+    #expect(events.count == 13)
 }
 
 @Test func `public text normalization surface exposes profile metadata`() {

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeControlSurfaceTests.swift
@@ -104,6 +104,215 @@ import TextForSpeech
     await playbackDrain.open()
 }
 
+@Test func `playback updates report public playback milestones`() async throws {
+    let output = OutputRecorder()
+    let updateRecorder = PlaybackUpdateRecorder()
+    let storeRoot = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: storeRoot) }
+
+    let store = try makeProfileStore(rootURL: storeRoot)
+    _ = try store.createProfile(
+        profileName: "default-femme",
+        modelRepo: "test-model",
+        voiceDescription: "Warm and bright.",
+        sourceText: "Reference transcript",
+        sampleRate: 24000,
+        canonicalAudioData: Data([0x01, 0x02]),
+    )
+
+    let runtime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: output,
+        playback: PlaybackSpy(behavior: .emitLowQueueThenStarve),
+        residentModelLoader: { _ in makeResidentModel() },
+    )
+    let updates = await runtime.playback.updates()
+    let collector = Task {
+        for await update in updates {
+            updateRecorder.record(update)
+        }
+    }
+    defer {
+        collector.cancel()
+    }
+
+    await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    let handle = await runtime.generate.speech(text: "Hello there", voiceProfile: "default-femme")
+
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            $0 == .started(requestID: handle.id)
+        }
+    })
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            $0 == .firstChunk(requestID: handle.id)
+        }
+    })
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            if case let .prerollReady(requestID, bufferedAudioMS, startupBufferTargetMS) = $0 {
+                return requestID == handle.id && bufferedAudioMS >= 0 && startupBufferTargetMS > 0
+            }
+            return false
+        }
+    })
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            if case let .rebufferStarted(requestID, queuedAudioMS, resumeBufferTargetMS) = $0 {
+                return requestID == handle.id && queuedAudioMS == 120 && resumeBufferTargetMS > 0
+            }
+            return false
+        }
+    })
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            if case let .rebufferResumed(requestID, bufferedAudioMS, resumeBufferTargetMS) = $0 {
+                return requestID == handle.id && bufferedAudioMS == 320 && resumeBufferTargetMS > 0
+            }
+            return false
+        }
+    })
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            $0 == .completed(requestID: handle.id)
+        }
+    })
+}
+
+@Test func `playback updates report queue handoff and pause resume state changes`() async throws {
+    let output = OutputRecorder()
+    let playbackDrain = AsyncGate()
+    let updateRecorder = PlaybackUpdateRecorder()
+    let storeRoot = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: storeRoot) }
+
+    let store = try makeProfileStore(rootURL: storeRoot)
+    _ = try store.createProfile(
+        profileName: "default-femme",
+        modelRepo: "test-model",
+        voiceDescription: "Warm and bright.",
+        sourceText: "Reference transcript",
+        sampleRate: 24000,
+        canonicalAudioData: Data([0x01, 0x02]),
+    )
+
+    let runtime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: output,
+        playback: PlaybackSpy(behavior: .gate(playbackDrain)),
+        residentModelLoader: { _ in makeResidentModel() },
+    )
+    let updates = await runtime.playback.updates()
+    let collector = Task {
+        for await update in updates {
+            updateRecorder.record(update)
+        }
+    }
+    defer {
+        collector.cancel()
+    }
+
+    await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    let activeHandle = await runtime.generate.speech(text: "Hello there", voiceProfile: "default-femme")
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            $0 == .started(requestID: activeHandle.id)
+        }
+    })
+
+    _ = await runtime.playback.pause()
+    #expect(await waitUntil {
+        updateRecorder.containsUpdate(state: .paused, event: .stateChanged(.paused))
+    })
+
+    _ = await runtime.playback.resume()
+    #expect(await waitUntil {
+        updateRecorder.containsUpdate(state: .playing, event: .stateChanged(.playing))
+    })
+
+    let queuedHandle = await runtime.generate.speech(text: "Hi there", voiceProfile: "default-femme")
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            if case let .queueChanged(activeRequest, queuedRequests) = $0 {
+                return activeRequest?.id == activeHandle.id
+                    && queuedRequests.map(\.id).contains(queuedHandle.id)
+            }
+            return false
+        }
+    })
+
+    await playbackDrain.open()
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            if case let .activeRequestChanged(activeRequest) = $0 {
+                return activeRequest?.id == queuedHandle.id
+            }
+            return false
+        }
+    })
+}
+
+@Test func `playback updates report stable environment events`() async throws {
+    let output = OutputRecorder()
+    let updateRecorder = PlaybackUpdateRecorder()
+    let runtime = try await makeRuntime(
+        output: output,
+        playback: PlaybackSpy(
+            environmentEvents: [
+                .outputDeviceChanged(previousDevice: "Built-in Output", currentDevice: "External Headphones"),
+                .interruptionStateChanged(isInterrupted: true, shouldResume: nil),
+                .interruptionStateChanged(isInterrupted: false, shouldResume: true),
+            ],
+        ),
+        residentModelLoader: { _ in makeResidentModel() },
+    )
+    let updates = await runtime.playback.updates()
+    let collector = Task {
+        for await update in updates {
+            updateRecorder.record(update)
+        }
+    }
+    defer {
+        collector.cancel()
+    }
+
+    await runtime.start()
+
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            $0 == .outputDeviceChanged(
+                previousDevice: "Built-in Output",
+                currentDevice: "External Headphones",
+            )
+        }
+    })
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            $0 == .interruptionChanged(isInterrupted: true, shouldResume: nil)
+        }
+    })
+    #expect(await waitUntil {
+        updateRecorder.containsEvent {
+            $0 == .interruptionChanged(isInterrupted: false, shouldResume: true)
+        }
+    })
+}
+
 @Test func `generation updates report running after a queued request is reserved`() async throws {
     let output = OutputRecorder()
     let generationDrain = AsyncGate()
@@ -1105,6 +1314,32 @@ private final class GenerateUpdateRecorder: @unchecked Sendable {
     func statesDescription() -> String {
         lock.withLock {
             String(describing: states)
+        }
+    }
+}
+
+private final class PlaybackUpdateRecorder: @unchecked Sendable {
+    private var updates = [SpeakSwiftly.PlaybackUpdate]()
+    private let lock = NSLock()
+
+    func record(_ update: SpeakSwiftly.PlaybackUpdate) {
+        lock.withLock {
+            updates.append(update)
+        }
+    }
+
+    func containsEvent(where predicate: (SpeakSwiftly.PlaybackEvent) -> Bool) -> Bool {
+        lock.withLock {
+            updates.contains { predicate($0.event) }
+        }
+    }
+
+    func containsUpdate(
+        state: SpeakSwiftly.PlaybackState,
+        event: SpeakSwiftly.PlaybackEvent,
+    ) -> Bool {
+        lock.withLock {
+            updates.contains { $0.state == state && $0.event == event }
         }
     }
 }

--- a/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
@@ -323,6 +323,11 @@ final class PlaybackSpy: @unchecked Sendable {
                     playCount += 1
                     playbackState = .playing
                 }
+                defer {
+                    lock.withLock {
+                        playbackState = .idle
+                    }
+                }
                 let thresholds = PlaybackThresholdController(text: text, tuningProfile: tuningProfile).thresholds
 
                 var emittedFirstChunk = false
@@ -507,10 +512,6 @@ final class PlaybackSpy: @unchecked Sendable {
                         fadeInChunkCount = 1
                     case let .throw(error):
                         throw error
-                }
-
-                lock.withLock {
-                    playbackState = .idle
                 }
 
                 return PlaybackSummary(

--- a/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
@@ -302,6 +302,7 @@ final class PlaybackSpy: @unchecked Sendable {
     private let lock = NSLock()
     private let behavior: Behavior
     private let environmentEvents: [PlaybackEnvironmentEvent]
+    private var playbackState: PlaybackState = .idle
 
     init(
         behavior: Behavior = .immediate,
@@ -318,7 +319,10 @@ final class PlaybackSpy: @unchecked Sendable {
                 return prepareCount == 1
             },
             play: { [self] _, text, tuningProfile, stream, onEvent in
-                lock.withLock { playCount += 1 }
+                lock.withLock {
+                    playCount += 1
+                    playbackState = .playing
+                }
                 let thresholds = PlaybackThresholdController(text: text, tuningProfile: tuningProfile).thresholds
 
                 var emittedFirstChunk = false
@@ -505,6 +509,10 @@ final class PlaybackSpy: @unchecked Sendable {
                         throw error
                 }
 
+                lock.withLock {
+                    playbackState = .idle
+                }
+
                 return PlaybackSummary(
                     thresholds: thresholds,
                     chunkCount: chunkCount,
@@ -534,11 +542,26 @@ final class PlaybackSpy: @unchecked Sendable {
                 )
             },
             stop: { [self] in
-                lock.withLock { stopCount += 1 }
+                lock.withLock {
+                    stopCount += 1
+                    playbackState = .idle
+                }
             },
-            pause: { .paused },
-            resume: { .playing },
-            state: { .idle },
+            pause: { [self] in
+                lock.withLock {
+                    playbackState = .paused
+                    return playbackState
+                }
+            },
+            resume: { [self] in
+                lock.withLock {
+                    playbackState = .playing
+                    return playbackState
+                }
+            },
+            state: { [self] in
+                lock.withLock { playbackState }
+            },
             bindEnvironmentEvents: { [environmentEvents] sink in
                 guard let sink else { return }
 

--- a/docs/maintainers/typed-observation-api.md
+++ b/docs/maintainers/typed-observation-api.md
@@ -147,6 +147,8 @@ for the worker contract, but make the native Swift inspection path direct and
 snapshot-shaped.
 
 `PlaybackState` remains small enough for UI and agent consumers to branch on directly. Snapshot carries richer telemetry.
+`PlaybackEvent` carries the stable public milestones that host and operator
+surfaces can branch on without parsing worker log event names.
 
 Shape:
 
@@ -159,10 +161,25 @@ enum PlaybackState: Sendable, Equatable {
     case recovering
 }
 
+enum PlaybackEvent: Sendable, Equatable {
+    case stateChanged(PlaybackState)
+    case started(requestID: String)
+    case activeRequestChanged(ActiveRequest?)
+    case queueChanged(activeRequest: ActiveRequest?, queuedRequests: [QueuedRequest])
+    case firstChunk(requestID: String)
+    case prerollReady(requestID: String, bufferedAudioMS: Int, startupBufferTargetMS: Int)
+    case rebufferStarted(requestID: String, queuedAudioMS: Int, resumeBufferTargetMS: Int)
+    case rebufferResumed(requestID: String, bufferedAudioMS: Int, resumeBufferTargetMS: Int)
+    case completed(requestID: String)
+    case outputDeviceChanged(previousDevice: String?, currentDevice: String?)
+    case interruptionChanged(isInterrupted: Bool, shouldResume: Bool?)
+}
+
 struct PlaybackUpdate: Sendable, Equatable {
     let sequence: Int
     let date: Date
     let state: PlaybackState
+    let event: PlaybackEvent
 }
 
 struct PlaybackSnapshot: Sendable, Equatable {
@@ -177,7 +194,17 @@ struct PlaybackSnapshot: Sendable, Equatable {
 }
 ```
 
-Raw playback-driver events such as trace samples, buffer-shape summaries, route-change internals, and rebuffer warnings stay internal diagnostics unless a concrete Swift consumer needs them. The public update stream publishes domain states, not driver chatter.
+Every `PlaybackUpdate` derives its `state` from the current
+`PlaybackSnapshot`, including milestone events. Consumers should branch on
+`update.event` for playback milestones, use `update.state` for the current
+coarse playback state, and call `runtime.playback.snapshot()` when they need a
+fresh aggregate read of active request, queued requests, and rebuffer telemetry.
+
+Raw playback-driver events such as trace samples, buffer-shape summaries,
+route-change internals, queue-depth warnings, rebuffer-thrash warnings,
+engine-configuration noise, recovery internals, and starvation diagnostics stay
+internal logs unless a concrete Swift consumer needs a new stable public
+milestone. The public update stream publishes domain events, not driver chatter.
 
 ### Runtime
 

--- a/docs/maintainers/validation-lanes.md
+++ b/docs/maintainers/validation-lanes.md
@@ -89,7 +89,7 @@ current macOS CI target set is:
 - `SpeakSwiftlyTests/LibrarySurfaceTests`
 - `SpeakSwiftlyTests/ModelClientsTests`
 
-## iOS Compile-And-Smoke Lane
+## Opt-In iOS Compile-And-Smoke Lane
 
 The iOS lane is intentionally smaller than the macOS package lane. Its job is
 to prove that:
@@ -97,6 +97,12 @@ to prove that:
 - the package resolves for iOS
 - the shared library and playback-environment code compile for iOS Simulator
 - a small library-first smoke slice still runs under Simulator
+
+This lane is opt-in in GitHub Actions. Run the `Swift` workflow manually with
+`run_ios_smoke` enabled when an implementation touches iOS portability,
+platform-conditional playback code, package resources, or shared library
+surfaces that need simulator proof. Ordinary PR and release CI does not run it
+by default.
 
 Build once:
 


### PR DESCRIPTION
## Release

- prepares v7.2.6 from branch `plan/issue-45`
- keeps protected `main` updates behind pull request review and CI
- release tag `v7.2.6` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Granular playback events added (start, first-chunk, preroll, rebuffer start/resume, completed), queue/active-request milestones, device and interruption changes.
  * New lifecycle hooks invoked at playback start and completion.
  * Playback updates now include event payloads with timing details.

* **Documentation**
  * Guidance updated to highlight observing playback milestones and update structure.

* **Tests**
  * Added coverage and helpers validating playback milestones, queue handoff, timing, and environment events.

* **Chores**
  * CI iOS smoke job made opt-in via manual trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->