### PR TITLE
network-audio: expose connection readiness diagnostics

### DIFF
--- a/Sources/SpeakSwiftlyCore/GeneratedAudioChunk.swift
+++ b/Sources/SpeakSwiftlyCore/GeneratedAudioChunk.swift
@@ -38,6 +38,19 @@ public enum GeneratedAudioOutputError: Error, Codable, Sendable, Equatable {
     case transportFailed(requestID: String, message: String)
 }
 
+extension GeneratedAudioOutputError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+            case let .invalidChunk(requestID, message):
+                "Generated audio chunk for request '\(requestID)' is invalid. \(message)"
+            case let .cancelled(requestID):
+                "Generated audio output for request '\(requestID)' was cancelled."
+            case let .transportFailed(requestID, message):
+                "Generated audio transport for request '\(requestID)' failed. \(message)"
+        }
+    }
+}
+
 public typealias GeneratedAudioChunkStream = AsyncThrowingStream<GeneratedAudioChunk, any Error>
 
 public enum GeneratedAudioChunkStreams {

--- a/Sources/SpeakSwiftlyNetworkAudioOutput/NetworkAudioStreamTransport.swift
+++ b/Sources/SpeakSwiftlyNetworkAudioOutput/NetworkAudioStreamTransport.swift
@@ -130,6 +130,7 @@ public actor NetworkAudioStreamListener {
                 on: queue,
                 timeout: connectionReadinessTimeout,
                 requestID: "unknown",
+                endpointDescription: "\(connection.endpoint)",
             )
             let firstFrame = try await connection.receiveLengthPrefixedFrame(maximumFrameByteCount: maximumFrameByteCount)
             guard case let .handshake(handshake) = firstFrame else {
@@ -257,6 +258,7 @@ public struct NetworkAudioStreamSender: Sendable {
                 on: queue,
                 timeout: connectionReadinessTimeout,
                 requestID: handshake.requestID,
+                endpointDescription: "\(endpoint.nwEndpoint)",
             )
             try await connection.sendFrame(.handshake(handshake), maximumFrameByteCount: maximumFrameByteCount)
             for try await chunk in chunks {
@@ -282,10 +284,12 @@ private extension NWConnection {
         on queue: DispatchQueue,
         timeout: Duration,
         requestID: String,
+        endpointDescription: String,
     ) async throws {
         try await withCheckedThrowingContinuation { continuation in
             let box = ReadyContinuationBox()
             let timeoutState = ReadinessTimeoutBox()
+            let readinessState = ConnectionReadinessStateBox()
             queue.asyncAfter(deadline: .now() + timeout.dispatchTimeInterval) {
                 guard timeoutState.fire() else {
                     return
@@ -293,11 +297,13 @@ private extension NWConnection {
 
                 box.resume(continuation, throwing: GeneratedAudioOutputError.transportFailed(
                     requestID: requestID,
-                    message: "Network audio connection for request '\(requestID)' did not become ready within \(timeout). Likely cause: the LAN audio receiver could not be resolved, accepted, or reached from this host.",
+                    message: "Network audio connection for request '\(requestID)' to '\(endpointDescription)' did not become ready within \(timeout). Last observed Network.framework state: \(readinessState.snapshot()). Likely cause: the LAN audio receiver could not be resolved, accepted, reached from this host, or permitted by local network privacy settings.",
                 ))
                 self.stateUpdateHandler = nil
             }
             stateUpdateHandler = { state in
+                readinessState.update(String(describing: state))
+
                 func finish(_ result: Result<Void, any Error>) {
                     timeoutState.cancel()
                     self.stateUpdateHandler = nil
@@ -315,12 +321,12 @@ private extension NWConnection {
                     case let .failed(error):
                         finish(.failure(GeneratedAudioOutputError.transportFailed(
                             requestID: requestID,
-                            message: "Network audio connection for request '\(requestID)' failed before it became ready: \(error)",
+                            message: "Network audio connection for request '\(requestID)' to '\(endpointDescription)' failed before it became ready: \(error)",
                         )))
                     case .cancelled:
                         finish(.failure(GeneratedAudioOutputError.transportFailed(
                             requestID: requestID,
-                            message: "Network audio connection for request '\(requestID)' was cancelled before it became ready.",
+                            message: "Network audio connection for request '\(requestID)' to '\(endpointDescription)' was cancelled before it became ready. Last observed Network.framework state: \(readinessState.snapshot()).",
                         )))
                     default:
                         break
@@ -416,6 +422,23 @@ private extension NetworkAudioStreamFrame {
             case let .audio(frame):
                 frame.chunk.requestID
         }
+    }
+}
+
+private final class ConnectionReadinessStateBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lastObservedState = "setup"
+
+    func update(_ state: String) {
+        lock.lock()
+        lastObservedState = state
+        lock.unlock()
+    }
+
+    func snapshot() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return lastObservedState
     }
 }
 

--- a/Tests/SpeakSwiftlyTests/Output/NetworkAudioOutputTests.swift
+++ b/Tests/SpeakSwiftlyTests/Output/NetworkAudioOutputTests.swift
@@ -206,9 +206,22 @@ import Testing
 
         #expect(requestID == "req-timeout")
         #expect(message.contains("req-timeout"))
+        #expect(message.contains("203.0.113.1:9"))
+        #expect(message.contains("Last observed Network.framework state:"))
     }
 
     #expect(started.duration(to: ContinuousClock.now) < .seconds(2))
+}
+
+@Test func `generated audio output errors have readable localized descriptions`() {
+    let error = GeneratedAudioOutputError.transportFailed(
+        requestID: "req-localized",
+        message: "Network audio connection to '192.0.2.10:51011' did not become ready.",
+    )
+
+    #expect(error.localizedDescription.contains("req-localized"))
+    #expect(error.localizedDescription.contains("192.0.2.10:51011"))
+    #expect(!error.localizedDescription.contains("error 2"))
 }
 
 @Test func `network audio listener rejects wrong shared token`() async throws {


### PR DESCRIPTION
## Summary
- make generated-audio output errors expose useful localized descriptions
- include the target endpoint and last observed Network.framework state in LAN audio readiness timeouts
- cover readable error descriptions and timeout diagnostics in network audio tests

## Verification
- xcrun swift test --filter NetworkAudioOutputTests
- xcrun swift test
- commit hook repo-maintenance validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error messages for audio streaming failures to include more detailed context, such as endpoint information and connection state, helping users better understand what went wrong.

* **Tests**
  * Added tests to verify accuracy and completeness of error messages in network audio operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->