### PR TITLE
release: prepare v9.0.1

### DIFF
--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
@@ -211,6 +211,50 @@ import TextForSpeech
     )
 }
 
+@Test func `decodes speak requests preserving preface policy overrides`() throws {
+    let liveRequest = try ToolRequest.decode(
+        from: #"{"id":"req-preface-live","op":"generate_speech","text":"Hello","voice_profile":"default-femme","request_context":{"reqPurpose":"speech","source":"status_panel","topic":"runtime","prefacePolicy":"never"}}"#,
+    )
+
+    #expect(
+        liveRequest == .queueSpeech(
+            id: "req-preface-live",
+            text: "Hello",
+            profileName: "default-femme",
+            textProfileID: nil,
+            jobType: .live,
+            requestContext: .init(
+                reqPurpose: .speech,
+                source: "status_panel",
+                topic: "runtime",
+                prefacePolicy: .never,
+            ),
+            qwenPreModelTextChunking: false,
+        ),
+    )
+
+    let fileRequest = try ToolRequest.decode(
+        from: #"{"id":"req-preface-file","op":"generate_audio_file","text":"Hello","voice_profile":"default-femme","request_context":{"reqPurpose":"audioFile","source":"status_panel","topic":"export","prefacePolicy":"always"}}"#,
+    )
+
+    #expect(
+        fileRequest == .queueSpeech(
+            id: "req-preface-file",
+            text: "Hello",
+            profileName: "default-femme",
+            textProfileID: nil,
+            jobType: .file,
+            requestContext: .init(
+                reqPurpose: .audioFile,
+                source: "status_panel",
+                topic: "export",
+                prefacePolicy: .always,
+            ),
+            qwenPreModelTextChunking: false,
+        ),
+    )
+}
+
 @Test func `decodes qwen pre-model text chunking opt in`() throws {
     let request = try ToolRequest.decode(
         from: #"{"id":"req-qwen-chunking","op":"generate_speech","text":"Hello","profile_name":"default-femme","qwen_pre_model_text_chunking":true}"#,

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerProtocolTests.swift
@@ -250,7 +250,7 @@ import TextForSpeech
                 topic: "export",
                 prefacePolicy: .always,
             ),
-            qwenPreModelTextChunking: false,
+            qwenPreModelTextChunking: nil,
         ),
     )
 }

--- a/docs/releases/v9-0-1-release-notes.md
+++ b/docs/releases/v9-0-1-release-notes.md
@@ -1,0 +1,24 @@
+# v9.0.1 Release Notes
+
+## What Changed
+
+- Added focused worker-protocol coverage for preserving
+  `request_context.prefacePolicy` through live speech and retained-file
+  generation request decoding.
+- Added the quick SpeakSwiftly E2E suite to the standard release script so patch
+  and release-candidate branches run generated-file coverage before PR creation.
+
+## Breaking Changes
+
+None.
+
+## Migration Notes
+
+No caller changes are required.
+
+## Verification
+
+- `swift test --filter WorkerProtocolTests`
+- `sh scripts/repo-maintenance/run-e2e.sh --suite quick`
+- Standard release validation runs `sh scripts/repo-maintenance/validate-all.sh`
+  and the quick E2E suite before pushing the release branch.

--- a/scripts/repo-maintenance/release.sh
+++ b/scripts/repo-maintenance/release.sh
@@ -156,6 +156,16 @@ run_version_bump() {
   log "Committed version bump for $RELEASE_TAG."
 }
 
+run_quick_e2e_validation() {
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would run quick SpeakSwiftly E2E validation with run-e2e.sh --suite quick."
+    return 0
+  fi
+
+  log "Running quick SpeakSwiftly E2E validation before release."
+  sh "$SELF_DIR/run-e2e.sh" --suite quick
+}
+
 create_release_tag() {
   head_sha="$(git -C "$REPO_ROOT" rev-parse HEAD)"
   tag_sha="$(git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$RELEASE_TAG" 2>/dev/null || true)"
@@ -448,6 +458,7 @@ run_standard_release() {
 
   if [ "$skip_validate" != "true" ]; then
     sh "$SELF_DIR/validate-all.sh"
+    run_quick_e2e_validation
   fi
 
   run_version_bump


### PR DESCRIPTION
## Release

- prepares v9.0.1 from branch `tests/preface-policy-release-e2e`
- keeps protected `main` updates behind pull request review and CI
- release tag `v9.0.1` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added decoding test coverage ensuring speak request context (including preface policy) is preserved for both live speech and generated-file workflows.

* **Documentation**
  * Published v9.0.1 release notes confirming no breaking changes and no migration steps required; includes verification steps for targeted tests and quick E2E.

* **Chores**
  * Added a quick SpeakSwiftly end-to-end validation step to the standard release flow (no-op in dry-run).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaelic-ghost/SpeakSwiftly/pull/80)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->