### PR TITLE
tests: add qwen quant benchmark harness

### DIFF
--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSignposts.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSignposts.swift
@@ -1,0 +1,86 @@
+#if os(macOS)
+import Foundation
+import os
+@testable import SpeakSwiftly
+
+struct BenchmarkSignpostRecorder {
+    private static let subsystem = "com.gaelic-ghost.SpeakSwiftly.benchmarks"
+
+    private let signposter: OSSignposter
+
+    init(
+        backend: SpeakSwiftly.SpeechBackend,
+        workload: String,
+    ) {
+        signposter = OSSignposter(
+            subsystem: Self.subsystem,
+            category: "qwen-quant.\(backend.rawValue).\(workload)",
+        )
+    }
+
+    func beginSample() -> BenchmarkSignpostInterval {
+        beginInterval("Benchmark Sample")
+    }
+
+    func beginResidentPreload() -> BenchmarkSignpostInterval {
+        beginInterval("Resident Preload")
+    }
+
+    func beginRequest() -> BenchmarkSignpostInterval {
+        beginInterval("Benchmark Request")
+    }
+
+    func emitQueued(id: OSSignpostID) {
+        signposter.emitEvent("Request Queued", id: id)
+    }
+
+    func emitAcknowledged(id: OSSignpostID) {
+        signposter.emitEvent("Request Acknowledged", id: id)
+    }
+
+    func emitStarted(id: OSSignpostID) {
+        signposter.emitEvent("Request Started", id: id)
+    }
+
+    func emitPrerollReady(id: OSSignpostID) {
+        signposter.emitEvent("Preroll Ready", id: id)
+    }
+
+    func emitPlaybackFinished(id: OSSignpostID) {
+        signposter.emitEvent("Playback Finished", id: id)
+    }
+
+    func emitCompleted(id: OSSignpostID) {
+        signposter.emitEvent("Request Completed", id: id)
+    }
+
+    func emitFirstToken(id: OSSignpostID) {
+        signposter.emitEvent("First Token", id: id)
+    }
+
+    func emitFirstAudioChunk(id: OSSignpostID) {
+        signposter.emitEvent("First Audio Chunk", id: id)
+    }
+
+    private func beginInterval(_ name: StaticString) -> BenchmarkSignpostInterval {
+        let id = signposter.makeSignpostID()
+        return BenchmarkSignpostInterval(
+            signposter: signposter,
+            id: id,
+            name: name,
+            state: signposter.beginInterval(name, id: id),
+        )
+    }
+}
+
+struct BenchmarkSignpostInterval {
+    let signposter: OSSignposter
+    let id: OSSignpostID
+    let name: StaticString
+    let state: OSSignpostIntervalState
+
+    func end() {
+        signposter.endInterval(name, state)
+    }
+}
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import Foundation
+import os
 @testable import SpeakSwiftly
 
 struct BenchmarkRuntimeSession {
@@ -39,6 +40,22 @@ struct BenchmarkHost: Codable {
             }
         }
     }
+}
+
+struct BenchmarkResourceSnapshot: Codable {
+    let processResidentBytes: Int?
+    let processPhysFootprintBytes: Int?
+    let processCPUTimeMS: Double?
+    let mlxActiveMemoryBytes: Int?
+    let mlxCacheMemoryBytes: Int?
+    let mlxPeakMemoryBytes: Int?
+}
+
+struct BenchmarkWarningSummary: Codable {
+    let warningCount: Int
+    let playbackWarningCount: Int
+    let generationQualityWarningCount: Int
+    let reasons: [String: Int]
 }
 
 struct BenchmarkMetricSummary: Codable {
@@ -267,6 +284,32 @@ final class BenchmarkLogRecorder: @unchecked Sendable {
         }
     }
 
+    private static func int(_ value: Any?) -> Int? {
+        switch value {
+            case let int as Int:
+                int
+            case let double as Double:
+                Int(double)
+            case let number as NSNumber:
+                number.intValue
+            default:
+                nil
+        }
+    }
+
+    private static func max(_ lhs: Int?, _ rhs: Int?) -> Int? {
+        switch (lhs, rhs) {
+            case let (lhs?, rhs?):
+                Swift.max(lhs, rhs)
+            case let (lhs?, nil):
+                lhs
+            case let (nil, rhs?):
+                rhs
+            case (nil, nil):
+                nil
+        }
+    }
+
     func appendStderr(_ message: String) {
         let lines = message
             .split(separator: "\n", omittingEmptySubsequences: true)
@@ -323,6 +366,79 @@ final class BenchmarkLogRecorder: @unchecked Sendable {
                 maxBoundaryDiscontinuity: Self.double(details["max_boundary_discontinuity"]),
                 maxLeadingAbsAmplitude: Self.double(details["max_leading_abs_amplitude"]),
                 maxTrailingAbsAmplitude: Self.double(details["max_trailing_abs_amplitude"]),
+            )
+        }
+    }
+
+    func warningSummary(for requestID: String) -> BenchmarkWarningSummary {
+        warningSummary(for: [requestID])
+    }
+
+    func warningSummary(for requestIDs: [String]) -> BenchmarkWarningSummary {
+        let requestIDSet = Set(requestIDs)
+        return lock.withLock {
+            var reasons = [String: Int]()
+            var warningCount = 0
+            var playbackWarningCount = 0
+            var generationQualityWarningCount = 0
+
+            for object in stderrObjects where requestIDSet.contains(object["request_id"] as? String ?? "") {
+                guard object["level"] as? String == "warning" else { continue }
+
+                warningCount += 1
+                let event = object["event"] as? String ?? "unknown"
+                if event.hasPrefix("playback_") {
+                    playbackWarningCount += 1
+                }
+                if event == "playback_generation_quality_warning" {
+                    generationQualityWarningCount += 1
+                }
+
+                let details = object["details"] as? [String: Any]
+                let reason = details?["reason"] as? String ?? event
+                reasons[reason, default: 0] += 1
+            }
+
+            return BenchmarkWarningSummary(
+                warningCount: warningCount,
+                playbackWarningCount: playbackWarningCount,
+                generationQualityWarningCount: generationQualityWarningCount,
+                reasons: reasons,
+            )
+        }
+    }
+
+    func peakResourceSnapshot() -> BenchmarkResourceSnapshot {
+        lock.withLock {
+            var processResidentBytes: Int?
+            var processPhysFootprintBytes: Int?
+            var processCPUTimeNS: Int?
+            var mlxActiveMemoryBytes: Int?
+            var mlxCacheMemoryBytes: Int?
+            var mlxPeakMemoryBytes: Int?
+
+            for object in stderrObjects {
+                guard let details = object["details"] as? [String: Any] else { continue }
+
+                processResidentBytes = Self.max(processResidentBytes, Self.int(details["process_resident_bytes"]))
+                processPhysFootprintBytes = Self.max(processPhysFootprintBytes, Self.int(details["process_phys_footprint_bytes"]))
+                let userCPUTimeNS = Self.int(details["process_user_cpu_time_ns"]) ?? 0
+                let systemCPUTimeNS = Self.int(details["process_system_cpu_time_ns"]) ?? 0
+                if userCPUTimeNS > 0 || systemCPUTimeNS > 0 {
+                    processCPUTimeNS = Self.max(processCPUTimeNS, userCPUTimeNS + systemCPUTimeNS)
+                }
+                mlxActiveMemoryBytes = Self.max(mlxActiveMemoryBytes, Self.int(details["mlx_active_memory_bytes"]))
+                mlxCacheMemoryBytes = Self.max(mlxCacheMemoryBytes, Self.int(details["mlx_cache_memory_bytes"]))
+                mlxPeakMemoryBytes = Self.max(mlxPeakMemoryBytes, Self.int(details["mlx_peak_memory_bytes"]))
+            }
+
+            return BenchmarkResourceSnapshot(
+                processResidentBytes: processResidentBytes,
+                processPhysFootprintBytes: processPhysFootprintBytes,
+                processCPUTimeMS: processCPUTimeNS.map { Double($0) / 1_000_000 },
+                mlxActiveMemoryBytes: mlxActiveMemoryBytes,
+                mlxCacheMemoryBytes: mlxCacheMemoryBytes,
+                mlxPeakMemoryBytes: mlxPeakMemoryBytes,
             )
         }
     }
@@ -460,19 +576,25 @@ enum BenchmarkHarness {
     static func runRequestBenchmark(
         handle: SpeakSwiftly.RequestHandle,
         logRecorder: BenchmarkLogRecorder? = nil,
+        signposts: BenchmarkSignpostRecorder? = nil,
     ) async throws -> BenchmarkRequest {
         let clock = ContinuousClock()
         let submittedAt = clock.now
+        let signpostInterval = signposts?.beginRequest()
 
         async let lifecycle = collectLifecycleMetrics(
             from: handle.events,
             submittedAt: submittedAt,
             clock: clock,
+            signposts: signposts,
+            signpostID: signpostInterval?.id,
         )
         async let generation = collectGenerationMetrics(
             from: handle.synthesisUpdates,
             submittedAt: submittedAt,
             clock: clock,
+            signposts: signposts,
+            signpostID: signpostInterval?.id,
         )
 
         let (lifecycleMetrics, success) = try await lifecycle
@@ -482,6 +604,7 @@ enum BenchmarkHarness {
             operation: handle.kind.rawValue,
             logRecorder: logRecorder,
         )
+        signpostInterval?.end()
 
         return BenchmarkRequest(
             requestID: handle.id,
@@ -498,9 +621,13 @@ enum BenchmarkHarness {
         timestampedStem: String,
         latestFilename: String,
         generatedAt: Date,
+        subdirectory: String? = nil,
     ) throws -> URL {
-        let benchmarksRoot = try packageRootURL()
+        var benchmarksRoot = try packageRootURL()
             .appendingPathComponent(".local/benchmarks", isDirectory: true)
+        if let subdirectory, !subdirectory.isEmpty {
+            benchmarksRoot = benchmarksRoot.appendingPathComponent(subdirectory, isDirectory: true)
+        }
         try FileManager.default.createDirectory(at: benchmarksRoot, withIntermediateDirectories: true)
 
         let formatter = ISO8601DateFormatter()
@@ -559,6 +686,8 @@ enum BenchmarkHarness {
         from events: AsyncThrowingStream<SpeakSwiftly.RequestEvent, any Swift.Error>,
         submittedAt: ContinuousClock.Instant,
         clock: ContinuousClock,
+        signposts: BenchmarkSignpostRecorder?,
+        signpostID: OSSignpostID?,
     ) async throws -> (BenchmarkRequestLifecycleMetrics, SpeakSwiftly.RequestCompletion) {
         var metrics = BenchmarkRequestLifecycleMetrics()
 
@@ -570,23 +699,29 @@ enum BenchmarkHarness {
                     metrics.queuedAtMS = metrics.queuedAtMS ?? elapsedMS
                     metrics.queueReason = queued.reason.rawValue
                     metrics.queuePosition = queued.queuePosition
+                    if let signpostID { signposts?.emitQueued(id: signpostID) }
                 case .acknowledged:
                     metrics.acknowledgedAtMS = metrics.acknowledgedAtMS ?? elapsedMS
+                    if let signpostID { signposts?.emitAcknowledged(id: signpostID) }
                 case .started:
                     metrics.startedAtMS = metrics.startedAtMS ?? elapsedMS
+                    if let signpostID { signposts?.emitStarted(id: signpostID) }
                 case let .progress(progress):
                     switch progress.stage {
                         case .bufferingAudio:
                             metrics.bufferingAudioAtMS = metrics.bufferingAudioAtMS ?? elapsedMS
                         case .prerollReady:
                             metrics.prerollReadyAtMS = metrics.prerollReadyAtMS ?? elapsedMS
+                            if let signpostID { signposts?.emitPrerollReady(id: signpostID) }
                         case .playbackFinished:
                             metrics.playbackFinishedAtMS = metrics.playbackFinishedAtMS ?? elapsedMS
+                            if let signpostID { signposts?.emitPlaybackFinished(id: signpostID) }
                         default:
                             continue
                     }
                 case let .completed(completion):
                     metrics.completedAtMS = metrics.completedAtMS ?? elapsedMS
+                    if let signpostID { signposts?.emitCompleted(id: signpostID) }
                     return (metrics, completion)
             }
         }
@@ -598,6 +733,8 @@ enum BenchmarkHarness {
         from events: AsyncThrowingStream<SpeakSwiftly.SynthesisUpdate, any Swift.Error>,
         submittedAt: ContinuousClock.Instant,
         clock: ContinuousClock,
+        signposts: BenchmarkSignpostRecorder?,
+        signpostID: OSSignpostID?,
     ) async throws -> BenchmarkRequestGenerationMetrics {
         var metrics = BenchmarkRequestGenerationMetrics()
 
@@ -606,6 +743,9 @@ enum BenchmarkHarness {
 
             switch update.event {
                 case .token:
+                    if metrics.firstTokenAtMS == nil, let signpostID {
+                        signposts?.emitFirstToken(id: signpostID)
+                    }
                     metrics.firstTokenAtMS = metrics.firstTokenAtMS ?? elapsedMS
                     metrics.observedTokenCount += 1
                 case let .info(info):
@@ -617,6 +757,9 @@ enum BenchmarkHarness {
                     metrics.tokensPerSecond = info.tokensPerSecond
                     metrics.peakMemoryUsageGB = info.peakMemoryUsage
                 case let .audioChunk(sampleCount):
+                    if metrics.firstAudioChunkAtMS == nil, let signpostID {
+                        signposts?.emitFirstAudioChunk(id: signpostID)
+                    }
                     metrics.firstAudioChunkAtMS = metrics.firstAudioChunkAtMS ?? elapsedMS
                     metrics.audioChunkCount += 1
                     metrics.totalAudioSampleCount += sampleCount

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenQuantizationBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenQuantizationBenchmarkE2ETests.swift
@@ -1,0 +1,383 @@
+#if os(macOS)
+import Foundation
+@testable import SpeakSwiftly
+import Testing
+
+private let qwenQuantBenchmarkSchemaVersion = 1
+
+@Suite(
+    .serialized,
+    .tags(.e2e, .qwen, .benchmark),
+    .enabled(
+        if: speakSwiftlyE2ETestsEnabled(),
+        "These end-to-end worker tests are opt-in and require SPEAKSWIFTLY_E2E=1.",
+    ),
+    .enabled(
+        if: speakSwiftlyQwenQuantBenchmarkE2ETestsEnabled(),
+        "This Qwen quantization benchmark suite is opt-in and requires SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_E2E=1.",
+    ),
+)
+struct QwenQuantizationBenchmarkE2ETests {
+    @Test func `measure qwen quant backend matrix`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        try await Self.provisionBenchmarkProfile(in: sandbox.profileRootURL)
+
+        let generatedAt = Date()
+        let deviceLabel = Self.deviceLabel(host: .localMachine())
+        let iterations = speakSwiftlyQwenBenchmarkIterations()
+        var backendReports = [QwenQuantBackendReport]()
+
+        for backend in speakSwiftlyQwenQuantBenchmarkBackends() {
+            var outcomes = [QwenQuantBenchmarkOutcome]()
+
+            for iteration in 1...iterations {
+                for scenario in QwenQuantBenchmarkScenario.allCases {
+                    await outcomes.append(
+                        Self.runOutcome(
+                            backend: backend,
+                            scenario: scenario,
+                            iteration: iteration,
+                            profileRootURL: sandbox.profileRootURL,
+                        ),
+                    )
+                }
+            }
+
+            backendReports.append(
+                QwenQuantBackendReport(
+                    backend: backend,
+                    modelRepo: backend.residentModelRepo,
+                    outcomes: outcomes,
+                ),
+            )
+        }
+
+        let summary = QwenQuantBenchmarkSummary(
+            schemaVersion: qwenQuantBenchmarkSchemaVersion,
+            generatedAt: generatedAt,
+            deviceLabel: deviceLabel,
+            host: .localMachine(),
+            settings: .current(
+                iterations: iterations,
+                benchmarkProfileName: Self.benchmarkProfileName,
+                playbackTextCharacterCount: E2EHarness.testingPlaybackText.count,
+                playbackMode: BenchmarkHarness.effectivePlaybackMode(),
+                backends: speakSwiftlyQwenQuantBenchmarkBackends(),
+            ),
+            backends: backendReports,
+        )
+        let summaryURL = try BenchmarkHarness.writeSummary(
+            summary,
+            timestampedStem: "qwen-quant-benchmark-\(deviceLabel)",
+            latestFilename: "latest.json",
+            generatedAt: generatedAt,
+            subdirectory: "qwen-quant/\(deviceLabel)",
+        )
+
+        print("SpeakSwiftly qwen quant benchmark summary: \(summaryURL.path)")
+        for report in summary.backends {
+            print(report.prettyDescription)
+        }
+    }
+}
+
+private extension QwenQuantizationBenchmarkE2ETests {
+    static let benchmarkProfileName = "benchmark-profile"
+    static let sampleTimeout: Duration = .seconds(20 * 60)
+
+    static func provisionBenchmarkProfile(in profileRootURL: URL) async throws {
+        try await BenchmarkHarness.withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: .qwen3_smol,
+            qwenConditioningStrategy: .preparedConditioning,
+        ) { session in
+            _ = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
+
+            let handle = await session.runtime.voices.create(
+                design: benchmarkProfileName,
+                from: E2EHarness.testingProfileText,
+                vibe: .masc,
+                voiceDescription: E2EHarness.testingProfileVoiceDescription,
+            )
+            _ = try await BenchmarkHarness.awaitSuccess(from: handle)
+        }
+    }
+
+    static func runOutcome(
+        backend: SpeakSwiftly.SpeechBackend,
+        scenario: QwenQuantBenchmarkScenario,
+        iteration: Int,
+        profileRootURL: URL,
+    ) async -> QwenQuantBenchmarkOutcome {
+        let startedAt = Date()
+        do {
+            let sample = try await withBenchmarkTimeout(sampleTimeout) {
+                try await runSample(
+                    backend: backend,
+                    scenario: scenario,
+                    iteration: iteration,
+                    profileRootURL: profileRootURL,
+                )
+            }
+            return QwenQuantBenchmarkOutcome(
+                backend: backend,
+                scenario: scenario,
+                iteration: iteration,
+                startedAt: startedAt,
+                status: .completed,
+                sample: sample,
+                failure: nil,
+            )
+        } catch let timeout as QwenQuantBenchmarkTimeout {
+            return QwenQuantBenchmarkOutcome(
+                backend: backend,
+                scenario: scenario,
+                iteration: iteration,
+                startedAt: startedAt,
+                status: .timedOut,
+                sample: nil,
+                failure: QwenQuantBenchmarkFailure(message: timeout.description),
+            )
+        } catch {
+            return QwenQuantBenchmarkOutcome(
+                backend: backend,
+                scenario: scenario,
+                iteration: iteration,
+                startedAt: startedAt,
+                status: .failed,
+                sample: nil,
+                failure: QwenQuantBenchmarkFailure(message: String(describing: error)),
+            )
+        }
+    }
+
+    static func withBenchmarkTimeout<T: Sendable>(
+        _ timeout: Duration,
+        operation: @escaping @Sendable () async throws -> T,
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw QwenQuantBenchmarkTimeout(timeout: timeout)
+            }
+
+            guard let result = try await group.next() else {
+                throw QwenQuantBenchmarkTimeout(timeout: timeout)
+            }
+
+            group.cancelAll()
+            return result
+        }
+    }
+
+    static func runSample(
+        backend: SpeakSwiftly.SpeechBackend,
+        scenario: QwenQuantBenchmarkScenario,
+        iteration: Int,
+        profileRootURL: URL,
+    ) async throws -> QwenQuantBenchmarkSample {
+        let signposts = BenchmarkSignpostRecorder(backend: backend, workload: scenario.rawValue)
+        let sampleInterval = signposts.beginSample()
+        defer { sampleInterval.end() }
+
+        return try await BenchmarkHarness.withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: backend,
+            qwenConditioningStrategy: .preparedConditioning,
+            playbackMode: BenchmarkHarness.effectivePlaybackMode(),
+            playbackTrace: speakSwiftlyPlaybackTraceE2ETestsEnabled(),
+        ) { session in
+            let residentPreloadInterval = signposts.beginResidentPreload()
+            let residentPreloadMS = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
+            residentPreloadInterval.end()
+
+            if scenario == .reload {
+                let unloadHandle = await session.runtime.unloadModels()
+                _ = try await BenchmarkHarness.awaitSuccess(from: unloadHandle)
+                let reloadHandle = await session.runtime.reloadModels()
+                _ = try await BenchmarkHarness.awaitSuccess(from: reloadHandle)
+            }
+
+            let generatedAudio = try await BenchmarkHarness.runRequestBenchmark(
+                handle: session.runtime.generate.audio(
+                    text: E2EHarness.testingPlaybackText,
+                    voiceProfile: benchmarkProfileName,
+                ),
+                logRecorder: session.logRecorder,
+                signposts: signposts,
+            )
+            let liveSpeech = try await BenchmarkHarness.runRequestBenchmark(
+                handle: session.runtime.generate.speech(
+                    text: E2EHarness.testingPlaybackText,
+                    voiceProfile: benchmarkProfileName,
+                ),
+                logRecorder: session.logRecorder,
+                signposts: signposts,
+            )
+
+            let firstQueued = await session.runtime.generate.speech(
+                text: E2EHarness.testingPlaybackText,
+                voiceProfile: benchmarkProfileName,
+            )
+            let secondQueued = await session.runtime.generate.speech(
+                text: E2EHarness.testingPlaybackText,
+                voiceProfile: benchmarkProfileName,
+            )
+            async let firstQueuedBenchmark = BenchmarkHarness.runRequestBenchmark(
+                handle: firstQueued,
+                logRecorder: session.logRecorder,
+                signposts: signposts,
+            )
+            async let secondQueuedBenchmark = BenchmarkHarness.runRequestBenchmark(
+                handle: secondQueued,
+                logRecorder: session.logRecorder,
+                signposts: signposts,
+            )
+            let queuedLiveSpeech = try await [firstQueuedBenchmark, secondQueuedBenchmark]
+
+            return QwenQuantBenchmarkSample(
+                backend: backend,
+                scenario: scenario,
+                iteration: iteration,
+                residentPreloadMS: residentPreloadMS,
+                generatedAudio: generatedAudio,
+                liveSpeech: liveSpeech,
+                queuedLiveSpeech: queuedLiveSpeech,
+                warnings: session.logRecorder.warningSummary(
+                    for: ([generatedAudio, liveSpeech] + queuedLiveSpeech).map(\.requestID),
+                ),
+                resources: session.logRecorder.peakResourceSnapshot(),
+            )
+        }
+    }
+
+    static func deviceLabel(host: BenchmarkHost) -> String {
+        if let configured = speakSwiftlyQwenQuantBenchmarkDeviceLabel() {
+            return slug(configured)
+        }
+
+        let memoryGB = Int((Double(host.physicalMemoryBytes) / 1_000_000_000).rounded())
+        return slug("\(host.machineArchitecture)-\(memoryGB)gb")
+    }
+
+    static func slug(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let scalars = value
+            .lowercased()
+            .unicodeScalars
+            .map { allowed.contains($0) ? Character($0) : "-" }
+        let collapsed = String(scalars)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+        return collapsed.isEmpty ? "unknown-device" : collapsed
+    }
+}
+
+private struct QwenQuantBenchmarkSummary: Codable {
+    let schemaVersion: Int
+    let generatedAt: Date
+    let deviceLabel: String
+    let host: BenchmarkHost
+    let settings: QwenQuantBenchmarkSettings
+    let backends: [QwenQuantBackendReport]
+}
+
+private struct QwenQuantBenchmarkSettings: Codable {
+    let iterations: Int
+    let benchmarkProfileName: String
+    let playbackTextCharacterCount: Int
+    let playbackMode: BenchmarkPlaybackMode
+    let timestampedSummaryPattern: String
+    let latestSummaryFilename: String
+    let comparedBackends: [SpeakSwiftly.SpeechBackend]
+    let scenarios: [QwenQuantBenchmarkScenario]
+
+    static func current(
+        iterations: Int,
+        benchmarkProfileName: String,
+        playbackTextCharacterCount: Int,
+        playbackMode: BenchmarkPlaybackMode,
+        backends: [SpeakSwiftly.SpeechBackend],
+    ) -> Self {
+        Self(
+            iterations: iterations,
+            benchmarkProfileName: benchmarkProfileName,
+            playbackTextCharacterCount: playbackTextCharacterCount,
+            playbackMode: playbackMode,
+            timestampedSummaryPattern: "qwen-quant-benchmark-<device>-<ISO8601>.json",
+            latestSummaryFilename: "latest.json",
+            comparedBackends: backends,
+            scenarios: QwenQuantBenchmarkScenario.allCases,
+        )
+    }
+}
+
+private struct QwenQuantBackendReport: Codable {
+    let backend: SpeakSwiftly.SpeechBackend
+    let modelRepo: String
+    let outcomes: [QwenQuantBenchmarkOutcome]
+
+    var prettyDescription: String {
+        let completedCount = outcomes.filter { $0.status == .completed }.count
+        let failedCount = outcomes.filter { $0.status == .failed }.count
+        let firstAudioMS = BenchmarkMetricSummary.make(
+            from: outcomes.compactMap { $0.sample?.liveSpeech.generation.firstAudioChunkAtMS },
+        )
+        let completedMS = BenchmarkMetricSummary.make(
+            from: outcomes.compactMap { $0.sample?.liveSpeech.lifecycle.completedAtMS },
+        )
+        return "\(backend.rawValue): \(completedCount) completed, \(failedCount) failed, live first audio \(firstAudioMS.prettyAverage) ms, live complete \(completedMS.prettyAverage) ms"
+    }
+}
+
+private struct QwenQuantBenchmarkOutcome: Codable {
+    let backend: SpeakSwiftly.SpeechBackend
+    let scenario: QwenQuantBenchmarkScenario
+    let iteration: Int
+    let startedAt: Date
+    let status: QwenQuantBenchmarkStatus
+    let sample: QwenQuantBenchmarkSample?
+    let failure: QwenQuantBenchmarkFailure?
+}
+
+private enum QwenQuantBenchmarkStatus: String, Codable {
+    case completed
+    case failed
+    case timedOut
+}
+
+private enum QwenQuantBenchmarkScenario: String, Codable, CaseIterable {
+    case cold
+    case warm
+    case reload
+}
+
+private struct QwenQuantBenchmarkFailure: Codable {
+    let message: String
+}
+
+private struct QwenQuantBenchmarkTimeout: Error, CustomStringConvertible {
+    let timeout: Duration
+
+    var description: String {
+        "Qwen quant benchmark sample timed out after \(timeout). The backend may have stalled during model load, generation, or playback drain."
+    }
+}
+
+private struct QwenQuantBenchmarkSample: Codable {
+    let backend: SpeakSwiftly.SpeechBackend
+    let scenario: QwenQuantBenchmarkScenario
+    let iteration: Int
+    let residentPreloadMS: Double
+    let generatedAudio: BenchmarkRequest
+    let liveSpeech: BenchmarkRequest
+    let queuedLiveSpeech: [BenchmarkRequest]
+    let warnings: BenchmarkWarningSummary
+    let resources: BenchmarkResourceSnapshot
+}
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import Foundation
+@testable import SpeakSwiftly
 
 func speakSwiftlyE2ETestsEnabled() -> Bool {
     ProcessInfo.processInfo.environment["SPEAKSWIFTLY_E2E"] == "1"
@@ -21,6 +22,10 @@ func speakSwiftlyQwenBenchmarkE2ETestsEnabled() -> Bool {
     ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_BENCHMARK_E2E"] == "1"
 }
 
+func speakSwiftlyQwenQuantBenchmarkE2ETestsEnabled() -> Bool {
+    ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_E2E"] == "1"
+}
+
 func speakSwiftlyQwenLongFormE2ETestsEnabled() -> Bool {
     ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_LONGFORM_E2E"] == "1"
 }
@@ -32,6 +37,43 @@ func speakSwiftlyQwenBackendE2ETestsEnabled() -> Bool {
 func speakSwiftlyQwenBenchmarkIterations() -> Int {
     let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS"] ?? ""
     return max(1, Int(rawValue) ?? 1)
+}
+
+func speakSwiftlyQwenQuantBenchmarkBackends() -> [SpeakSwiftly.SpeechBackend] {
+    let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_BACKENDS"] ?? ""
+    let requestedBackends = rawValue
+        .split(separator: ",")
+        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+
+    guard !requestedBackends.isEmpty else {
+        return SpeakSwiftly.SpeechBackend.qwenFamilyBackends
+    }
+
+    var backends = [SpeakSwiftly.SpeechBackend]()
+    var invalidBackends = [String]()
+    for requestedBackend in requestedBackends {
+        if let backend = SpeakSwiftly.SpeechBackend.normalized(rawValue: requestedBackend) {
+            backends.append(backend)
+        } else {
+            invalidBackends.append(requestedBackend)
+        }
+    }
+
+    precondition(
+        invalidBackends.isEmpty,
+        """
+        SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_BACKENDS contains unsupported backend value(s): \(invalidBackends.joined(separator: ", ")). \
+        Use one or more SpeechBackend.qwenFamilyBackends raw values separated by commas.
+        """,
+    )
+    return backends
+}
+
+func speakSwiftlyQwenQuantBenchmarkDeviceLabel() -> String? {
+    let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_DEVICE_LABEL"] ?? ""
+    let label = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    return label.isEmpty ? nil : label
 }
 
 #endif

--- a/scripts/repo-maintenance/run-benchmark.sh
+++ b/scripts/repo-maintenance/run-benchmark.sh
@@ -12,11 +12,17 @@ benchmark_target="qwen"
 audible="false"
 playback_trace="false"
 iterations=""
+qwen_quant_backends=""
+device_label=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --qwen)
       benchmark_target="qwen"
+      shift
+      ;;
+    --qwen-quant)
+      benchmark_target="qwen-quant"
       shift
       ;;
     --audible)
@@ -31,10 +37,23 @@ while [ "$#" -gt 0 ]; do
       iterations="${2:-}"
       shift 2
       ;;
+    --backend)
+      qwen_quant_backends="${2:-}"
+      shift 2
+      ;;
+    --backends)
+      qwen_quant_backends="${2:-}"
+      shift 2
+      ;;
+    --device-label)
+      device_label="${2:-}"
+      shift 2
+      ;;
     -h|--help)
       cat <<'USAGE'
 Usage:
-  run-benchmark.sh [--qwen] [--audible] [--playback-trace] [--iterations <count>]
+  run-benchmark.sh [--qwen|--qwen-quant] [--audible] [--playback-trace] [--iterations <count>]
+                   [--backend <backend>|--backends <comma-separated-backends>] [--device-label <label>]
 
 Defaults:
   --qwen is the default benchmark target.
@@ -43,6 +62,7 @@ Examples:
   sh scripts/repo-maintenance/run-benchmark.sh
   sh scripts/repo-maintenance/run-benchmark.sh --audible --iterations 3
   sh scripts/repo-maintenance/run-benchmark.sh --qwen --iterations 5
+  sh scripts/repo-maintenance/run-benchmark.sh --qwen-quant --backend qwen3_smol_8bit --iterations 1
 USAGE
       exit 0
       ;;
@@ -52,7 +72,17 @@ USAGE
   esac
 done
 
-suite_name="qwen-benchmark"
+case "$benchmark_target" in
+  qwen)
+    suite_name="qwen-benchmark"
+    ;;
+  qwen-quant)
+    suite_name="qwen-quant-benchmark"
+    ;;
+  *)
+    die "Unsupported benchmark target '$benchmark_target'."
+    ;;
+esac
 
 suite_args=""
 if [ "$audible" = "true" ]; then
@@ -63,6 +93,15 @@ if [ "$playback_trace" = "true" ]; then
 fi
 if [ -n "$iterations" ]; then
   suite_args="$suite_args --benchmark-iterations $iterations"
+fi
+if [ "$benchmark_target" = "qwen-quant" ]; then
+  suite_args="$suite_args --qwen-quant-benchmark"
+  if [ -n "$qwen_quant_backends" ]; then
+    suite_args="$suite_args --qwen-quant-backends $qwen_quant_backends"
+  fi
+  if [ -n "$device_label" ]; then
+    suite_args="$suite_args --device-label $device_label"
+  fi
 fi
 
 log "Running SpeakSwiftly benchmark target '$benchmark_target' via suite '$suite_name'."

--- a/scripts/repo-maintenance/run-e2e.sh
+++ b/scripts/repo-maintenance/run-e2e.sh
@@ -14,6 +14,9 @@ playback_trace="false"
 deep_trace="false"
 benchmark="false"
 benchmark_iterations=""
+qwen_quant_benchmark="false"
+qwen_quant_benchmark_backends=""
+qwen_quant_benchmark_device_label=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -37,8 +40,20 @@ while [ "$#" -gt 0 ]; do
       benchmark="true"
       shift
       ;;
+    --qwen-quant-benchmark)
+      qwen_quant_benchmark="true"
+      shift
+      ;;
     --benchmark-iterations)
       benchmark_iterations="${2:-}"
+      shift 2
+      ;;
+    --qwen-quant-backends)
+      qwen_quant_benchmark_backends="${2:-}"
+      shift 2
+      ;;
+    --device-label)
+      qwen_quant_benchmark_device_label="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -57,13 +72,17 @@ Suite names:
   trace | TraceCaptureE2ETests
   deep-trace | DeepTraceE2ETests
   qwen-benchmark | QwenBenchmarkE2ETests
+  qwen-quant-benchmark | QwenQuantizationBenchmarkE2ETests
 
 Flags:
   --audible
   --playback-trace
   --deep-trace
   --benchmark
+  --qwen-quant-benchmark
   --benchmark-iterations <count>
+  --qwen-quant-backends <comma-separated-backends>
+  --device-label <label>
 USAGE
       exit 0
       ;;
@@ -86,6 +105,7 @@ resolve_suite_name() {
     trace|TraceCaptureE2ETests) printf '%s\n' "TraceCaptureE2ETests" ;;
     deep-trace|DeepTraceE2ETests) printf '%s\n' "DeepTraceE2ETests" ;;
     qwen-benchmark|QwenBenchmarkE2ETests) printf '%s\n' "QwenBenchmarkE2ETests" ;;
+    qwen-quant-benchmark|QwenQuantizationBenchmarkE2ETests) printf '%s\n' "QwenQuantizationBenchmarkE2ETests" ;;
     *)
       return 1
       ;;
@@ -96,7 +116,7 @@ suite_name=$(resolve_suite_name "$suite_arg") \
   || die "Unsupported E2E suite '$suite_arg'. Use --help to see the supported top-level suite names."
 
 case "$suite_name" in
-  GeneratedFileE2ETests|GeneratedBatchE2ETests|QwenE2ETests|QueueControlE2ETests|QwenLongFormE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests)
+  GeneratedFileE2ETests|GeneratedBatchE2ETests|QwenE2ETests|QueueControlE2ETests|QwenLongFormE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests|QwenQuantizationBenchmarkE2ETests)
     ;;
   *)
     die "Refusing to run '$suite_name' because only one top-level E2E suite may run per invocation."
@@ -125,6 +145,10 @@ if [ "$benchmark" = "true" ] || [ "$suite_name" = "QwenBenchmarkE2ETests" ]; the
   export SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1
 fi
 
+if [ "$qwen_quant_benchmark" = "true" ] || [ "$suite_name" = "QwenQuantizationBenchmarkE2ETests" ]; then
+  export SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_E2E=1
+fi
+
 if [ "$suite_name" = "QwenLongFormE2ETests" ]; then
   export SPEAKSWIFTLY_QWEN_LONGFORM_E2E=1
 fi
@@ -135,6 +159,14 @@ fi
 
 if [ -n "$benchmark_iterations" ]; then
   export SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS="$benchmark_iterations"
+fi
+
+if [ -n "$qwen_quant_benchmark_backends" ]; then
+  export SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_BACKENDS="$qwen_quant_benchmark_backends"
+fi
+
+if [ -n "$qwen_quant_benchmark_device_label" ]; then
+  export SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_DEVICE_LABEL="$qwen_quant_benchmark_device_label"
 fi
 
 restore_status=0

--- a/scripts/repo-maintenance/run-qwen-quant-benchmark.sh
+++ b/scripts/repo-maintenance/run-qwen-quant-benchmark.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env sh
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
+. "$SELF_DIR/lib/common.sh"
+
+load_env_file "$SELF_DIR/config/validation.env"
+ensure_git_repo
+
+backends=""
+device_label=""
+audible="false"
+playback_trace="true"
+iterations="1"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --backend)
+      backends="${2:-}"
+      [ -n "$backends" ] || die "Pass a backend after --backend."
+      shift 2
+      ;;
+    --backends)
+      backends="${2:-}"
+      [ -n "$backends" ] || die "Pass a comma-separated backend list after --backends."
+      shift 2
+      ;;
+    --all)
+      backends=""
+      shift
+      ;;
+    --device-label)
+      device_label="${2:-}"
+      [ -n "$device_label" ] || die "Pass a non-empty device label after --device-label."
+      shift 2
+      ;;
+    --iterations)
+      iterations="${2:-}"
+      [ -n "$iterations" ] || die "Pass an iteration count after --iterations."
+      shift 2
+      ;;
+    --audible)
+      audible="true"
+      shift
+      ;;
+    --no-playback-trace)
+      playback_trace="false"
+      shift
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage:
+  run-qwen-quant-benchmark.sh [--backend <backend>|--backends <comma-separated-backends>|--all]
+                              [--device-label <label>] [--iterations <count>]
+                              [--audible] [--no-playback-trace]
+
+Examples:
+  sh scripts/repo-maintenance/run-qwen-quant-benchmark.sh --backend qwen3_smol_8bit --iterations 1
+  sh scripts/repo-maintenance/run-qwen-quant-benchmark.sh --all --device-label macbook-pro-m4-pro-24gb
+USAGE
+      exit 0
+      ;;
+    *)
+      die "Unknown run-qwen-quant-benchmark argument: $1"
+      ;;
+  esac
+done
+
+set -- "$SELF_DIR/run-benchmark.sh" --qwen-quant --iterations "$iterations"
+if [ -n "$backends" ]; then
+  set -- "$@" --backends "$backends"
+fi
+if [ -n "$device_label" ]; then
+  set -- "$@" --device-label "$device_label"
+fi
+if [ "$audible" = "true" ]; then
+  set -- "$@" --audible
+fi
+if [ "$playback_trace" = "true" ]; then
+  set -- "$@" --playback-trace
+fi
+
+sh "$@"

--- a/scripts/repo-maintenance/summarize-qwen-quant-benchmark.sh
+++ b/scripts/repo-maintenance/summarize-qwen-quant-benchmark.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env sh
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
+. "$SELF_DIR/lib/common.sh"
+
+ensure_git_repo
+
+input_root="$REPO_ROOT/.local/benchmarks/qwen-quant"
+output_root="$input_root/summaries"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --input-root)
+      input_root="${2:-}"
+      [ -n "$input_root" ] || die "Pass a non-empty input root after --input-root."
+      shift 2
+      ;;
+    --output-root)
+      output_root="${2:-}"
+      [ -n "$output_root" ] || die "Pass a non-empty output root after --output-root."
+      shift 2
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage:
+  summarize-qwen-quant-benchmark.sh [--input-root <path>] [--output-root <path>]
+
+Reads each <input-root>/<device>/latest.json and writes a Markdown comparison
+report under <output-root>.
+USAGE
+      exit 0
+      ;;
+    *)
+      die "Unknown summarize-qwen-quant-benchmark argument: $1"
+      ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || die "jq is required to summarize qwen quant benchmark JSON artifacts."
+[ -d "$input_root" ] || die "Qwen quant benchmark input root '$input_root' does not exist."
+
+mkdir -p "$output_root"
+stamp=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
+report_path="$output_root/qwen-quant-comparison-$stamp.md"
+latest_path="$output_root/qwen-quant-comparison-latest.md"
+
+{
+  printf '# Qwen Quant Benchmark Comparison\n\n'
+  printf 'Generated: `%s`\n\n' "$stamp"
+  printf '| Device | Backend | Completed | Failed | Timed out | Live first audio avg ms | Live complete avg ms | Peak resident GB | Quality warnings |\n'
+  printf '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n'
+
+  find "$input_root" -mindepth 2 -maxdepth 2 -name latest.json -print | sort | while IFS= read -r summary_file; do
+    jq -r '
+      def fmt($value): if $value == null then "n/a" else (($value * 100 | round) / 100 | tostring) end;
+      def avg($values): if ($values | length) == 0 then "n/a" else fmt(($values | add) / ($values | length)) end;
+      .deviceLabel as $device
+      | .backends[]
+      | .backend as $backend
+      | [.outcomes[] | select(.status == "completed")] as $completed
+      | [.outcomes[] | select(.status == "failed")] as $failed
+      | [.outcomes[] | select(.status == "timedOut")] as $timedOut
+      | [$completed[].sample.liveSpeech.generation.firstAudioChunkAtMS] as $firstAudio
+      | [$completed[].sample.liveSpeech.lifecycle.completedAtMS] as $completedMS
+      | [$completed[].sample.resources.processResidentBytes] as $resident
+      | [$completed[].sample.warnings.generationQualityWarningCount] as $qualityWarnings
+      | [
+          $device,
+          $backend,
+          ($completed | length | tostring),
+          ($failed | length | tostring),
+          ($timedOut | length | tostring),
+          avg($firstAudio),
+          avg($completedMS),
+          (if ($resident | length) == 0 then "n/a" else fmt(($resident | max) / 1073741824) end),
+          (if ($qualityWarnings | length) == 0 then "0" else ($qualityWarnings | add | tostring) end)
+        ]
+      | "| " + join(" | ") + " |"
+    ' "$summary_file"
+  done
+
+  printf '\n## Default Candidate Signals\n\n'
+  find "$input_root" -mindepth 2 -maxdepth 2 -name latest.json -print | sort | while IFS= read -r summary_file; do
+    jq -r '
+      def fmt($value): if $value == null then "n/a" else (($value * 100 | round) / 100 | tostring) end;
+      def avg($values): if ($values | length) == 0 then null else (($values | add) / ($values | length)) end;
+      .deviceLabel as $device
+      | .backends[]
+      | .backend as $backend
+      | [.outcomes[] | select(.status == "completed")] as $completed
+      | [.outcomes[] | select(.status == "failed" or .status == "timedOut")] as $incomplete
+      | [$completed[].sample.warnings.generationQualityWarningCount] as $qualityWarnings
+      | [$completed[].sample.liveSpeech.generation.firstAudioChunkAtMS] as $firstAudio
+      | select(($completed | length) > 0 and ($incomplete | length) == 0 and (($qualityWarnings | add // 0) == 0))
+      | "- `" + $device + "` candidate: `" + $backend + "` completed all recorded samples with no generation-quality warnings; average live first audio `" + fmt(avg($firstAudio)) + "` ms."
+    ' "$summary_file"
+  done
+
+  printf '\n## Variants To Review Or Prune\n\n'
+  find "$input_root" -mindepth 2 -maxdepth 2 -name latest.json -print | sort | while IFS= read -r summary_file; do
+    jq -r '
+      .deviceLabel as $device
+      | .backends[]
+      | .backend as $backend
+      | [.outcomes[] | select(.status == "failed")] as $failed
+      | [.outcomes[] | select(.status == "timedOut")] as $timedOut
+      | [.outcomes[] | select(.status == "completed")] as $completed
+      | [$completed[].sample.warnings.generationQualityWarningCount] as $qualityWarnings
+      | ($qualityWarnings | add // 0) as $qualityWarningCount
+      | select(($failed | length) > 0 or ($timedOut | length) > 0 or $qualityWarningCount > 0)
+      | "- `" + $device + "` review: `" + $backend + "` has failed samples `" + ($failed | length | tostring) + "`, timed-out samples `" + ($timedOut | length | tostring) + "`, and generation-quality warnings `" + ($qualityWarningCount | tostring) + "`."
+    ' "$summary_file"
+  done
+
+  printf '\n## Notes\n\n'
+  printf -- '- Treat failed backend rows as benchmark evidence, especially on memory-constrained machines.\n'
+  printf -- '- Prefer a default only when first-audio latency, completion time, memory, and quality warning counts are all acceptable for that device.\n'
+  printf -- '- Keep raw JSON artifacts local unless they have been reviewed for machine-local paths and private data.\n'
+} > "$report_path"
+
+cp "$report_path" "$latest_path"
+
+log "Wrote qwen quant benchmark report: $report_path"
+log "Updated latest qwen quant benchmark report: $latest_path"


### PR DESCRIPTION
## Summary
- add opt-in Qwen quant benchmark E2E coverage for cold, warm, and reload scenarios
- record failed and timed-out backend runs as benchmark data
- add local benchmark runners, OSSignposter correlation, and Markdown comparison summaries

## Verification
- swift test --filter QwenQuantizationBenchmarkE2ETests
- swift test
- swift build
- sh scripts/repo-maintenance/run-qwen-quant-benchmark.sh --backend qwen3_smol_4bit --iterations 1 --device-label macbook-pro-m4-pro-24gb --no-playback-trace
- sh scripts/repo-maintenance/summarize-qwen-quant-benchmark.sh
- commit hook repo-maintenance validation