### PR TITLE
release: prepare v11.0.0-alpha.2

### DIFF
--- a/Sources/SpeakSwiftly/API/AudioOutput.swift
+++ b/Sources/SpeakSwiftly/API/AudioOutput.swift
@@ -19,8 +19,16 @@ public extension SpeakSwiftly {
     typealias NetworkAudioDestinationBrowserState = SpeakSwiftlyNetworkAudioOutput.NetworkAudioDestinationBrowserState
     typealias NetworkAudioEndpoint = SpeakSwiftlyNetworkAudioOutput.NetworkAudioEndpoint
     typealias NetworkAudioServiceAdvertisement = SpeakSwiftlyNetworkAudioOutput.NetworkAudioServiceAdvertisement
+    typealias NetworkAudioInboundStream = SpeakSwiftlyNetworkAudioOutput.NetworkAudioInboundStream
+    typealias NetworkAudioLengthPrefixedFrameCodec = SpeakSwiftlyNetworkAudioOutput.NetworkAudioLengthPrefixedFrameCodec
+    typealias NetworkAudioStreamFrame = SpeakSwiftlyNetworkAudioOutput.NetworkAudioStreamFrame
+    typealias NetworkAudioStreamHandshake = SpeakSwiftlyNetworkAudioOutput.NetworkAudioStreamHandshake
+    typealias NetworkAudioStreamListener = SpeakSwiftlyNetworkAudioOutput.NetworkAudioStreamListener
+    typealias NetworkAudioStreamSender = SpeakSwiftlyNetworkAudioOutput.NetworkAudioStreamSender
+    typealias NetworkAudioStreamState = SpeakSwiftlyNetworkAudioOutput.NetworkAudioStreamState
     typealias NetworkGeneratedAudioFrame = SpeakSwiftlyNetworkAudioOutput.NetworkGeneratedAudioFrame
     typealias NetworkGeneratedAudioFrameCodec = SpeakSwiftlyNetworkAudioOutput.NetworkGeneratedAudioFrameCodec
+    typealias LocalGeneratedAudioPlayer = SpeakSwiftlyPlayback.LocalGeneratedAudioPlayer
 
     enum AudioOutputDestination: Codable, Sendable, Equatable {
         case localPlayback

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
@@ -108,6 +108,10 @@ Hosts that want selectable LAN audio receivers can use
 Bonjour-advertised audio receivers. A receiver host can attach
 ``SpeakSwiftly/NetworkAudioServiceAdvertisement/listenerService`` to its
 Network.framework listener so other SpeakSwiftly instances can discover it.
+Use ``SpeakSwiftly/NetworkAudioStreamSender`` to send generated chunks to a
+selected endpoint, ``SpeakSwiftly/NetworkAudioStreamListener`` to accept
+token-authenticated inbound streams, and ``SpeakSwiftly/LocalGeneratedAudioPlayer``
+to play the received chunk stream on the local machine.
 
 Use ``SpeakSwiftly/Generate/audio(text:voiceProfile:textProfile:requestContext:format:)`` when you want retained file output instead:
 

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/SpeakSwiftly.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/SpeakSwiftly.md
@@ -69,6 +69,11 @@ If you need custom text normalization behavior, create a ``SpeakSwiftly/Normaliz
 - ``SpeakSwiftly/NetworkAudioEndpoint``
 - ``SpeakSwiftly/NetworkAudioServiceAdvertisement``
 - ``SpeakSwiftly/NetworkAudioCapabilities``
+- ``SpeakSwiftly/NetworkAudioStreamSender``
+- ``SpeakSwiftly/NetworkAudioStreamListener``
+- ``SpeakSwiftly/NetworkAudioInboundStream``
+- ``SpeakSwiftly/NetworkAudioStreamHandshake``
+- ``SpeakSwiftly/LocalGeneratedAudioPlayer``
 
 ### Support
 

--- a/Sources/SpeakSwiftlyNetworkAudioOutput/NetworkAudioStreamTransport.swift
+++ b/Sources/SpeakSwiftlyNetworkAudioOutput/NetworkAudioStreamTransport.swift
@@ -1,0 +1,413 @@
+import Foundation
+import Network
+import SpeakSwiftlyCore
+
+public struct NetworkAudioInboundStream: Sendable {
+    public let requestID: String
+    public let remoteEndpointDescription: String
+    public let handshake: NetworkAudioStreamHandshake
+    public let chunks: AsyncThrowingStream<GeneratedAudioChunk, any Error>
+
+    public init(
+        requestID: String,
+        remoteEndpointDescription: String,
+        handshake: NetworkAudioStreamHandshake,
+        chunks: AsyncThrowingStream<GeneratedAudioChunk, any Error>,
+    ) {
+        self.requestID = requestID
+        self.remoteEndpointDescription = remoteEndpointDescription
+        self.handshake = handshake
+        self.chunks = chunks
+    }
+}
+
+public enum NetworkAudioStreamState: Sendable, Equatable {
+    case idle
+    case starting
+    case listening(port: UInt16?)
+    case failed(message: String)
+    case stopped
+}
+
+public actor NetworkAudioStreamListener {
+    public private(set) var state: NetworkAudioStreamState = .idle
+
+    private let advertisement: NetworkAudioServiceAdvertisement
+    private let port: UInt16
+    private let sharedToken: String
+    private let maximumFrameByteCount: Int
+    private let queue: DispatchQueue
+    private var listener: NWListener?
+    private var continuations = [UUID: AsyncStream<NetworkAudioInboundStream>.Continuation]()
+    private var connectionTasks = [ObjectIdentifier: Task<Void, Never>]()
+
+    public init(
+        advertisement: NetworkAudioServiceAdvertisement,
+        port: UInt16,
+        sharedToken: String,
+        maximumFrameByteCount: Int = NetworkAudioLengthPrefixedFrameCodec.defaultMaximumFrameByteCount,
+        queue: DispatchQueue = DispatchQueue(label: "SpeakSwiftly.NetworkAudioStreamListener"),
+    ) {
+        self.advertisement = advertisement
+        self.port = port
+        self.sharedToken = sharedToken
+        self.maximumFrameByteCount = maximumFrameByteCount
+        self.queue = queue
+    }
+
+    public func start() throws {
+        guard listener == nil else {
+            return
+        }
+        guard !sharedToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw GeneratedAudioOutputError.transportFailed(
+                requestID: "unknown",
+                message: "Network audio listener cannot start because its shared token is empty.",
+            )
+        }
+
+        let listener = try NWListener(
+            using: .tcp,
+            on: NWEndpoint.Port(integerLiteral: port),
+        )
+        listener.service = advertisement.listenerService
+        listener.newConnectionHandler = { connection in
+            Task {
+                await self.accept(connection)
+            }
+        }
+        listener.stateUpdateHandler = { state in
+            Task {
+                await self.updateState(from: state)
+            }
+        }
+        self.listener = listener
+        state = .starting
+        listener.start(queue: queue)
+    }
+
+    public func stop() {
+        listener?.cancel()
+        listener = nil
+        for task in connectionTasks.values {
+            task.cancel()
+        }
+        connectionTasks.removeAll()
+        for continuation in continuations.values {
+            continuation.finish()
+        }
+        continuations.removeAll()
+        state = .stopped
+    }
+
+    public func inboundStreams() -> AsyncStream<NetworkAudioInboundStream> {
+        let id = UUID()
+        let stream = AsyncStream<NetworkAudioInboundStream>.makeStream()
+        continuations[id] = stream.continuation
+        stream.continuation.onTermination = { _ in
+            Task {
+                await self.removeContinuation(id)
+            }
+        }
+        return stream.stream
+    }
+
+    private func accept(_ connection: NWConnection) {
+        let connectionID = ObjectIdentifier(connection)
+        let task = Task {
+            await runConnection(connection)
+            removeConnectionTask(connectionID)
+        }
+        connectionTasks[connectionID] = task
+    }
+
+    private func runConnection(_ connection: NWConnection) async {
+        connection.start(queue: queue)
+        do {
+            try await connection.waitUntilReady()
+            let firstFrame = try await connection.receiveLengthPrefixedFrame(maximumFrameByteCount: maximumFrameByteCount)
+            guard case let .handshake(handshake) = firstFrame else {
+                throw GeneratedAudioOutputError.transportFailed(
+                    requestID: "unknown",
+                    message: "Network audio connection from '\(connection.endpoint)' did not start with a stream handshake.",
+                )
+            }
+
+            try validate(handshake)
+
+            let stream = AsyncThrowingStream<GeneratedAudioChunk, any Error> { continuation in
+                let receiveTask = Task {
+                    do {
+                        while !Task.isCancelled {
+                            let frame = try await connection.receiveLengthPrefixedFrame(maximumFrameByteCount: maximumFrameByteCount)
+                            guard case let .audio(audioFrame) = frame else {
+                                throw GeneratedAudioOutputError.transportFailed(
+                                    requestID: handshake.requestID,
+                                    message: "Network audio connection from '\(connection.endpoint)' sent a second handshake after audio streaming had started.",
+                                )
+                            }
+
+                            continuation.yield(audioFrame.chunk)
+                            if audioFrame.chunk.isFinal {
+                                continuation.finish()
+                                connection.cancel()
+                                return
+                            }
+                        }
+                        continuation.finish(throwing: CancellationError())
+                    } catch {
+                        continuation.finish(throwing: error)
+                        connection.cancel()
+                    }
+                }
+                continuation.onTermination = { _ in
+                    receiveTask.cancel()
+                    connection.cancel()
+                }
+            }
+
+            let inbound = NetworkAudioInboundStream(
+                requestID: handshake.requestID,
+                remoteEndpointDescription: "\(connection.endpoint)",
+                handshake: handshake,
+                chunks: stream,
+            )
+            for continuation in continuations.values {
+                continuation.yield(inbound)
+            }
+        } catch {
+            connection.cancel()
+        }
+    }
+
+    private func validate(_ handshake: NetworkAudioStreamHandshake) throws {
+        guard handshake.protocolVersion == NetworkAudioBonjour.protocolVersion else {
+            throw GeneratedAudioOutputError.transportFailed(
+                requestID: handshake.requestID,
+                message: "Network audio stream '\(handshake.requestID)' used protocol version \(handshake.protocolVersion), but this listener supports version \(NetworkAudioBonjour.protocolVersion).",
+            )
+        }
+        guard handshake.sharedToken == sharedToken else {
+            throw GeneratedAudioOutputError.transportFailed(
+                requestID: handshake.requestID,
+                message: "Network audio stream '\(handshake.requestID)' was rejected because its shared token did not match this listener.",
+            )
+        }
+    }
+
+    private func updateState(from listenerState: NWListener.State) {
+        switch listenerState {
+            case .setup:
+                state = .idle
+            case .ready:
+                state = .listening(port: listener?.port?.rawValue)
+            case .cancelled:
+                state = .stopped
+            case let .waiting(error):
+                state = .failed(message: "Network audio listener is waiting for the network to become available: \(error)")
+            case let .failed(error):
+                state = .failed(message: "Network audio listener failed: \(error)")
+            @unknown default:
+                state = .failed(message: "Network audio listener entered an unknown Network.framework listener state.")
+        }
+    }
+
+    private func removeContinuation(_ id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+
+    private func removeConnectionTask(_ id: ObjectIdentifier) {
+        connectionTasks.removeValue(forKey: id)
+    }
+}
+
+public struct NetworkAudioStreamSender: Sendable {
+    private let endpoint: NetworkAudioEndpoint
+    private let handshake: NetworkAudioStreamHandshake
+    private let maximumFrameByteCount: Int
+    private let queue: DispatchQueue
+
+    public init(
+        endpoint: NetworkAudioEndpoint,
+        handshake: NetworkAudioStreamHandshake,
+        maximumFrameByteCount: Int = NetworkAudioLengthPrefixedFrameCodec.defaultMaximumFrameByteCount,
+        queue: DispatchQueue = DispatchQueue(label: "SpeakSwiftly.NetworkAudioStreamSender"),
+    ) {
+        self.endpoint = endpoint
+        self.handshake = handshake
+        self.maximumFrameByteCount = maximumFrameByteCount
+        self.queue = queue
+    }
+
+    public func send(
+        chunks: AsyncThrowingStream<GeneratedAudioChunk, any Error>,
+    ) async throws {
+        let connection = NWConnection(to: endpoint.nwEndpoint, using: .tcp)
+        connection.start(queue: queue)
+        do {
+            try await connection.waitUntilReady()
+            try await connection.sendFrame(.handshake(handshake), maximumFrameByteCount: maximumFrameByteCount)
+            for try await chunk in chunks {
+                try Task.checkCancellation()
+                try await connection.sendFrame(
+                    .audio(NetworkGeneratedAudioFrame(chunk: chunk)),
+                    maximumFrameByteCount: maximumFrameByteCount,
+                )
+                if chunk.isFinal {
+                    break
+                }
+            }
+            connection.cancel()
+        } catch {
+            connection.cancel()
+            throw error
+        }
+    }
+}
+
+private extension NWConnection {
+    func waitUntilReady() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            let box = ReadyContinuationBox()
+            stateUpdateHandler = { state in
+                switch state {
+                    case .ready:
+                        box.resume(continuation)
+                    case let .failed(error):
+                        box.resume(continuation, throwing: GeneratedAudioOutputError.transportFailed(
+                            requestID: "unknown",
+                            message: "Network audio connection failed before it became ready: \(error)",
+                        ))
+                    case .cancelled:
+                        box.resume(continuation, throwing: GeneratedAudioOutputError.transportFailed(
+                            requestID: "unknown",
+                            message: "Network audio connection was cancelled before it became ready.",
+                        ))
+                    default:
+                        break
+                }
+            }
+        }
+    }
+
+    func sendFrame(
+        _ frame: NetworkAudioStreamFrame,
+        maximumFrameByteCount: Int,
+    ) async throws {
+        let data = try NetworkAudioLengthPrefixedFrameCodec.encode(
+            frame,
+            maximumFrameByteCount: maximumFrameByteCount,
+        )
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            send(content: data, completion: .contentProcessed { error in
+                if let error {
+                    continuation.resume(throwing: GeneratedAudioOutputError.transportFailed(
+                        requestID: frame.requestID,
+                        message: "Network audio frame for request '\(frame.requestID)' could not be sent: \(error)",
+                    ))
+                } else {
+                    continuation.resume()
+                }
+            })
+        }
+    }
+
+    func receiveLengthPrefixedFrame(maximumFrameByteCount: Int) async throws -> NetworkAudioStreamFrame {
+        let prefix = try await receiveExactly(NetworkAudioLengthPrefixedFrameCodec.prefixByteCount)
+        let frameLength = Int(prefix.reduce(UInt32(0)) { partial, byte in
+            (partial << 8) | UInt32(byte)
+        })
+        guard frameLength <= maximumFrameByteCount else {
+            throw GeneratedAudioOutputError.transportFailed(
+                requestID: "unknown",
+                message: "Network audio frame declared \(frameLength) bytes, which exceeds the configured maximum of \(maximumFrameByteCount) bytes.",
+            )
+        }
+
+        let payload = try await receiveExactly(frameLength)
+        return try NetworkAudioLengthPrefixedFrameCodec.decodePayload(payload)
+    }
+
+    func receiveExactly(_ byteCount: Int) async throws -> Data {
+        var buffer = Data()
+        while buffer.count < byteCount {
+            let remaining = byteCount - buffer.count
+            let chunk = try await receiveChunk(maximumLength: remaining)
+            guard !chunk.isEmpty else {
+                throw GeneratedAudioOutputError.transportFailed(
+                    requestID: "unknown",
+                    message: "Network audio connection closed before \(byteCount) bytes could be read.",
+                )
+            }
+
+            buffer.append(chunk)
+        }
+        return buffer
+    }
+
+    func receiveChunk(maximumLength: Int) async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            receive(minimumIncompleteLength: 1, maximumLength: maximumLength) { data, _, isComplete, error in
+                if let error {
+                    continuation.resume(throwing: GeneratedAudioOutputError.transportFailed(
+                        requestID: "unknown",
+                        message: "Network audio receive failed: \(error)",
+                    ))
+                } else if let data {
+                    continuation.resume(returning: data)
+                } else if isComplete {
+                    continuation.resume(returning: Data())
+                } else {
+                    continuation.resume(throwing: GeneratedAudioOutputError.transportFailed(
+                        requestID: "unknown",
+                        message: "Network audio receive returned no data before the connection completed.",
+                    ))
+                }
+            }
+        }
+    }
+}
+
+private extension NetworkAudioStreamFrame {
+    var requestID: String {
+        switch self {
+            case let .handshake(handshake):
+                handshake.requestID
+            case let .audio(frame):
+                frame.chunk.requestID
+        }
+    }
+}
+
+private final class ReadyContinuationBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didResume = false
+
+    func resume(
+        _ continuation: CheckedContinuation<Void, any Error>,
+    ) {
+        guard markResumed() else { return }
+
+        continuation.resume()
+    }
+
+    func resume(
+        _ continuation: CheckedContinuation<Void, any Error>,
+        throwing error: any Error,
+    ) {
+        guard markResumed() else { return }
+
+        continuation.resume(throwing: error)
+    }
+
+    private func markResumed() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !didResume else {
+            return false
+        }
+
+        didResume = true
+        return true
+    }
+}

--- a/Sources/SpeakSwiftlyNetworkAudioOutput/NetworkGeneratedAudioFrame.swift
+++ b/Sources/SpeakSwiftlyNetworkAudioOutput/NetworkGeneratedAudioFrame.swift
@@ -18,3 +18,124 @@ public enum NetworkGeneratedAudioFrameCodec {
         try JSONDecoder().decode(NetworkGeneratedAudioFrame.self, from: data)
     }
 }
+
+public struct NetworkAudioStreamHandshake: Codable, Sendable, Equatable {
+    public let protocolVersion: Int
+    public let requestID: String
+    public let senderName: String
+    public let sharedToken: String
+
+    public init(
+        protocolVersion: Int = NetworkAudioBonjour.protocolVersion,
+        requestID: String,
+        senderName: String,
+        sharedToken: String,
+    ) {
+        self.protocolVersion = protocolVersion
+        self.requestID = requestID
+        self.senderName = senderName
+        self.sharedToken = sharedToken
+    }
+}
+
+public enum NetworkAudioStreamFrame: Codable, Sendable, Equatable {
+    case handshake(NetworkAudioStreamHandshake)
+    case audio(NetworkGeneratedAudioFrame)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case handshake
+        case audio
+    }
+
+    private enum Kind: String, Codable {
+        case handshake
+        case audio
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+            case .handshake:
+                self = try .handshake(container.decode(NetworkAudioStreamHandshake.self, forKey: .handshake))
+            case .audio:
+                self = try .audio(container.decode(NetworkGeneratedAudioFrame.self, forKey: .audio))
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+            case let .handshake(handshake):
+                try container.encode(Kind.handshake, forKey: .kind)
+                try container.encode(handshake, forKey: .handshake)
+            case let .audio(audio):
+                try container.encode(Kind.audio, forKey: .kind)
+                try container.encode(audio, forKey: .audio)
+        }
+    }
+}
+
+public enum NetworkAudioLengthPrefixedFrameCodec {
+    public static let prefixByteCount = 4
+    public static let defaultMaximumFrameByteCount = 8 * 1024 * 1024
+
+    public static func encode(
+        _ frame: NetworkAudioStreamFrame,
+        maximumFrameByteCount: Int = defaultMaximumFrameByteCount,
+    ) throws -> Data {
+        let payload = try JSONEncoder().encode(frame)
+        guard payload.count <= maximumFrameByteCount else {
+            throw GeneratedAudioOutputError.invalidChunk(
+                requestID: requestID(for: frame),
+                message: "Network audio frame payload is \(payload.count) bytes, which exceeds the configured maximum of \(maximumFrameByteCount) bytes.",
+            )
+        }
+
+        var length = UInt32(payload.count).bigEndian
+        var data = Data(bytes: &length, count: prefixByteCount)
+        data.append(payload)
+        return data
+    }
+
+    public static func decodePayload(_ payload: Data) throws -> NetworkAudioStreamFrame {
+        try JSONDecoder().decode(NetworkAudioStreamFrame.self, from: payload)
+    }
+
+    public static func splitFrames(
+        from buffer: inout Data,
+        maximumFrameByteCount: Int = defaultMaximumFrameByteCount,
+    ) throws -> [NetworkAudioStreamFrame] {
+        var frames = [NetworkAudioStreamFrame]()
+        while buffer.count >= prefixByteCount {
+            let frameLength = Int(buffer.prefix(prefixByteCount).reduce(UInt32(0)) { partial, byte in
+                (partial << 8) | UInt32(byte)
+            })
+            guard frameLength <= maximumFrameByteCount else {
+                throw GeneratedAudioOutputError.transportFailed(
+                    requestID: "unknown",
+                    message: "Network audio frame declared \(frameLength) bytes, which exceeds the configured maximum of \(maximumFrameByteCount) bytes.",
+                )
+            }
+            guard buffer.count >= prefixByteCount + frameLength else {
+                break
+            }
+
+            let payloadStart = buffer.index(buffer.startIndex, offsetBy: prefixByteCount)
+            let payloadEnd = buffer.index(payloadStart, offsetBy: frameLength)
+            let payload = Data(buffer[payloadStart..<payloadEnd])
+            try frames.append(decodePayload(payload))
+            buffer.removeSubrange(buffer.startIndex..<payloadEnd)
+        }
+        return frames
+    }
+
+    private static func requestID(for frame: NetworkAudioStreamFrame) -> String {
+        switch frame {
+            case let .handshake(handshake):
+                handshake.requestID
+            case let .audio(frame):
+                frame.chunk.requestID
+        }
+    }
+}

--- a/Sources/SpeakSwiftlyPlayback/LocalPlaybackAudioOutput.swift
+++ b/Sources/SpeakSwiftlyPlayback/LocalPlaybackAudioOutput.swift
@@ -1,3 +1,4 @@
+@preconcurrency import AVFoundation
 import Foundation
 import SpeakSwiftlyCore
 
@@ -24,5 +25,161 @@ public enum LocalPlaybackAudioOutput {
                 task.cancel()
             }
         }
+    }
+}
+
+@MainActor
+public final class LocalGeneratedAudioPlayer {
+    public typealias SampleSink = @Sendable (GeneratedAudioChunk) async throws -> Void
+
+    private let sampleSink: SampleSink?
+    private var audioEngine: AVAudioEngine?
+    private var playerNode: AVAudioPlayerNode?
+    private var streamingFormat: AVAudioFormat?
+
+    public init(sampleSink: SampleSink? = nil) {
+        self.sampleSink = sampleSink
+    }
+
+    public func play(
+        chunks: AsyncThrowingStream<GeneratedAudioChunk, any Error>,
+    ) async throws {
+        if let sampleSink {
+            try await playWithSampleSink(chunks: chunks, sampleSink: sampleSink)
+            return
+        }
+
+        try await playWithAudioEngine(chunks: chunks)
+    }
+
+    public func stop() {
+        playerNode?.stop()
+        audioEngine?.stop()
+        playerNode = nil
+        audioEngine = nil
+        streamingFormat = nil
+    }
+
+    private func playWithSampleSink(
+        chunks: AsyncThrowingStream<GeneratedAudioChunk, any Error>,
+        sampleSink: SampleSink,
+    ) async throws {
+        for try await chunk in chunks {
+            guard !chunk.isFinal else {
+                return
+            }
+
+            try await sampleSink(chunk)
+        }
+    }
+
+    private func playWithAudioEngine(
+        chunks: AsyncThrowingStream<GeneratedAudioChunk, any Error>,
+    ) async throws {
+        do {
+            for try await chunk in chunks {
+                guard !chunk.isFinal else {
+                    return
+                }
+
+                try prepareIfNeeded(for: chunk)
+                try schedule(chunk)
+            }
+        } catch {
+            stop()
+            throw error
+        }
+    }
+
+    private func prepareIfNeeded(for chunk: GeneratedAudioChunk) throws {
+        guard chunk.sampleFormat == .float32PCM else {
+            throw GeneratedAudioOutputError.invalidChunk(
+                requestID: chunk.requestID,
+                message: "Local generated-audio playback supports float32 PCM chunks, but request '\(chunk.requestID)' provided '\(chunk.sampleFormat.rawValue)'.",
+            )
+        }
+        guard chunk.channelCount > 0 else {
+            throw GeneratedAudioOutputError.invalidChunk(
+                requestID: chunk.requestID,
+                message: "Local generated-audio playback requires at least one channel for request '\(chunk.requestID)'.",
+            )
+        }
+
+        if let streamingFormat,
+           Int(streamingFormat.sampleRate) == chunk.sampleRate,
+           Int(streamingFormat.channelCount) == chunk.channelCount {
+            if playerNode?.isPlaying == false {
+                playerNode?.play()
+            }
+            return
+        }
+
+        stop()
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(chunk.sampleRate),
+            channels: AVAudioChannelCount(chunk.channelCount),
+            interleaved: false,
+        ) else {
+            throw GeneratedAudioOutputError.invalidChunk(
+                requestID: chunk.requestID,
+                message: "Local generated-audio playback could not create an AVAudioFormat for request '\(chunk.requestID)' at \(chunk.sampleRate) Hz with \(chunk.channelCount) channel(s).",
+            )
+        }
+
+        let engine = AVAudioEngine()
+        let node = AVAudioPlayerNode()
+        engine.attach(node)
+        engine.connect(node, to: engine.mainMixerNode, format: format)
+        try engine.start()
+        node.play()
+        audioEngine = engine
+        playerNode = node
+        streamingFormat = format
+    }
+
+    private func schedule(_ chunk: GeneratedAudioChunk) throws {
+        guard !chunk.samples.isEmpty else {
+            return
+        }
+        guard let format = streamingFormat, let playerNode else {
+            throw GeneratedAudioOutputError.invalidChunk(
+                requestID: chunk.requestID,
+                message: "Local generated-audio playback could not schedule request '\(chunk.requestID)' because the audio engine was not prepared.",
+            )
+        }
+        guard chunk.samples.count.isMultiple(of: chunk.channelCount) else {
+            throw GeneratedAudioOutputError.invalidChunk(
+                requestID: chunk.requestID,
+                message: "Local generated-audio playback received \(chunk.samples.count) sample(s) for request '\(chunk.requestID)', which is not divisible by \(chunk.channelCount) channel(s).",
+            )
+        }
+
+        let frameCount = AVAudioFrameCount(chunk.samples.count / chunk.channelCount)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            throw GeneratedAudioOutputError.invalidChunk(
+                requestID: chunk.requestID,
+                message: "Local generated-audio playback could not allocate a PCM buffer for request '\(chunk.requestID)'.",
+            )
+        }
+
+        buffer.frameLength = frameCount
+        guard let channelData = buffer.floatChannelData else {
+            throw GeneratedAudioOutputError.invalidChunk(
+                requestID: chunk.requestID,
+                message: "Local generated-audio playback could not access PCM channel storage for request '\(chunk.requestID)'.",
+            )
+        }
+
+        if chunk.channelCount == 1 {
+            channelData[0].update(from: chunk.samples, count: chunk.samples.count)
+        } else {
+            for frameIndex in 0..<Int(frameCount) {
+                for channelIndex in 0..<chunk.channelCount {
+                    channelData[channelIndex][frameIndex] = chunk.samples[frameIndex * chunk.channelCount + channelIndex]
+                }
+            }
+        }
+        playerNode.scheduleBuffer(buffer)
     }
 }

--- a/Tests/SpeakSwiftlyTests/Output/GeneratedAudioOutputTests.swift
+++ b/Tests/SpeakSwiftlyTests/Output/GeneratedAudioOutputTests.swift
@@ -78,6 +78,50 @@ import Testing
     #expect(sampleChunks == [[0.4, 0.5]])
 }
 
+@MainActor
+@Test func `local generated audio player consumes chunk stream through sample sink`() async throws {
+    let collector = GeneratedAudioChunkCollector()
+    let player = LocalGeneratedAudioPlayer { chunk in
+        await collector.append(chunk)
+    }
+    let source = AsyncThrowingStream<GeneratedAudioChunk, any Error> { continuation in
+        continuation.yield(GeneratedAudioChunk(
+            requestID: "req-play",
+            sequenceNumber: 0,
+            sampleRate: 24000,
+            channelCount: 1,
+            samples: [0.4, 0.5],
+        ))
+        continuation.yield(GeneratedAudioChunk(
+            requestID: "req-play",
+            sequenceNumber: 1,
+            sampleRate: 24000,
+            channelCount: 1,
+            samples: [],
+            isFinal: true,
+        ))
+        continuation.finish()
+    }
+
+    try await player.play(chunks: source)
+
+    let received = await collector.chunks()
+    #expect(received.map(\.sequenceNumber) == [0])
+    #expect(received.first?.samples == [0.4, 0.5])
+}
+
+private actor GeneratedAudioChunkCollector {
+    private var values = [GeneratedAudioChunk]()
+
+    func append(_ chunk: GeneratedAudioChunk) {
+        values.append(chunk)
+    }
+
+    func chunks() -> [GeneratedAudioChunk] {
+        values
+    }
+}
+
 @Test func `http audio frames preserve chunk metadata and pcm payload`() throws {
     let chunk = GeneratedAudioChunk(
         requestID: "req-http",

--- a/Tests/SpeakSwiftlyTests/Output/NetworkAudioOutputTests.swift
+++ b/Tests/SpeakSwiftlyTests/Output/NetworkAudioOutputTests.swift
@@ -21,6 +21,42 @@ import Testing
     #expect(decoded == frame)
 }
 
+@Test func `network audio length prefixed frames decode after partial reads`() throws {
+    let handshake = NetworkAudioStreamHandshake(
+        requestID: "req-lan",
+        senderName: "Mac mini",
+        sharedToken: "secret",
+    )
+    let chunk = GeneratedAudioChunk(
+        requestID: "req-lan",
+        sequenceNumber: 0,
+        sampleRate: 24000,
+        channelCount: 1,
+        samples: [0.1, 0.2],
+    )
+    let handshakeData = try NetworkAudioLengthPrefixedFrameCodec.encode(.handshake(handshake))
+    let audioData = try NetworkAudioLengthPrefixedFrameCodec.encode(.audio(NetworkGeneratedAudioFrame(chunk: chunk)))
+    let combined = handshakeData + audioData
+
+    var partialBuffer = Data(combined.prefix(2))
+    #expect(try NetworkAudioLengthPrefixedFrameCodec.splitFrames(from: &partialBuffer).isEmpty)
+    partialBuffer.append(combined.dropFirst(2).prefix(handshakeData.count - 2))
+    #expect(try NetworkAudioLengthPrefixedFrameCodec.splitFrames(from: &partialBuffer) == [.handshake(handshake)])
+    partialBuffer.append(combined.dropFirst(handshakeData.count))
+    #expect(try NetworkAudioLengthPrefixedFrameCodec.splitFrames(from: &partialBuffer) == [.audio(NetworkGeneratedAudioFrame(chunk: chunk))])
+    #expect(partialBuffer.isEmpty)
+}
+
+@Test func `network audio length prefixed frames reject oversized declarations`() throws {
+    var declaredLength = UInt32(NetworkAudioLengthPrefixedFrameCodec.defaultMaximumFrameByteCount + 1).bigEndian
+    var data = Data(bytes: &declaredLength, count: NetworkAudioLengthPrefixedFrameCodec.prefixByteCount)
+    data.append(Data([0]))
+
+    #expect(throws: GeneratedAudioOutputError.self) {
+        _ = try NetworkAudioLengthPrefixedFrameCodec.splitFrames(from: &data)
+    }
+}
+
 @Test func `network audio endpoint encodes manual and bonjour destinations`() throws {
     let endpoints: [NetworkAudioEndpoint] = [
         NetworkAudioEndpoint(host: "mac-mini.local", port: 17371),
@@ -83,6 +119,100 @@ import Testing
     #expect(await browser.snapshot().isEmpty)
 }
 
+@Test func `network audio sender streams chunks to loopback listener`() async throws {
+    let listener = NetworkAudioStreamListener(
+        advertisement: NetworkAudioServiceAdvertisement(name: "Loopback receiver"),
+        port: 0,
+        sharedToken: "secret",
+    )
+    let inboundStreams = await listener.inboundStreams()
+    try await listener.start()
+    let port = try await waitForListeningPort(listener)
+
+    let chunks = AsyncThrowingStream<GeneratedAudioChunk, any Error> { continuation in
+        continuation.yield(GeneratedAudioChunk(
+            requestID: "req-loopback",
+            sequenceNumber: 0,
+            sampleRate: 24000,
+            channelCount: 1,
+            samples: [0.25],
+        ))
+        continuation.yield(GeneratedAudioChunk(
+            requestID: "req-loopback",
+            sequenceNumber: 1,
+            sampleRate: 24000,
+            channelCount: 1,
+            samples: [],
+            isFinal: true,
+        ))
+        continuation.finish()
+    }
+    let sender = NetworkAudioStreamSender(
+        endpoint: NetworkAudioEndpoint(host: "127.0.0.1", port: port),
+        handshake: NetworkAudioStreamHandshake(
+            requestID: "req-loopback",
+            senderName: "test-sender",
+            sharedToken: "secret",
+        ),
+    )
+    async let sendResult: Void = sender.send(chunks: chunks)
+
+    var iterator = inboundStreams.makeAsyncIterator()
+    let inbound = try #require(await iterator.next())
+    var receivedChunks = [GeneratedAudioChunk]()
+    for try await chunk in inbound.chunks {
+        receivedChunks.append(chunk)
+    }
+    try await sendResult
+    await listener.stop()
+
+    #expect(inbound.requestID == "req-loopback")
+    #expect(inbound.handshake.senderName == "test-sender")
+    #expect(receivedChunks.map(\.sequenceNumber) == [0, 1])
+    #expect(receivedChunks.last?.isFinal == true)
+}
+
+@Test func `network audio listener rejects wrong shared token`() async throws {
+    let listener = NetworkAudioStreamListener(
+        advertisement: NetworkAudioServiceAdvertisement(name: "Loopback receiver"),
+        port: 0,
+        sharedToken: "secret",
+    )
+    let inboundStreams = await listener.inboundStreams()
+    try await listener.start()
+    let port = try await waitForListeningPort(listener)
+    let chunks = AsyncThrowingStream<GeneratedAudioChunk, any Error> { continuation in
+        continuation.yield(GeneratedAudioChunk(
+            requestID: "req-rejected",
+            sequenceNumber: 0,
+            sampleRate: 24000,
+            channelCount: 1,
+            samples: [],
+            isFinal: true,
+        ))
+        continuation.finish()
+    }
+    let sender = NetworkAudioStreamSender(
+        endpoint: NetworkAudioEndpoint(host: "127.0.0.1", port: port),
+        handshake: NetworkAudioStreamHandshake(
+            requestID: "req-rejected",
+            senderName: "test-sender",
+            sharedToken: "wrong",
+        ),
+    )
+
+    do {
+        try await sender.send(chunks: chunks)
+    } catch {
+        // The peer may close before the sender observes success; either way the listener must
+        // not publish an accepted inbound stream.
+    }
+    await listener.stop()
+
+    var iterator = inboundStreams.makeAsyncIterator()
+    #expect(await iterator.next() == nil)
+}
+
 @Test func `configuration carries manual network output destination`() throws {
     let configuration = SpeakSwiftly.Configuration(
         audioOutputDestination: .networkStream(host: "mac-mini.local", port: 17371),
@@ -101,4 +231,16 @@ import Testing
     let decoded = try JSONDecoder().decode(SpeakSwiftly.Configuration.self, from: data)
 
     #expect(decoded.audioOutputDestination == .networkService(name: "Mac mini"))
+}
+
+private func waitForListeningPort(_ listener: NetworkAudioStreamListener) async throws -> UInt16 {
+    for _ in 0..<100 {
+        if case let .listening(port?) = await listener.state {
+            return port
+        }
+        try await Task.sleep(for: .milliseconds(10))
+    }
+
+    Issue.record("Network audio listener did not report a loopback port in time.")
+    throw CancellationError()
 }

--- a/docs/releases/v11-0-0-alpha-1-release-notes.md
+++ b/docs/releases/v11-0-0-alpha-1-release-notes.md
@@ -14,6 +14,8 @@
   response streaming.
 - Added Network.framework audio frame encoding plus Bonjour audio-receiver
   discovery primitives for LAN receiver selection.
+- Added follow-up LAN stream sender/listener primitives for length-prefixed,
+  token-authenticated Network.framework audio receiver workflows.
 - Raised the `TextForSpeech` dependency floor to `0.23.0`.
 
 ## Breaking Changes

--- a/docs/releases/v11-0-0-alpha-2-release-notes.md
+++ b/docs/releases/v11-0-0-alpha-2-release-notes.md
@@ -1,0 +1,43 @@
+# v11.0.0-alpha.2 Draft Release Notes
+
+## What Changed
+
+- Added `SpeakSwiftlyFileAudioOutput` for retained `.wav` and AAC `.m4a`
+  generated-audio files.
+- Added length-prefixed Network.framework stream sender and listener primitives
+  under `SpeakSwiftlyNetworkAudioOutput`.
+- Added token-authenticated LAN audio stream handshakes for receiver workflows.
+- Added `LocalGeneratedAudioPlayer` under `SpeakSwiftlyPlayback` for playing
+  canonical generated-audio chunk streams locally.
+- Updated release automation so SemVer prerelease tags create GitHub prerelease
+  objects and verify existing prerelease metadata.
+
+## Breaking Changes
+
+- This remains part of the v11 major cleanup line. Removed backend and
+  request-context compatibility shims from alpha.1 remain removed.
+
+## Migration Notes
+
+- Use `GeneratedAudioFileFormat.m4a` when a portable compressed retained file is
+  preferred over `.wav`.
+- LAN receiver hosts should enable `NetworkAudioStreamListener` explicitly,
+  require a shared token, and pass accepted chunk streams to
+  `LocalGeneratedAudioPlayer`.
+- Server or app hosts still own request sessions, authorization policy,
+  configuration, and routing between remote callers and selected audio receivers.
+
+## Verification
+
+- `swift build`
+- `swift test --filter NetworkAudioOutputTests`
+- `swift test --filter GeneratedAudioOutputTests`
+- `swift test`
+- `bash scripts/repo-maintenance/validate-all.sh`
+
+## Follow-Up Before Final v11.0.0
+
+- Update `SpeakSwiftlyServer` to consume this prerelease as an opt-in Bonjour
+  LAN audio receiver.
+- Add server-side remote-output routing after the receiver can play package
+  loopback streams reliably.


### PR DESCRIPTION
## Release

- prepares v11.0.0-alpha.2 from branch `output/lan-audio-receiver-primitives`
- keeps protected `main` updates behind pull request review and CI
- release tag `v11.0.0-alpha.2` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
