### PR TITLE
api: add generated audio stream surface

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -293,7 +293,7 @@ In Progress
 - [x] Add HTTP-friendly raw PCM payload framing with metadata headers to `SpeakSwiftlyHTTPAudioOutput`.
 - [x] Add Network.framework audio frame encoding and Bonjour audio-receiver discovery primitives to `SpeakSwiftlyNetworkAudioOutput`.
 - [x] Add `generate.speech(... output:)` to the typed runtime surface.
-- [ ] Add `generate.audioStream(...)` only after the host boundary can return a successful chunk stream instead of a failed request handle.
+- [x] Add `generate.audioStream(...)` so host boundaries can consume successful canonical chunk streams instead of failed request handles.
 - [x] Remove the local `request_context.reqPurpose: "audioStream"` rejection guard after TextForSpeech removed `RequestPurpose.audioStream` in [gaelic-ghost/TextForSpeech#33](https://github.com/gaelic-ghost/TextForSpeech/issues/33).
 - [x] Add tests for canonical chunks, local playback chunk consumption, HTTP frames, Network frame round trips, Bonjour metadata, discovered-destination selection, and removed backend rejection.
 - [x] Add organized unit and integration matrix coverage for every Qwen3 size and quant variant so routing, decoding, configuration, resident repo mapping, generation policy, and runtime scheduling stay covered without real-model downloads in the default suite.

--- a/Sources/SpeakSwiftly/API/AudioOutput.swift
+++ b/Sources/SpeakSwiftly/API/AudioOutput.swift
@@ -7,6 +7,7 @@ import SpeakSwiftlyPlayback
 public extension SpeakSwiftly {
     typealias GeneratedAudioChunk = SpeakSwiftlyCore.GeneratedAudioChunk
     typealias GeneratedAudioChunkStream = SpeakSwiftlyCore.GeneratedAudioChunkStream
+    typealias GeneratedAudioChunkStreams = SpeakSwiftlyCore.GeneratedAudioChunkStreams
     typealias GeneratedAudioSampleFormat = SpeakSwiftlyCore.GeneratedAudioSampleFormat
     typealias GeneratedAudioOutputError = SpeakSwiftlyCore.GeneratedAudioOutputError
     typealias LocalPlaybackAudioOutput = SpeakSwiftlyPlayback.LocalPlaybackAudioOutput

--- a/Sources/SpeakSwiftly/API/GeneratedAudioStream.swift
+++ b/Sources/SpeakSwiftly/API/GeneratedAudioStream.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public extension SpeakSwiftly {
+    struct GeneratedAudioStream: Sendable {
+        public let handle: RequestHandle
+        public let chunks: GeneratedAudioChunkStream
+
+        init(
+            handle: RequestHandle,
+            chunks: GeneratedAudioChunkStream,
+        ) {
+            self.handle = handle
+            self.chunks = chunks
+        }
+    }
+}

--- a/Sources/SpeakSwiftly/API/Generation.swift
+++ b/Sources/SpeakSwiftly/API/Generation.swift
@@ -97,6 +97,29 @@ public extension SpeakSwiftly.Generate {
         )
     }
 
+    /// Generates speech audio as canonical chunk metadata plus Float32 PCM samples.
+    ///
+    /// Use this lower-level surface when the caller owns the output boundary, such as an
+    /// HTTP response stream, LAN transport sender, file encoder, benchmark, or custom player.
+    func audioStream(
+        text: String,
+        voiceProfile: SpeakSwiftly.Name? = nil,
+        textProfile: SpeakSwiftly.TextProfileID? = nil,
+        requestContext: SpeakSwiftly.RequestContext? = nil,
+        qwenPreModelTextChunking: Bool = false,
+    ) async -> SpeakSwiftly.GeneratedAudioStream {
+        let requestID = UUID().uuidString
+        let resolvedVoiceProfile = await runtime.resolveGenerationVoiceProfile(voiceProfile)
+        return await runtime.submitGeneratedAudioStream(
+            requestID: requestID,
+            text: text,
+            profileName: resolvedVoiceProfile,
+            textProfileID: textProfile,
+            requestContext: requestContext,
+            qwenPreModelTextChunking: qwenPreModelTextChunking,
+        )
+    }
+
     /// Queues a batch of retained audio-file generation requests under one voice profile.
     ///
     /// - Parameters:

--- a/Sources/SpeakSwiftly/Runtime/LiveSpeechRequestState.swift
+++ b/Sources/SpeakSwiftly/Runtime/LiveSpeechRequestState.swift
@@ -45,13 +45,15 @@ final class LiveSpeechRequestState: @unchecked Sendable {
             text: text,
             profileName: profileName,
             textProfileID: textProfileID,
-            jobType: .live,
+            jobType: jobType,
             audioFormat: _,
             requestContext: requestContext,
             qwenPreModelTextChunking: _,
-        ) = request else {
+        ) = request,
+            jobType == .live || jobType == .stream
+        else {
             fatalError(
-                "SpeakSwiftly attempted to create live speech request state for request '\(request.id)' (\(request.opName)), but that request does not require live playback. This indicates a runtime queueing bug.",
+                "SpeakSwiftly attempted to create speech request state for request '\(request.id)' (\(request.opName)), but that request is not a live playback or generated-audio stream request. This indicates a runtime queueing bug.",
             )
         }
 

--- a/Sources/SpeakSwiftly/Runtime/WorkerProtocol.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerProtocol.swift
@@ -135,6 +135,8 @@ enum WorkerRequest: Equatable {
         switch self {
             case .queueSpeech(id: _, text: _, profileName: _, textProfileID: _, jobType: .live, audioFormat: _, requestContext: _, qwenPreModelTextChunking: _):
                 "generate_speech"
+            case .queueSpeech(id: _, text: _, profileName: _, textProfileID: _, jobType: .stream, audioFormat: _, requestContext: _, qwenPreModelTextChunking: _):
+                "generate_audio_stream"
             case .queueSpeech(id: _, text: _, profileName: _, textProfileID: _, jobType: .file, audioFormat: _, requestContext: _, qwenPreModelTextChunking: _):
                 "generate_audio_file"
             case .queueBatch:
@@ -298,7 +300,8 @@ enum WorkerRequest: Equatable {
 
     var emitsTerminalSuccessAfterAcknowledgement: Bool {
         switch self {
-            case .queueSpeech(id: _, text: _, profileName: _, textProfileID: _, jobType: .file, audioFormat: _, requestContext: _, qwenPreModelTextChunking: _),
+            case .queueSpeech(id: _, text: _, profileName: _, textProfileID: _, jobType: .stream, audioFormat: _, requestContext: _, qwenPreModelTextChunking: _),
+                 .queueSpeech(id: _, text: _, profileName: _, textProfileID: _, jobType: .file, audioFormat: _, requestContext: _, qwenPreModelTextChunking: _),
                  .queueBatch,
                  .switchSpeechBackend,
                  .reloadModels,

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+GeneratedAudioStreams.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+GeneratedAudioStreams.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+extension SpeakSwiftly.Runtime {
+    func submitGeneratedAudioStream(
+        requestID: String,
+        text: String,
+        profileName: String,
+        textProfileID: String?,
+        requestContext: SpeakSwiftly.RequestContext?,
+        qwenPreModelTextChunking: Bool,
+    ) async -> SpeakSwiftly.GeneratedAudioStream {
+        let stream = AsyncThrowingStream<SpeakSwiftly.GeneratedAudioChunk, any Swift.Error>.makeStream()
+        generatedAudioStreamContinuations[requestID] = stream.continuation
+        stream.continuation.onTermination = { _ in
+            Task {
+                await self.removeGeneratedAudioStreamContinuation(for: requestID)
+            }
+        }
+
+        let handle = await submit(
+            .queueSpeech(
+                id: requestID,
+                text: text,
+                profileName: profileName,
+                textProfileID: textProfileID,
+                jobType: .stream,
+                audioFormat: nil,
+                requestContext: requestContext,
+                qwenPreModelTextChunking: qwenPreModelTextChunking,
+            ),
+        )
+        return SpeakSwiftly.GeneratedAudioStream(handle: handle, chunks: stream.stream)
+    }
+
+    func removeGeneratedAudioStreamContinuation(for requestID: String) {
+        generatedAudioStreamContinuations.removeValue(forKey: requestID)
+    }
+
+    func yieldGeneratedAudioChunk(_ chunk: SpeakSwiftly.GeneratedAudioChunk, for requestID: String) throws {
+        guard let continuation = generatedAudioStreamContinuations[requestID] else {
+            throw WorkerError(
+                code: .requestCancelled,
+                message: "Request '\(requestID)' could not continue generated-audio streaming because the caller stopped consuming the chunk stream.",
+            )
+        }
+
+        continuation.yield(chunk)
+    }
+
+    func finishGeneratedAudioStream(for requestID: String, throwing error: (any Swift.Error)? = nil) {
+        guard let continuation = generatedAudioStreamContinuations.removeValue(forKey: requestID) else {
+            return
+        }
+
+        if let error {
+            continuation.finish(throwing: error)
+        } else {
+            continuation.finish()
+        }
+    }
+}

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime+GenerationRequests.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime+GenerationRequests.swift
@@ -13,6 +13,10 @@ extension SpeakSwiftly.Runtime {
                     try await handleQueueSpeechLiveGeneration(id: id, op: request.opName, text: text, profileName: profileName)
                     disposition = .requestStillPendingPlayback
 
+                case .queueSpeech(id: let id, text: _, profileName: let profileName, textProfileID: _, jobType: .stream, audioFormat: _, requestContext: _, qwenPreModelTextChunking: _):
+                    try await handleQueueSpeechStreamGeneration(id: id, op: request.opName, profileName: profileName, request: request)
+                    disposition = .requestCompleted(.success(WorkerSuccessPayload(id: id)))
+
                 case .queueSpeech(
                 id: let id,
                 text: let text,
@@ -372,6 +376,65 @@ extension SpeakSwiftly.Runtime {
             throw WorkerError(
                 code: .modelGenerationFailed,
                 message: "Live speech generation failed while streaming audio for request '\(id)'. \(error.localizedDescription)",
+            )
+        }
+    }
+
+    private func handleQueueSpeechStreamGeneration(
+        id: String,
+        op: String,
+        profileName: String,
+        request: WorkerRequest,
+    ) async throws {
+        let speechState = try await makeSpeechJobState(for: request)
+        let residentInputs = try await loadResidentSpeechInputs(
+            requestID: id,
+            op: op,
+            profileName: profileName,
+        )
+        let residentModel = residentInputs.model
+
+        if speechBackend.isQwenFamily {
+            await logQwenLiveChunkPlan(for: speechState)
+        }
+
+        await emitProgress(id: id, stage: .bufferingAudio)
+        let sampleStream = residentLiveGenerationStream(
+            requestID: id,
+            op: op,
+            profileName: profileName,
+            text: speechState.normalizedText,
+            plannedTextChunks: speechState.normalizedLiveChunks,
+            inputs: residentInputs,
+            generationParameters: GenerationPolicy.residentParameters(
+                for: speechBackend,
+                text: speechState.normalizedText,
+            ),
+            streamingInterval: speechState.residentStreamingInterval,
+        )
+        let chunkStream = SpeakSwiftly.GeneratedAudioChunkStreams.chunks(
+            requestID: id,
+            sampleRate: residentModel.sampleRate,
+            samples: sampleStream,
+        )
+
+        do {
+            for try await chunk in chunkStream {
+                try Task.checkCancellation()
+                try yieldGeneratedAudioChunk(chunk, for: id)
+            }
+            finishGeneratedAudioStream(for: id)
+        } catch {
+            finishGeneratedAudioStream(for: id, throwing: error)
+            if let workerError = error as? WorkerError {
+                throw workerError
+            }
+            if error is CancellationError {
+                throw CancellationError()
+            }
+            throw WorkerError(
+                code: .modelGenerationFailed,
+                message: "Generated-audio stream request '\(id)' failed while streaming canonical audio chunks. \(error.localizedDescription)",
             )
         }
     }

--- a/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
+++ b/Sources/SpeakSwiftly/Runtime/WorkerRuntime.swift
@@ -281,6 +281,7 @@ public extension SpeakSwiftly {
         var playbackObservationBroker = SingletonObservationBroker<SpeakSwiftly.PlaybackUpdate>()
         var requestBrokers = [String: RequestBroker]()
         var requestAudioOutputDestinations = [String: SpeakSwiftly.AudioOutputDestination]()
+        var generatedAudioStreamContinuations = [String: AsyncThrowingStream<SpeakSwiftly.GeneratedAudioChunk, any Swift.Error>.Continuation]()
         var terminalRequestBrokerOrder = [String]()
         var workerOutputContinuations = [UUID: AsyncStream<SpeakSwiftly.WorkerOutputEvent>.Continuation]()
         var activeGenerations = [UUID: ActiveRequest]()

--- a/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.docc/RuntimeQuickStart.md
@@ -103,6 +103,20 @@ audio to an HTTP response or LAN transport. The output modules expose framing
 and discovery primitives, while the host-owned server boundary is responsible
 for attaching those bytes to a response or network connection.
 
+Use ``SpeakSwiftly/Generate/audioStream(text:voiceProfile:textProfile:requestContext:qwenPreModelTextChunking:)``
+when the host owns that boundary directly and needs canonical generated-audio
+chunks instead of local playback:
+
+```swift
+let stream = await runtime.generate.audioStream(
+    text: "Stream this as generated speech."
+)
+
+for try await chunk in stream.chunks {
+    // Frame the chunk for HTTP, send it over LAN, or play it with a custom sink.
+}
+```
+
 Hosts that want selectable LAN audio receivers can use
 ``SpeakSwiftly/NetworkAudioDestinationBrowser`` to keep an in-memory list of
 Bonjour-advertised audio receivers. A receiver host can attach

--- a/Sources/SpeakSwiftly/SpeakSwiftly.swift
+++ b/Sources/SpeakSwiftly/SpeakSwiftly.swift
@@ -10,6 +10,7 @@ public enum SpeakSwiftly {
 
     enum SpeechJobType: Equatable {
         case live
+        case stream
         case file
     }
 

--- a/Sources/SpeakSwiftlyCore/GeneratedAudioChunk.swift
+++ b/Sources/SpeakSwiftlyCore/GeneratedAudioChunk.swift
@@ -38,13 +38,15 @@ public enum GeneratedAudioOutputError: Error, Codable, Sendable, Equatable {
     case transportFailed(requestID: String, message: String)
 }
 
-public enum GeneratedAudioChunkStream {
+public typealias GeneratedAudioChunkStream = AsyncThrowingStream<GeneratedAudioChunk, any Error>
+
+public enum GeneratedAudioChunkStreams {
     public static func chunks(
         requestID: String,
         sampleRate: Int,
         channelCount: Int = 1,
         samples: some AsyncSequence<[Float], any Error> & Sendable,
-    ) -> AsyncThrowingStream<GeneratedAudioChunk, any Error> {
+    ) -> GeneratedAudioChunkStream {
         AsyncThrowingStream { continuation in
             let task = Task {
                 var sequenceNumber = 0

--- a/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
+++ b/Tests/SpeakSwiftlyTests/API/LibrarySurfaceTests.swift
@@ -323,6 +323,20 @@ import Darwin
     let generateAudioWithDefaultVoice: @Sendable (SpeakSwiftly.Generate, String) async -> SpeakSwiftly.RequestHandle = { generate, text in
         await generate.audio(text: text)
     }
+    let generateAudioStream: @Sendable (SpeakSwiftly.Generate, String, SpeakSwiftly.Name, SpeakSwiftly.TextProfileID?) async -> SpeakSwiftly.GeneratedAudioStream = {
+        generate,
+        text,
+        profileName,
+        textProfile in
+        await generate.audioStream(
+            text: text,
+            voiceProfile: profileName,
+            textProfile: textProfile,
+        )
+    }
+    let generateAudioStreamWithDefaultVoice: @Sendable (SpeakSwiftly.Generate, String) async -> SpeakSwiftly.GeneratedAudioStream = { generate, text in
+        await generate.audioStream(text: text)
+    }
     let generateHandle: @Sendable (SpeakSwiftly.Runtime) -> SpeakSwiftly.Generate = { runtime in
         runtime.generate
     }
@@ -739,6 +753,8 @@ import Darwin
     _ = speakWithDefaultVoice
     _ = generateAudio
     _ = generateAudioWithDefaultVoice
+    _ = generateAudioStream
+    _ = generateAudioStreamWithDefaultVoice
     _ = generateHandle
     _ = playbackHandle
     _ = voicesHandle

--- a/Tests/SpeakSwiftlyTests/Output/GeneratedAudioOutputTests.swift
+++ b/Tests/SpeakSwiftlyTests/Output/GeneratedAudioOutputTests.swift
@@ -33,7 +33,7 @@ import Testing
     }
     var chunks = [GeneratedAudioChunk]()
 
-    for try await chunk in GeneratedAudioChunkStream.chunks(
+    for try await chunk in GeneratedAudioChunkStreams.chunks(
         requestID: "req-qwen",
         sampleRate: 24000,
         samples: source,

--- a/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeGenerationTests.swift
+++ b/Tests/SpeakSwiftlyTests/Runtime/WorkerRuntimeGenerationTests.swift
@@ -5,6 +5,71 @@ import TextForSpeech
 
 // MARK: - Generated File Queueing
 
+@Test func `audio stream returns canonical generated chunks without local playback`() async throws {
+    let output = OutputRecorder()
+    let playback = PlaybackSpy()
+    let storeRoot = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: storeRoot) }
+
+    let store = try makeProfileStore(rootURL: storeRoot)
+    _ = try store.createProfile(
+        profileName: "default-femme",
+        modelRepo: "test-model",
+        voiceDescription: "Warm and bright.",
+        sourceText: "Reference transcript",
+        sampleRate: 24000,
+        canonicalAudioData: Data([0x01, 0x02]),
+    )
+
+    let runtime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: output,
+        playback: playback,
+        residentModelLoader: { _ in makeResidentModel(chunkCount: 2) },
+    )
+
+    await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    let generatedStream = await runtime.generate.audioStream(
+        text: "Hello from the generated stream path.",
+        voiceProfile: "default-femme",
+    )
+
+    var chunks = [SpeakSwiftly.GeneratedAudioChunk]()
+    for try await chunk in generatedStream.chunks {
+        chunks.append(chunk)
+    }
+
+    #expect(chunks.map(\.sequenceNumber) == [0, 1, 2])
+    #expect(chunks.map(\.samples) == [[0.1, 0.2], [0.2, 0.3], []])
+    #expect(chunks.map(\.isFinal) == [false, false, true])
+    #expect(chunks.allSatisfy { $0.requestID == generatedStream.handle.id })
+    #expect(chunks.allSatisfy { $0.sampleRate == 24000 })
+    #expect(chunks.allSatisfy { $0.channelCount == 1 })
+    #expect(chunks.allSatisfy { $0.sampleFormat == .float32PCM })
+    #expect(playback.playCount == 0)
+
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["id"] as? String == generatedStream.handle.id
+                && $0["event"] as? String == "started"
+                && $0["op"] as? String == "generate_audio_stream"
+        }
+    })
+    #expect(await waitUntil {
+        output.countJSONObjects {
+            $0["id"] as? String == generatedStream.handle.id
+                && $0["ok"] as? Bool == true
+        } == 2
+    })
+}
+
 @Test func `speak file acknowledges queue then completes with generated file metadata`() async throws {
     let output = OutputRecorder()
     let playback = PlaybackSpy()


### PR DESCRIPTION
## Summary
- add `generate.audioStream(...)` returning a request handle plus canonical generated-audio chunks
- route stream jobs through Qwen resident generation without local playback
- update runtime docs, roadmap, and API/runtime tests

## Verification
- `swift build`
- `swift test --filter WorkerRuntimeGenerationTests`
- `swift test --filter LibrarySurfaceTests`
- `swift test`
- commit hook repo-maintenance validation profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `audioStream()` API to generate and stream audio chunks directly, enabling direct access to canonical audio data without requiring local playback or file artifacts.

* **Documentation**
  * Updated Runtime Quick Start with streaming usage examples and guidance for consuming audio chunks via async iteration.

* **Tests**
  * Added comprehensive test coverage for audio streaming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->