### PR TITLE
tests: add qwen quantization benchmark lane

### DIFF
--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift
@@ -1,0 +1,768 @@
+#if os(macOS)
+import Foundation
+@testable import SpeakSwiftly
+import Testing
+
+private let backendBenchmarkSchemaVersion = 1
+
+@Suite(
+    .serialized,
+    .tags(.e2e, .benchmark),
+    .enabled(
+        if: speakSwiftlyE2ETestsEnabled(),
+        "These end-to-end worker tests are opt-in and require SPEAKSWIFTLY_E2E=1.",
+    ),
+    .enabled(
+        if: speakSwiftlyBackendBenchmarkE2ETestsEnabled(),
+        "This backend benchmark suite is opt-in and requires SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1.",
+    ),
+)
+struct BackendBenchmarkE2ETests {
+    @Test(
+        .enabled(
+            if: speakSwiftlyBackendBenchmarkComparisonEnabled(),
+            "This full backend benchmark requires SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1.",
+        ),
+    )
+    func `compare resident backends with two queued live requests`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        try await Self.provisionBenchmarkProfiles(
+            in: sandbox.profileRootURL,
+            backends: SpeakSwiftly.SpeechBackend.allCases,
+        )
+
+        let iterations = speakSwiftlyBackendBenchmarkIterations()
+        let playbackMode = BenchmarkHarness.effectivePlaybackMode()
+        var samples = [BackendBenchmarkSample]()
+        samples.reserveCapacity(iterations * SpeakSwiftly.SpeechBackend.allCases.count)
+
+        for backend in SpeakSwiftly.SpeechBackend.allCases {
+            for iteration in 1...iterations {
+                try await samples.append(
+                    Self.runBenchmarkSample(
+                        profileRootURL: sandbox.profileRootURL,
+                        backend: backend,
+                        iteration: iteration,
+                        playbackMode: playbackMode,
+                    ),
+                )
+            }
+        }
+
+        let summary = BackendBenchmarkSummary(
+            schemaVersion: backendBenchmarkSchemaVersion,
+            generatedAt: Date(),
+            host: .localMachine(),
+            settings: .current(
+                iterations: iterations,
+                playbackMode: playbackMode,
+                benchmarkTextCharacterCount: Self.benchmarkText.count,
+                benchmarkedBackends: SpeakSwiftly.SpeechBackend.allCases,
+            ),
+            backends: BackendBenchmarkReport.make(from: samples),
+        )
+        let summaryURL = try BenchmarkHarness.writeSummary(
+            summary,
+            timestampedStem: playbackMode == .audible ? "backend-live-audible-benchmark" : "backend-live-benchmark",
+            latestFilename: playbackMode == .audible ? "backend-live-audible-benchmark-latest.json" : "backend-live-benchmark-latest.json",
+            generatedAt: summary.generatedAt,
+        )
+
+        print("SpeakSwiftly backend benchmark summary: \(summaryURL.path)")
+        for report in summary.backends {
+            print(report.prettyDescription)
+        }
+    }
+
+    @Test(
+        .enabled(
+            if: speakSwiftlyQwenQuantizationBenchmarkE2ETestsEnabled(),
+            "This Qwen quantization benchmark requires SPEAKSWIFTLY_QWEN_QUANTIZATION_BENCHMARK_E2E=1.",
+        ),
+    )
+    func `compare qwen 0 6b six bit and eight bit with two queued live requests`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        try await Self.provisionBenchmarkProfiles(
+            in: sandbox.profileRootURL,
+            backends: Self.qwenQuantizationBackends,
+        )
+
+        let iterations = speakSwiftlyBackendBenchmarkIterations()
+        let playbackMode = BenchmarkHarness.effectivePlaybackMode()
+        var samples = [BackendBenchmarkSample]()
+        samples.reserveCapacity(iterations * Self.qwenQuantizationBackends.count)
+
+        for backend in Self.qwenQuantizationBackends {
+            for iteration in 1...iterations {
+                try await samples.append(
+                    Self.runBenchmarkSample(
+                        profileRootURL: sandbox.profileRootURL,
+                        backend: backend,
+                        iteration: iteration,
+                        playbackMode: playbackMode,
+                    ),
+                )
+            }
+        }
+
+        let summary = BackendBenchmarkSummary(
+            schemaVersion: backendBenchmarkSchemaVersion,
+            generatedAt: Date(),
+            host: .localMachine(),
+            settings: .current(
+                iterations: iterations,
+                playbackMode: playbackMode,
+                benchmarkTextCharacterCount: Self.benchmarkText.count,
+                benchmarkedBackends: Self.qwenQuantizationBackends,
+            ),
+            backends: BackendBenchmarkReport.make(from: samples),
+        )
+        let summaryURL = try BenchmarkHarness.writeSummary(
+            summary,
+            timestampedStem: playbackMode == .audible
+                ? "qwen-0-6b-quantization-audible-benchmark"
+                : "qwen-0-6b-quantization-benchmark",
+            latestFilename: playbackMode == .audible
+                ? "qwen-0-6b-quantization-audible-benchmark-latest.json"
+                : "qwen-0-6b-quantization-benchmark-latest.json",
+            generatedAt: summary.generatedAt,
+        )
+
+        print("SpeakSwiftly Qwen 0.6B quantization benchmark summary: \(summaryURL.path)")
+        for report in summary.backends {
+            print(report.prettyDescription)
+        }
+    }
+
+    @Test(
+        .enabled(
+            if: speakSwiftlyBackendBenchmarkComparisonEnabled(),
+            "This Marvis resident-policy benchmark requires SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1.",
+        ),
+    )
+    func `compare marvis resident policies with three queued voice switches`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+
+        try await Self.provisionMarvisBenchmarkProfiles(in: sandbox.profileRootURL)
+
+        let iterations = speakSwiftlyBackendBenchmarkIterations()
+        let playbackMode = BenchmarkHarness.effectivePlaybackMode()
+        var samples = [MarvisResidentPolicyBenchmarkSample]()
+        samples.reserveCapacity(iterations * SpeakSwiftly.MarvisResidentPolicy.allCases.count)
+
+        for residentPolicy in SpeakSwiftly.MarvisResidentPolicy.allCases {
+            for iteration in 1...iterations {
+                try await samples.append(
+                    Self.runMarvisResidentPolicySample(
+                        profileRootURL: sandbox.profileRootURL,
+                        residentPolicy: residentPolicy,
+                        iteration: iteration,
+                        playbackMode: playbackMode,
+                    ),
+                )
+            }
+        }
+
+        let summary = MarvisResidentPolicyBenchmarkSummary(
+            schemaVersion: backendBenchmarkSchemaVersion,
+            generatedAt: Date(),
+            host: .localMachine(),
+            settings: .current(
+                iterations: iterations,
+                playbackMode: playbackMode,
+                benchmarkTextCharacterCount: Self.benchmarkText.count,
+            ),
+            residentPolicies: MarvisResidentPolicyBenchmarkReport.make(from: samples),
+        )
+        let summaryURL = try BenchmarkHarness.writeSummary(
+            summary,
+            timestampedStem: playbackMode == .audible
+                ? "marvis-resident-policy-audible-benchmark"
+                : "marvis-resident-policy-benchmark",
+            latestFilename: playbackMode == .audible
+                ? "marvis-resident-policy-audible-benchmark-latest.json"
+                : "marvis-resident-policy-benchmark-latest.json",
+            generatedAt: summary.generatedAt,
+        )
+
+        print("SpeakSwiftly Marvis resident policy benchmark summary: \(summaryURL.path)")
+        for report in summary.residentPolicies {
+            print(report.prettyDescription)
+        }
+    }
+}
+
+private extension BackendBenchmarkE2ETests {
+    static let qwenQuantizationBackends: [SpeakSwiftly.SpeechBackend] = [
+        .qwen3_smol_6bit,
+        .qwen3_smol_8bit,
+    ]
+
+    static let benchmarkText = """
+    SpeakSwiftly backend benchmarking starts with a deliberate stretch of ordinary prose so the first live request has enough time to warm the resident model, enter buffering, reach preroll, and settle into sustained playback instead of disappearing before the timings become useful. The point of this paragraph is not theatrical reading. The point is to give the benchmark a realistic opening span with sentences long enough to expose startup cost, queue pressure, and early playback stability under normal language.
+
+    The second paragraph adds denser phrasing, longer clauses, and more punctuation so the benchmark does not flatten every backend into a tiny trivial request. We want the package to speak something that still sounds like real operator-facing text while being substantial enough to reveal how the second queued request behaves once the first request is already active. That lets us compare the queued-request tax across backends instead of pretending a one-line utterance tells the whole performance story.
+    """
+
+    static func profileName(for backend: SpeakSwiftly.SpeechBackend) -> String {
+        "benchmark-\(backend.rawValue)-profile"
+    }
+
+    static func provisionBenchmarkProfiles(
+        in profileRootURL: URL,
+        backends: [SpeakSwiftly.SpeechBackend],
+    ) async throws {
+        for backend in backends {
+            try await BenchmarkHarness.withBenchmarkRuntime(
+                profileRootURL: profileRootURL,
+                backend: backend,
+                qwenConditioningStrategy: .preparedConditioning,
+            ) { session in
+                _ = try await BenchmarkHarness.awaitResidentReady(
+                    on: session.runtime,
+                    signposts: session.signposts,
+                )
+
+                let handle = await session.runtime.voices.create(
+                    design: profileName(for: backend),
+                    from: E2EHarness.testingProfileText,
+                    vibe: .masc,
+                    voiceDescription: E2EHarness.testingProfileVoiceDescription,
+                )
+                _ = try await BenchmarkHarness.awaitSuccess(from: handle)
+            }
+        }
+    }
+
+    static func provisionMarvisBenchmarkProfiles(in profileRootURL: URL) async throws {
+        try await BenchmarkHarness.withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: .marvis,
+            qwenConditioningStrategy: .preparedConditioning,
+        ) { session in
+            _ = try await BenchmarkHarness.awaitResidentReady(
+                on: session.runtime,
+                signposts: session.signposts,
+            )
+
+            for fixture in MarvisResidentPolicyFixture.allCases {
+                let handle = await session.runtime.voices.create(
+                    design: fixture.profileName,
+                    from: E2EHarness.testingCloneSourceText,
+                    vibe: fixture.vibe,
+                    voiceDescription: fixture.voiceDescription,
+                )
+                _ = try await BenchmarkHarness.awaitSuccess(from: handle)
+            }
+        }
+    }
+
+    static func runBenchmarkSample(
+        profileRootURL: URL,
+        backend: SpeakSwiftly.SpeechBackend,
+        iteration: Int,
+        playbackMode: BenchmarkPlaybackMode,
+    ) async throws -> BackendBenchmarkSample {
+        try await BenchmarkHarness.withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: backend,
+            qwenConditioningStrategy: .preparedConditioning,
+            playbackMode: playbackMode,
+        ) { session in
+            let sampleSignpost = session.signposts.beginSample()
+            defer { sampleSignpost.end() }
+
+            let residentPreloadMS = try await BenchmarkHarness.awaitResidentReady(
+                on: session.runtime,
+                signposts: session.signposts,
+            )
+            let queuedPair = try await runQueuedLivePairBenchmark(
+                in: session,
+                backend: backend,
+            )
+
+            return BackendBenchmarkSample(
+                backend: backend,
+                iteration: iteration,
+                residentPreloadMS: residentPreloadMS,
+                queuedLivePair: queuedPair,
+            )
+        }
+    }
+
+    static func runQueuedLivePairBenchmark(
+        in session: BenchmarkRuntimeSession,
+        backend: SpeakSwiftly.SpeechBackend,
+    ) async throws -> BackendQueuedLivePairBenchmark {
+        let firstHandle = await session.runtime.generate.speech(
+            text: benchmarkText,
+            voiceProfile: profileName(for: backend),
+        )
+        let secondHandle = await session.runtime.generate.speech(
+            text: benchmarkText,
+            voiceProfile: profileName(for: backend),
+        )
+
+        async let firstRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: firstHandle,
+            signposts: session.signposts,
+            logRecorder: session.logRecorder,
+        )
+        async let secondRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: secondHandle,
+            signposts: session.signposts,
+            logRecorder: session.logRecorder,
+        )
+
+        let pair = try await BackendQueuedLivePairBenchmark(
+            firstRequest: firstRequest,
+            secondRequest: secondRequest,
+        )
+
+        guard pair.secondRequest.lifecycle.queuedAtMS != nil else {
+            throw BenchmarkError(
+                "Backend benchmark expected the second live request for backend '\(backend.rawValue)' to enter the queue, but it never reported a queued event.",
+            )
+        }
+
+        return pair
+    }
+
+    static func runMarvisResidentPolicySample(
+        profileRootURL: URL,
+        residentPolicy: SpeakSwiftly.MarvisResidentPolicy,
+        iteration: Int,
+        playbackMode: BenchmarkPlaybackMode,
+    ) async throws -> MarvisResidentPolicyBenchmarkSample {
+        try await BenchmarkHarness.withBenchmarkRuntime(
+            profileRootURL: profileRootURL,
+            backend: .marvis,
+            qwenConditioningStrategy: .preparedConditioning,
+            marvisResidentPolicy: residentPolicy,
+            playbackMode: playbackMode,
+        ) { session in
+            let sampleSignpost = session.signposts.beginSample()
+            defer { sampleSignpost.end() }
+
+            let residentPreloadMS = try await BenchmarkHarness.awaitResidentReady(
+                on: session.runtime,
+                signposts: session.signposts,
+            )
+            let threeRequestSwitch = try await runMarvisThreeRequestSwitchBenchmark(in: session)
+
+            return MarvisResidentPolicyBenchmarkSample(
+                residentPolicy: residentPolicy,
+                iteration: iteration,
+                residentPreloadMS: residentPreloadMS,
+                threeRequestSwitch: threeRequestSwitch,
+            )
+        }
+    }
+
+    static func runMarvisThreeRequestSwitchBenchmark(
+        in session: BenchmarkRuntimeSession,
+    ) async throws -> MarvisThreeRequestSwitchBenchmark {
+        let handles = await [
+            session.runtime.generate.speech(
+                text: benchmarkText,
+                voiceProfile: MarvisResidentPolicyFixture.femme.profileName,
+            ),
+            session.runtime.generate.speech(
+                text: benchmarkText,
+                voiceProfile: MarvisResidentPolicyFixture.masc.profileName,
+            ),
+            session.runtime.generate.speech(
+                text: benchmarkText,
+                voiceProfile: MarvisResidentPolicyFixture.returnToA.profileName,
+            ),
+        ]
+
+        async let firstRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: handles[0],
+            signposts: session.signposts,
+            logRecorder: session.logRecorder,
+        )
+        async let secondRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: handles[1],
+            signposts: session.signposts,
+            logRecorder: session.logRecorder,
+        )
+        async let thirdRequest = BenchmarkHarness.runRequestBenchmark(
+            handle: handles[2],
+            signposts: session.signposts,
+            logRecorder: session.logRecorder,
+        )
+
+        let result = try await MarvisThreeRequestSwitchBenchmark(
+            firstRequest: firstRequest,
+            secondRequest: secondRequest,
+            thirdRequest: thirdRequest,
+        )
+
+        guard
+            result.secondRequest.lifecycle.queuedAtMS != nil,
+            result.thirdRequest.lifecycle.queuedAtMS != nil
+        else {
+            throw BenchmarkError(
+                "The Marvis resident-policy benchmark expected the second and third live requests to enter the queue, but one of them never reported a queued event.",
+            )
+        }
+
+        return result
+    }
+}
+
+private enum MarvisResidentPolicyFixture: CaseIterable {
+    case femme
+    case masc
+    case returnToA
+
+    var profileName: String {
+        switch self {
+            case .femme:
+                "benchmark-marvis-femme-profile"
+            case .masc:
+                "benchmark-marvis-masc-profile"
+            case .returnToA:
+                "benchmark-marvis-return-to-a-profile"
+        }
+    }
+
+    var vibe: SpeakSwiftly.Vibe {
+        switch self {
+            case .femme:
+                .femme
+            case .masc:
+                .masc
+            case .returnToA:
+                .femme
+        }
+    }
+
+    var voiceDescription: String {
+        switch self {
+            case .femme:
+                "A warm, bright, feminine narrator voice."
+            case .masc:
+                "A grounded, rich, masculine speaking voice."
+            case .returnToA:
+                "A polished, airy, feminine speaking voice."
+        }
+    }
+}
+
+private struct BackendBenchmarkSummary: Codable {
+    let schemaVersion: Int
+    let generatedAt: Date
+    let host: BenchmarkHost
+    let settings: BackendBenchmarkSettings
+    let backends: [BackendBenchmarkReport]
+}
+
+private struct MarvisResidentPolicyBenchmarkSummary: Codable {
+    let schemaVersion: Int
+    let generatedAt: Date
+    let host: BenchmarkHost
+    let settings: MarvisResidentPolicyBenchmarkSettings
+    let residentPolicies: [MarvisResidentPolicyBenchmarkReport]
+}
+
+private struct BackendBenchmarkSettings: Codable {
+    let iterations: Int
+    let playbackMode: BenchmarkPlaybackMode
+    let benchmarkTextCharacterCount: Int
+    let timestampedSummaryPattern: String
+    let latestSummaryFilename: String
+    let benchmarkedBackends: [SpeakSwiftly.SpeechBackend]
+
+    static func current(
+        iterations: Int,
+        playbackMode: BenchmarkPlaybackMode,
+        benchmarkTextCharacterCount: Int,
+        benchmarkedBackends: [SpeakSwiftly.SpeechBackend],
+    ) -> Self {
+        Self(
+            iterations: iterations,
+            playbackMode: playbackMode,
+            benchmarkTextCharacterCount: benchmarkTextCharacterCount,
+            timestampedSummaryPattern: playbackMode == .audible
+                ? "backend-live-audible-benchmark-<ISO8601>.json"
+                : "backend-live-benchmark-<ISO8601>.json",
+            latestSummaryFilename: playbackMode == .audible
+                ? "backend-live-audible-benchmark-latest.json"
+                : "backend-live-benchmark-latest.json",
+            benchmarkedBackends: benchmarkedBackends,
+        )
+    }
+}
+
+private struct MarvisResidentPolicyBenchmarkSettings: Codable {
+    let iterations: Int
+    let playbackMode: BenchmarkPlaybackMode
+    let benchmarkTextCharacterCount: Int
+    let timestampedSummaryPattern: String
+    let latestSummaryFilename: String
+    let benchmarkedResidentPolicies: [SpeakSwiftly.MarvisResidentPolicy]
+    let requestProfileOrder: [String]
+
+    static func current(
+        iterations: Int,
+        playbackMode: BenchmarkPlaybackMode,
+        benchmarkTextCharacterCount: Int,
+    ) -> Self {
+        Self(
+            iterations: iterations,
+            playbackMode: playbackMode,
+            benchmarkTextCharacterCount: benchmarkTextCharacterCount,
+            timestampedSummaryPattern: playbackMode == .audible
+                ? "marvis-resident-policy-audible-benchmark-<ISO8601>.json"
+                : "marvis-resident-policy-benchmark-<ISO8601>.json",
+            latestSummaryFilename: playbackMode == .audible
+                ? "marvis-resident-policy-audible-benchmark-latest.json"
+                : "marvis-resident-policy-benchmark-latest.json",
+            benchmarkedResidentPolicies: SpeakSwiftly.MarvisResidentPolicy.allCases,
+            requestProfileOrder: MarvisResidentPolicyFixture.allCases.map(\.profileName),
+        )
+    }
+}
+
+private struct BackendBenchmarkReport: Codable {
+    let backend: SpeakSwiftly.SpeechBackend
+    let profileName: String
+    let sampleCount: Int
+    let residentPreloadMS: BenchmarkMetricSummary
+    let queuedLivePair: BackendQueuedLivePairAggregate
+    let samples: [BackendBenchmarkSample]
+
+    var prettyDescription: String {
+        """
+        \(backend.rawValue): preload \(residentPreloadMS.prettyAverage) ms, first request complete \(queuedLivePair.firstRequest.lifecycle.completedMS.prettyAverage) ms, second request complete \(queuedLivePair.secondRequest.lifecycle.completedMS.prettyAverage) ms, second request queue wait \(queuedLivePair.penalties.secondRequestQueueWaitMS.prettyAverage) ms, second request first audio penalty \(queuedLivePair.penalties.secondRequestFirstAudioPenaltyMS.prettyAverage) ms, first request CPU \(queuedLivePair.firstRequest.resources.processCPUTimeDeltaMS.prettyAverage) ms, second request CPU \(queuedLivePair.secondRequest.resources.processCPUTimeDeltaMS.prettyAverage) ms, first request max MLX peak \(queuedLivePair.firstRequest.resources.maxMLXPeakMemoryBytes.prettyAverage) bytes
+        """
+    }
+
+    static func make(from samples: [BackendBenchmarkSample]) -> [Self] {
+        Dictionary(grouping: samples, by: \.backend)
+            .map { backend, backendSamples in
+                Self(
+                    backend: backend,
+                    profileName: BackendBenchmarkE2ETests.profileName(for: backend),
+                    sampleCount: backendSamples.count,
+                    residentPreloadMS: .make(from: backendSamples.map(\.residentPreloadMS)),
+                    queuedLivePair: .make(from: backendSamples.map(\.queuedLivePair)),
+                    samples: backendSamples.sorted { $0.iteration < $1.iteration },
+                )
+            }
+            .sorted { $0.backend.rawValue < $1.backend.rawValue }
+    }
+}
+
+private struct MarvisResidentPolicyBenchmarkReport: Codable {
+    let residentPolicy: SpeakSwiftly.MarvisResidentPolicy
+    let sampleCount: Int
+    let residentPreloadMS: BenchmarkMetricSummary
+    let threeRequestSwitch: MarvisThreeRequestSwitchAggregate
+    let samples: [MarvisResidentPolicyBenchmarkSample]
+
+    var prettyDescription: String {
+        """
+        \(residentPolicy.rawValue): preload \(residentPreloadMS.prettyAverage) ms, first complete \(threeRequestSwitch.firstRequest.lifecycle.completedMS.prettyAverage) ms, second complete \(threeRequestSwitch.secondRequest.lifecycle.completedMS.prettyAverage) ms, third complete \(threeRequestSwitch.thirdRequest.lifecycle.completedMS.prettyAverage) ms, third queue wait \(threeRequestSwitch.penalties.thirdRequestQueueWaitMS.prettyAverage) ms, return-to-a first audio penalty \(threeRequestSwitch.penalties.thirdRequestFirstAudioPenaltyMS.prettyAverage) ms
+        """
+    }
+
+    static func make(from samples: [MarvisResidentPolicyBenchmarkSample]) -> [Self] {
+        Dictionary(grouping: samples, by: \.residentPolicy)
+            .map { residentPolicy, policySamples in
+                Self(
+                    residentPolicy: residentPolicy,
+                    sampleCount: policySamples.count,
+                    residentPreloadMS: .make(from: policySamples.map(\.residentPreloadMS)),
+                    threeRequestSwitch: .make(from: policySamples.map(\.threeRequestSwitch)),
+                    samples: policySamples.sorted { $0.iteration < $1.iteration },
+                )
+            }
+            .sorted { $0.residentPolicy.rawValue < $1.residentPolicy.rawValue }
+    }
+}
+
+private struct BackendBenchmarkSample: Codable {
+    let backend: SpeakSwiftly.SpeechBackend
+    let iteration: Int
+    let residentPreloadMS: Double
+    let queuedLivePair: BackendQueuedLivePairBenchmark
+}
+
+private struct MarvisResidentPolicyBenchmarkSample: Codable {
+    let residentPolicy: SpeakSwiftly.MarvisResidentPolicy
+    let iteration: Int
+    let residentPreloadMS: Double
+    let threeRequestSwitch: MarvisThreeRequestSwitchBenchmark
+}
+
+private struct BackendQueuedLivePairBenchmark: Codable {
+    let firstRequest: BenchmarkRequest
+    let secondRequest: BenchmarkRequest
+}
+
+private struct MarvisThreeRequestSwitchBenchmark: Codable {
+    let firstRequest: BenchmarkRequest
+    let secondRequest: BenchmarkRequest
+    let thirdRequest: BenchmarkRequest
+}
+
+private struct BackendQueuedLivePairAggregate: Codable {
+    let sampleCount: Int
+    let firstRequest: BenchmarkRequestAggregate
+    let secondRequest: BenchmarkRequestAggregate
+    let penalties: BackendQueuedLivePenaltyAggregate
+
+    static func make(from samples: [BackendQueuedLivePairBenchmark]) -> Self {
+        Self(
+            sampleCount: samples.count,
+            firstRequest: .make(from: samples.map(\.firstRequest)),
+            secondRequest: .make(from: samples.map(\.secondRequest)),
+            penalties: .make(from: samples),
+        )
+    }
+}
+
+private struct MarvisThreeRequestSwitchAggregate: Codable {
+    let sampleCount: Int
+    let firstRequest: BenchmarkRequestAggregate
+    let secondRequest: BenchmarkRequestAggregate
+    let thirdRequest: BenchmarkRequestAggregate
+    let penalties: MarvisThreeRequestSwitchPenaltyAggregate
+
+    static func make(from samples: [MarvisThreeRequestSwitchBenchmark]) -> Self {
+        Self(
+            sampleCount: samples.count,
+            firstRequest: .make(from: samples.map(\.firstRequest)),
+            secondRequest: .make(from: samples.map(\.secondRequest)),
+            thirdRequest: .make(from: samples.map(\.thirdRequest)),
+            penalties: .make(from: samples),
+        )
+    }
+}
+
+private struct BackendQueuedLivePenaltyAggregate: Codable {
+    let secondRequestQueueWaitMS: BenchmarkMetricSummary
+    let secondRequestFirstAudioPenaltyMS: BenchmarkMetricSummary
+    let secondRequestCompletionPenaltyMS: BenchmarkMetricSummary
+
+    static func make(from samples: [BackendQueuedLivePairBenchmark]) -> Self {
+        Self(
+            secondRequestQueueWaitMS: .make(
+                from: samples.compactMap {
+                    queueWaitMS(for: $0.secondRequest.lifecycle)
+                },
+            ),
+            secondRequestFirstAudioPenaltyMS: .make(
+                from: samples.compactMap {
+                    guard
+                        let first = $0.firstRequest.generation.firstAudioChunkAtMS,
+                        let second = $0.secondRequest.generation.firstAudioChunkAtMS
+                    else {
+                        return nil
+                    }
+
+                    return second - first
+                },
+            ),
+            secondRequestCompletionPenaltyMS: .make(
+                from: samples.compactMap {
+                    guard
+                        let first = $0.firstRequest.lifecycle.completedAtMS,
+                        let second = $0.secondRequest.lifecycle.completedAtMS
+                    else {
+                        return nil
+                    }
+
+                    return second - first
+                },
+            ),
+        )
+    }
+
+    private static func queueWaitMS(for lifecycle: BenchmarkRequestLifecycleMetrics) -> Double? {
+        guard
+            let queuedAtMS = lifecycle.queuedAtMS,
+            let startedAtMS = lifecycle.startedAtMS
+        else {
+            return nil
+        }
+
+        return startedAtMS - queuedAtMS
+    }
+}
+
+private struct MarvisThreeRequestSwitchPenaltyAggregate: Codable {
+    let secondRequestQueueWaitMS: BenchmarkMetricSummary
+    let thirdRequestQueueWaitMS: BenchmarkMetricSummary
+    let secondRequestFirstAudioPenaltyMS: BenchmarkMetricSummary
+    let thirdRequestFirstAudioPenaltyMS: BenchmarkMetricSummary
+    let returnToACompletionPenaltyMS: BenchmarkMetricSummary
+
+    static func make(from samples: [MarvisThreeRequestSwitchBenchmark]) -> Self {
+        Self(
+            secondRequestQueueWaitMS: .make(from: samples.compactMap {
+                queueWaitMS(for: $0.secondRequest)
+            }),
+            thirdRequestQueueWaitMS: .make(from: samples.compactMap {
+                queueWaitMS(for: $0.thirdRequest)
+            }),
+            secondRequestFirstAudioPenaltyMS: .make(from: samples.compactMap {
+                firstAudioPenaltyMS(for: $0.firstRequest, comparedTo: $0.secondRequest)
+            }),
+            thirdRequestFirstAudioPenaltyMS: .make(from: samples.compactMap {
+                firstAudioPenaltyMS(for: $0.firstRequest, comparedTo: $0.thirdRequest)
+            }),
+            returnToACompletionPenaltyMS: .make(from: samples.compactMap {
+                completionPenaltyMS(for: $0.firstRequest, comparedTo: $0.thirdRequest)
+            }),
+        )
+    }
+
+    private static func queueWaitMS(for request: BenchmarkRequest) -> Double? {
+        guard
+            let queuedAtMS = request.lifecycle.queuedAtMS,
+            let startedAtMS = request.lifecycle.startedAtMS
+        else {
+            return nil
+        }
+
+        return startedAtMS - queuedAtMS
+    }
+
+    private static func firstAudioPenaltyMS(
+        for baseline: BenchmarkRequest,
+        comparedTo request: BenchmarkRequest,
+    ) -> Double? {
+        guard
+            let baselineFirstAudio = baseline.generation.firstAudioChunkAtMS,
+            let requestFirstAudio = request.generation.firstAudioChunkAtMS
+        else {
+            return nil
+        }
+
+        return requestFirstAudio - baselineFirstAudio
+    }
+
+    private static func completionPenaltyMS(
+        for baseline: BenchmarkRequest,
+        comparedTo request: BenchmarkRequest,
+    ) -> Double? {
+        guard
+            let baselineCompleted = baseline.lifecycle.completedAtMS,
+            let requestCompleted = request.lifecycle.completedAtMS
+        else {
+            return nil
+        }
+
+        return requestCompleted - baselineCompleted
+    }
+}
+#endif

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift
@@ -137,64 +137,6 @@ struct BackendBenchmarkE2ETests {
             print(report.prettyDescription)
         }
     }
-
-    @Test(
-        .enabled(
-            if: speakSwiftlyBackendBenchmarkComparisonEnabled(),
-            "This Marvis resident-policy benchmark requires SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1.",
-        ),
-    )
-    func `compare marvis resident policies with three queued voice switches`() async throws {
-        let sandbox = try E2ESandbox()
-        defer { sandbox.cleanup() }
-
-        try await Self.provisionMarvisBenchmarkProfiles(in: sandbox.profileRootURL)
-
-        let iterations = speakSwiftlyBackendBenchmarkIterations()
-        let playbackMode = BenchmarkHarness.effectivePlaybackMode()
-        var samples = [MarvisResidentPolicyBenchmarkSample]()
-        samples.reserveCapacity(iterations * SpeakSwiftly.MarvisResidentPolicy.allCases.count)
-
-        for residentPolicy in SpeakSwiftly.MarvisResidentPolicy.allCases {
-            for iteration in 1...iterations {
-                try await samples.append(
-                    Self.runMarvisResidentPolicySample(
-                        profileRootURL: sandbox.profileRootURL,
-                        residentPolicy: residentPolicy,
-                        iteration: iteration,
-                        playbackMode: playbackMode,
-                    ),
-                )
-            }
-        }
-
-        let summary = MarvisResidentPolicyBenchmarkSummary(
-            schemaVersion: backendBenchmarkSchemaVersion,
-            generatedAt: Date(),
-            host: .localMachine(),
-            settings: .current(
-                iterations: iterations,
-                playbackMode: playbackMode,
-                benchmarkTextCharacterCount: Self.benchmarkText.count,
-            ),
-            residentPolicies: MarvisResidentPolicyBenchmarkReport.make(from: samples),
-        )
-        let summaryURL = try BenchmarkHarness.writeSummary(
-            summary,
-            timestampedStem: playbackMode == .audible
-                ? "marvis-resident-policy-audible-benchmark"
-                : "marvis-resident-policy-benchmark",
-            latestFilename: playbackMode == .audible
-                ? "marvis-resident-policy-audible-benchmark-latest.json"
-                : "marvis-resident-policy-benchmark-latest.json",
-            generatedAt: summary.generatedAt,
-        )
-
-        print("SpeakSwiftly Marvis resident policy benchmark summary: \(summaryURL.path)")
-        for report in summary.residentPolicies {
-            print(report.prettyDescription)
-        }
-    }
 }
 
 private extension BackendBenchmarkE2ETests {
@@ -233,29 +175,6 @@ private extension BackendBenchmarkE2ETests {
                     from: E2EHarness.testingProfileText,
                     vibe: .masc,
                     voiceDescription: E2EHarness.testingProfileVoiceDescription,
-                )
-                _ = try await BenchmarkHarness.awaitSuccess(from: handle)
-            }
-        }
-    }
-
-    static func provisionMarvisBenchmarkProfiles(in profileRootURL: URL) async throws {
-        try await BenchmarkHarness.withBenchmarkRuntime(
-            profileRootURL: profileRootURL,
-            backend: .marvis,
-            qwenConditioningStrategy: .preparedConditioning,
-        ) { session in
-            _ = try await BenchmarkHarness.awaitResidentReady(
-                on: session.runtime,
-                signposts: session.signposts,
-            )
-
-            for fixture in MarvisResidentPolicyFixture.allCases {
-                let handle = await session.runtime.voices.create(
-                    design: fixture.profileName,
-                    from: E2EHarness.testingCloneSourceText,
-                    vibe: fixture.vibe,
-                    voiceDescription: fixture.voiceDescription,
                 )
                 _ = try await BenchmarkHarness.awaitSuccess(from: handle)
             }
@@ -332,128 +251,6 @@ private extension BackendBenchmarkE2ETests {
 
         return pair
     }
-
-    static func runMarvisResidentPolicySample(
-        profileRootURL: URL,
-        residentPolicy: SpeakSwiftly.MarvisResidentPolicy,
-        iteration: Int,
-        playbackMode: BenchmarkPlaybackMode,
-    ) async throws -> MarvisResidentPolicyBenchmarkSample {
-        try await BenchmarkHarness.withBenchmarkRuntime(
-            profileRootURL: profileRootURL,
-            backend: .marvis,
-            qwenConditioningStrategy: .preparedConditioning,
-            marvisResidentPolicy: residentPolicy,
-            playbackMode: playbackMode,
-        ) { session in
-            let sampleSignpost = session.signposts.beginSample()
-            defer { sampleSignpost.end() }
-
-            let residentPreloadMS = try await BenchmarkHarness.awaitResidentReady(
-                on: session.runtime,
-                signposts: session.signposts,
-            )
-            let threeRequestSwitch = try await runMarvisThreeRequestSwitchBenchmark(in: session)
-
-            return MarvisResidentPolicyBenchmarkSample(
-                residentPolicy: residentPolicy,
-                iteration: iteration,
-                residentPreloadMS: residentPreloadMS,
-                threeRequestSwitch: threeRequestSwitch,
-            )
-        }
-    }
-
-    static func runMarvisThreeRequestSwitchBenchmark(
-        in session: BenchmarkRuntimeSession,
-    ) async throws -> MarvisThreeRequestSwitchBenchmark {
-        let handles = await [
-            session.runtime.generate.speech(
-                text: benchmarkText,
-                voiceProfile: MarvisResidentPolicyFixture.femme.profileName,
-            ),
-            session.runtime.generate.speech(
-                text: benchmarkText,
-                voiceProfile: MarvisResidentPolicyFixture.masc.profileName,
-            ),
-            session.runtime.generate.speech(
-                text: benchmarkText,
-                voiceProfile: MarvisResidentPolicyFixture.returnToA.profileName,
-            ),
-        ]
-
-        async let firstRequest = BenchmarkHarness.runRequestBenchmark(
-            handle: handles[0],
-            signposts: session.signposts,
-            logRecorder: session.logRecorder,
-        )
-        async let secondRequest = BenchmarkHarness.runRequestBenchmark(
-            handle: handles[1],
-            signposts: session.signposts,
-            logRecorder: session.logRecorder,
-        )
-        async let thirdRequest = BenchmarkHarness.runRequestBenchmark(
-            handle: handles[2],
-            signposts: session.signposts,
-            logRecorder: session.logRecorder,
-        )
-
-        let result = try await MarvisThreeRequestSwitchBenchmark(
-            firstRequest: firstRequest,
-            secondRequest: secondRequest,
-            thirdRequest: thirdRequest,
-        )
-
-        guard
-            result.secondRequest.lifecycle.queuedAtMS != nil,
-            result.thirdRequest.lifecycle.queuedAtMS != nil
-        else {
-            throw BenchmarkError(
-                "The Marvis resident-policy benchmark expected the second and third live requests to enter the queue, but one of them never reported a queued event.",
-            )
-        }
-
-        return result
-    }
-}
-
-private enum MarvisResidentPolicyFixture: CaseIterable {
-    case femme
-    case masc
-    case returnToA
-
-    var profileName: String {
-        switch self {
-            case .femme:
-                "benchmark-marvis-femme-profile"
-            case .masc:
-                "benchmark-marvis-masc-profile"
-            case .returnToA:
-                "benchmark-marvis-return-to-a-profile"
-        }
-    }
-
-    var vibe: SpeakSwiftly.Vibe {
-        switch self {
-            case .femme:
-                .femme
-            case .masc:
-                .masc
-            case .returnToA:
-                .femme
-        }
-    }
-
-    var voiceDescription: String {
-        switch self {
-            case .femme:
-                "A warm, bright, feminine narrator voice."
-            case .masc:
-                "A grounded, rich, masculine speaking voice."
-            case .returnToA:
-                "A polished, airy, feminine speaking voice."
-        }
-    }
 }
 
 private struct BackendBenchmarkSummary: Codable {
@@ -462,14 +259,6 @@ private struct BackendBenchmarkSummary: Codable {
     let host: BenchmarkHost
     let settings: BackendBenchmarkSettings
     let backends: [BackendBenchmarkReport]
-}
-
-private struct MarvisResidentPolicyBenchmarkSummary: Codable {
-    let schemaVersion: Int
-    let generatedAt: Date
-    let host: BenchmarkHost
-    let settings: MarvisResidentPolicyBenchmarkSettings
-    let residentPolicies: [MarvisResidentPolicyBenchmarkReport]
 }
 
 private struct BackendBenchmarkSettings: Codable {
@@ -497,36 +286,6 @@ private struct BackendBenchmarkSettings: Codable {
                 ? "backend-live-audible-benchmark-latest.json"
                 : "backend-live-benchmark-latest.json",
             benchmarkedBackends: benchmarkedBackends,
-        )
-    }
-}
-
-private struct MarvisResidentPolicyBenchmarkSettings: Codable {
-    let iterations: Int
-    let playbackMode: BenchmarkPlaybackMode
-    let benchmarkTextCharacterCount: Int
-    let timestampedSummaryPattern: String
-    let latestSummaryFilename: String
-    let benchmarkedResidentPolicies: [SpeakSwiftly.MarvisResidentPolicy]
-    let requestProfileOrder: [String]
-
-    static func current(
-        iterations: Int,
-        playbackMode: BenchmarkPlaybackMode,
-        benchmarkTextCharacterCount: Int,
-    ) -> Self {
-        Self(
-            iterations: iterations,
-            playbackMode: playbackMode,
-            benchmarkTextCharacterCount: benchmarkTextCharacterCount,
-            timestampedSummaryPattern: playbackMode == .audible
-                ? "marvis-resident-policy-audible-benchmark-<ISO8601>.json"
-                : "marvis-resident-policy-benchmark-<ISO8601>.json",
-            latestSummaryFilename: playbackMode == .audible
-                ? "marvis-resident-policy-audible-benchmark-latest.json"
-                : "marvis-resident-policy-benchmark-latest.json",
-            benchmarkedResidentPolicies: SpeakSwiftly.MarvisResidentPolicy.allCases,
-            requestProfileOrder: MarvisResidentPolicyFixture.allCases.map(\.profileName),
         )
     }
 }
@@ -561,34 +320,6 @@ private struct BackendBenchmarkReport: Codable {
     }
 }
 
-private struct MarvisResidentPolicyBenchmarkReport: Codable {
-    let residentPolicy: SpeakSwiftly.MarvisResidentPolicy
-    let sampleCount: Int
-    let residentPreloadMS: BenchmarkMetricSummary
-    let threeRequestSwitch: MarvisThreeRequestSwitchAggregate
-    let samples: [MarvisResidentPolicyBenchmarkSample]
-
-    var prettyDescription: String {
-        """
-        \(residentPolicy.rawValue): preload \(residentPreloadMS.prettyAverage) ms, first complete \(threeRequestSwitch.firstRequest.lifecycle.completedMS.prettyAverage) ms, second complete \(threeRequestSwitch.secondRequest.lifecycle.completedMS.prettyAverage) ms, third complete \(threeRequestSwitch.thirdRequest.lifecycle.completedMS.prettyAverage) ms, third queue wait \(threeRequestSwitch.penalties.thirdRequestQueueWaitMS.prettyAverage) ms, return-to-a first audio penalty \(threeRequestSwitch.penalties.thirdRequestFirstAudioPenaltyMS.prettyAverage) ms
-        """
-    }
-
-    static func make(from samples: [MarvisResidentPolicyBenchmarkSample]) -> [Self] {
-        Dictionary(grouping: samples, by: \.residentPolicy)
-            .map { residentPolicy, policySamples in
-                Self(
-                    residentPolicy: residentPolicy,
-                    sampleCount: policySamples.count,
-                    residentPreloadMS: .make(from: policySamples.map(\.residentPreloadMS)),
-                    threeRequestSwitch: .make(from: policySamples.map(\.threeRequestSwitch)),
-                    samples: policySamples.sorted { $0.iteration < $1.iteration },
-                )
-            }
-            .sorted { $0.residentPolicy.rawValue < $1.residentPolicy.rawValue }
-    }
-}
-
 private struct BackendBenchmarkSample: Codable {
     let backend: SpeakSwiftly.SpeechBackend
     let iteration: Int
@@ -596,22 +327,9 @@ private struct BackendBenchmarkSample: Codable {
     let queuedLivePair: BackendQueuedLivePairBenchmark
 }
 
-private struct MarvisResidentPolicyBenchmarkSample: Codable {
-    let residentPolicy: SpeakSwiftly.MarvisResidentPolicy
-    let iteration: Int
-    let residentPreloadMS: Double
-    let threeRequestSwitch: MarvisThreeRequestSwitchBenchmark
-}
-
 private struct BackendQueuedLivePairBenchmark: Codable {
     let firstRequest: BenchmarkRequest
     let secondRequest: BenchmarkRequest
-}
-
-private struct MarvisThreeRequestSwitchBenchmark: Codable {
-    let firstRequest: BenchmarkRequest
-    let secondRequest: BenchmarkRequest
-    let thirdRequest: BenchmarkRequest
 }
 
 private struct BackendQueuedLivePairAggregate: Codable {
@@ -625,24 +343,6 @@ private struct BackendQueuedLivePairAggregate: Codable {
             sampleCount: samples.count,
             firstRequest: .make(from: samples.map(\.firstRequest)),
             secondRequest: .make(from: samples.map(\.secondRequest)),
-            penalties: .make(from: samples),
-        )
-    }
-}
-
-private struct MarvisThreeRequestSwitchAggregate: Codable {
-    let sampleCount: Int
-    let firstRequest: BenchmarkRequestAggregate
-    let secondRequest: BenchmarkRequestAggregate
-    let thirdRequest: BenchmarkRequestAggregate
-    let penalties: MarvisThreeRequestSwitchPenaltyAggregate
-
-    static func make(from samples: [MarvisThreeRequestSwitchBenchmark]) -> Self {
-        Self(
-            sampleCount: samples.count,
-            firstRequest: .make(from: samples.map(\.firstRequest)),
-            secondRequest: .make(from: samples.map(\.secondRequest)),
-            thirdRequest: .make(from: samples.map(\.thirdRequest)),
             penalties: .make(from: samples),
         )
     }
@@ -699,70 +399,4 @@ private struct BackendQueuedLivePenaltyAggregate: Codable {
     }
 }
 
-private struct MarvisThreeRequestSwitchPenaltyAggregate: Codable {
-    let secondRequestQueueWaitMS: BenchmarkMetricSummary
-    let thirdRequestQueueWaitMS: BenchmarkMetricSummary
-    let secondRequestFirstAudioPenaltyMS: BenchmarkMetricSummary
-    let thirdRequestFirstAudioPenaltyMS: BenchmarkMetricSummary
-    let returnToACompletionPenaltyMS: BenchmarkMetricSummary
-
-    static func make(from samples: [MarvisThreeRequestSwitchBenchmark]) -> Self {
-        Self(
-            secondRequestQueueWaitMS: .make(from: samples.compactMap {
-                queueWaitMS(for: $0.secondRequest)
-            }),
-            thirdRequestQueueWaitMS: .make(from: samples.compactMap {
-                queueWaitMS(for: $0.thirdRequest)
-            }),
-            secondRequestFirstAudioPenaltyMS: .make(from: samples.compactMap {
-                firstAudioPenaltyMS(for: $0.firstRequest, comparedTo: $0.secondRequest)
-            }),
-            thirdRequestFirstAudioPenaltyMS: .make(from: samples.compactMap {
-                firstAudioPenaltyMS(for: $0.firstRequest, comparedTo: $0.thirdRequest)
-            }),
-            returnToACompletionPenaltyMS: .make(from: samples.compactMap {
-                completionPenaltyMS(for: $0.firstRequest, comparedTo: $0.thirdRequest)
-            }),
-        )
-    }
-
-    private static func queueWaitMS(for request: BenchmarkRequest) -> Double? {
-        guard
-            let queuedAtMS = request.lifecycle.queuedAtMS,
-            let startedAtMS = request.lifecycle.startedAtMS
-        else {
-            return nil
-        }
-
-        return startedAtMS - queuedAtMS
-    }
-
-    private static func firstAudioPenaltyMS(
-        for baseline: BenchmarkRequest,
-        comparedTo request: BenchmarkRequest,
-    ) -> Double? {
-        guard
-            let baselineFirstAudio = baseline.generation.firstAudioChunkAtMS,
-            let requestFirstAudio = request.generation.firstAudioChunkAtMS
-        else {
-            return nil
-        }
-
-        return requestFirstAudio - baselineFirstAudio
-    }
-
-    private static func completionPenaltyMS(
-        for baseline: BenchmarkRequest,
-        comparedTo request: BenchmarkRequest,
-    ) -> Double? {
-        guard
-            let baselineCompleted = baseline.lifecycle.completedAtMS,
-            let requestCompleted = request.lifecycle.completedAtMS
-        else {
-            return nil
-        }
-
-        return requestCompleted - baselineCompleted
-    }
-}
 #endif

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSignposts.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSignposts.swift
@@ -10,11 +10,11 @@ struct BenchmarkSignpostRecorder {
 
     init(
         backend: SpeakSwiftly.SpeechBackend,
-        workload: String,
+        playbackMode: BenchmarkPlaybackMode,
     ) {
         signposter = OSSignposter(
             subsystem: Self.subsystem,
-            category: "qwen-quant.\(backend.rawValue).\(workload)",
+            category: "benchmark.\(backend.rawValue).\(playbackMode.rawValue)",
         )
     }
 
@@ -42,6 +42,10 @@ struct BenchmarkSignpostRecorder {
         signposter.emitEvent("Request Started", id: id)
     }
 
+    func emitBufferingAudio(id: OSSignpostID) {
+        signposter.emitEvent("Buffering Audio", id: id)
+    }
+
     func emitPrerollReady(id: OSSignpostID) {
         signposter.emitEvent("Preroll Ready", id: id)
     }
@@ -56,6 +60,10 @@ struct BenchmarkSignpostRecorder {
 
     func emitFirstToken(id: OSSignpostID) {
         signposter.emitEvent("First Token", id: id)
+    }
+
+    func emitGenerationInfo(id: OSSignpostID) {
+        signposter.emitEvent("Generation Info", id: id)
     }
 
     func emitFirstAudioChunk(id: OSSignpostID) {

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSignposts.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSignposts.swift
@@ -18,6 +18,16 @@ struct BenchmarkSignpostRecorder {
         )
     }
 
+    init(
+        backend: SpeakSwiftly.SpeechBackend,
+        workload: String,
+    ) {
+        signposter = OSSignposter(
+            subsystem: Self.subsystem,
+            category: "benchmark.\(backend.rawValue).\(workload)",
+        )
+    }
+
     func beginSample() -> BenchmarkSignpostInterval {
         beginInterval("Benchmark Sample")
     }

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
@@ -1,11 +1,13 @@
 #if os(macOS)
 import Foundation
+@preconcurrency import MLX
 import os
 @testable import SpeakSwiftly
 
 struct BenchmarkRuntimeSession {
     let runtime: SpeakSwiftly.Runtime
     let logRecorder: BenchmarkLogRecorder
+    let signposts: BenchmarkSignpostRecorder
 }
 
 enum BenchmarkPlaybackMode: String, Codable {
@@ -40,22 +42,6 @@ struct BenchmarkHost: Codable {
             }
         }
     }
-}
-
-struct BenchmarkResourceSnapshot: Codable {
-    let processResidentBytes: Int?
-    let processPhysFootprintBytes: Int?
-    let processCPUTimeMS: Double?
-    let mlxActiveMemoryBytes: Int?
-    let mlxCacheMemoryBytes: Int?
-    let mlxPeakMemoryBytes: Int?
-}
-
-struct BenchmarkWarningSummary: Codable {
-    let warningCount: Int
-    let playbackWarningCount: Int
-    let generationQualityWarningCount: Int
-    let reasons: [String: Int]
 }
 
 struct BenchmarkMetricSummary: Codable {
@@ -117,6 +103,7 @@ struct BenchmarkRequest: Codable {
     let generatedArtifactID: String?
     let lifecycle: BenchmarkRequestLifecycleMetrics
     let generation: BenchmarkRequestGenerationMetrics
+    let resources: BenchmarkRequestResourceMetrics
     let playback: BenchmarkPlaybackMetrics?
 }
 
@@ -124,6 +111,7 @@ struct BenchmarkRequestAggregate: Codable {
     let sampleCount: Int
     let lifecycle: BenchmarkLifecycleMetricAggregate
     let generation: BenchmarkGenerationMetricAggregate
+    let resources: BenchmarkResourceMetricAggregate
     let playback: BenchmarkPlaybackMetricAggregate
 
     static func make(from samples: [BenchmarkRequest]) -> Self {
@@ -131,6 +119,7 @@ struct BenchmarkRequestAggregate: Codable {
             sampleCount: samples.count,
             lifecycle: .make(from: samples.map(\.lifecycle)),
             generation: .make(from: samples.map(\.generation)),
+            resources: .make(from: samples.map(\.resources)),
             playback: .make(from: samples.compactMap(\.playback)),
         )
     }
@@ -184,6 +173,86 @@ struct BenchmarkGenerationMetricAggregate: Codable {
             generateTimeMS: .make(from: samples.compactMap(\.generateTimeMS)),
             tokensPerSecond: .make(from: samples.compactMap(\.tokensPerSecond)),
             peakMemoryUsageGB: .make(from: samples.compactMap(\.peakMemoryUsageGB)),
+        )
+    }
+}
+
+struct BenchmarkResourceSnapshot: Codable {
+    let label: String
+    let elapsedMS: Double
+    let processResidentBytes: Int?
+    let processPhysFootprintBytes: Int?
+    let processUserCPUTimeNS: Int?
+    let processSystemCPUTimeNS: Int?
+    let mlxActiveMemoryBytes: Int?
+    let mlxCacheMemoryBytes: Int?
+    let mlxPeakMemoryBytes: Int?
+    let mlxCacheLimitBytes: Int?
+    let mlxMemoryLimitBytes: Int?
+
+    var processCPUTimeNS: Int? {
+        guard
+            let processUserCPUTimeNS,
+            let processSystemCPUTimeNS
+        else {
+            return nil
+        }
+
+        return processUserCPUTimeNS + processSystemCPUTimeNS
+    }
+}
+
+struct BenchmarkRequestResourceMetrics: Codable {
+    let snapshots: [BenchmarkResourceSnapshot]
+    let processCPUTimeDeltaMS: Double?
+    let maxProcessResidentBytes: Int?
+    let maxProcessPhysFootprintBytes: Int?
+    let maxMLXActiveMemoryBytes: Int?
+    let maxMLXCacheMemoryBytes: Int?
+    let maxMLXPeakMemoryBytes: Int?
+
+    static func make(from snapshots: [BenchmarkResourceSnapshot]) -> Self {
+        let sortedSnapshots = snapshots.sorted { $0.elapsedMS < $1.elapsedMS }
+        return Self(
+            snapshots: sortedSnapshots,
+            processCPUTimeDeltaMS: cpuTimeDeltaMS(from: sortedSnapshots),
+            maxProcessResidentBytes: sortedSnapshots.compactMap(\.processResidentBytes).max(),
+            maxProcessPhysFootprintBytes: sortedSnapshots.compactMap(\.processPhysFootprintBytes).max(),
+            maxMLXActiveMemoryBytes: sortedSnapshots.compactMap(\.mlxActiveMemoryBytes).max(),
+            maxMLXCacheMemoryBytes: sortedSnapshots.compactMap(\.mlxCacheMemoryBytes).max(),
+            maxMLXPeakMemoryBytes: sortedSnapshots.compactMap(\.mlxPeakMemoryBytes).max(),
+        )
+    }
+
+    private static func cpuTimeDeltaMS(from snapshots: [BenchmarkResourceSnapshot]) -> Double? {
+        guard
+            let first = snapshots.compactMap(\.processCPUTimeNS).first,
+            let last = snapshots.compactMap(\.processCPUTimeNS).last,
+            last >= first
+        else {
+            return nil
+        }
+
+        return Double(last - first) / 1_000_000
+    }
+}
+
+struct BenchmarkResourceMetricAggregate: Codable {
+    let processCPUTimeDeltaMS: BenchmarkMetricSummary
+    let maxProcessResidentBytes: BenchmarkMetricSummary
+    let maxProcessPhysFootprintBytes: BenchmarkMetricSummary
+    let maxMLXActiveMemoryBytes: BenchmarkMetricSummary
+    let maxMLXCacheMemoryBytes: BenchmarkMetricSummary
+    let maxMLXPeakMemoryBytes: BenchmarkMetricSummary
+
+    static func make(from samples: [BenchmarkRequestResourceMetrics]) -> Self {
+        Self(
+            processCPUTimeDeltaMS: .make(from: samples.compactMap(\.processCPUTimeDeltaMS)),
+            maxProcessResidentBytes: .make(from: samples.compactMap { $0.maxProcessResidentBytes.map(Double.init) }),
+            maxProcessPhysFootprintBytes: .make(from: samples.compactMap { $0.maxProcessPhysFootprintBytes.map(Double.init) }),
+            maxMLXActiveMemoryBytes: .make(from: samples.compactMap { $0.maxMLXActiveMemoryBytes.map(Double.init) }),
+            maxMLXCacheMemoryBytes: .make(from: samples.compactMap { $0.maxMLXCacheMemoryBytes.map(Double.init) }),
+            maxMLXPeakMemoryBytes: .make(from: samples.compactMap { $0.maxMLXPeakMemoryBytes.map(Double.init) }),
         )
     }
 }
@@ -284,32 +353,6 @@ final class BenchmarkLogRecorder: @unchecked Sendable {
         }
     }
 
-    private static func int(_ value: Any?) -> Int? {
-        switch value {
-            case let int as Int:
-                int
-            case let double as Double:
-                Int(double)
-            case let number as NSNumber:
-                number.intValue
-            default:
-                nil
-        }
-    }
-
-    private static func max(_ lhs: Int?, _ rhs: Int?) -> Int? {
-        switch (lhs, rhs) {
-            case let (lhs?, rhs?):
-                Swift.max(lhs, rhs)
-            case let (lhs?, nil):
-                lhs
-            case let (nil, rhs?):
-                rhs
-            case (nil, nil):
-                nil
-        }
-    }
-
     func appendStderr(_ message: String) {
         let lines = message
             .split(separator: "\n", omittingEmptySubsequences: true)
@@ -369,90 +412,18 @@ final class BenchmarkLogRecorder: @unchecked Sendable {
             )
         }
     }
-
-    func warningSummary(for requestID: String) -> BenchmarkWarningSummary {
-        warningSummary(for: [requestID])
-    }
-
-    func warningSummary(for requestIDs: [String]) -> BenchmarkWarningSummary {
-        let requestIDSet = Set(requestIDs)
-        return lock.withLock {
-            var reasons = [String: Int]()
-            var warningCount = 0
-            var playbackWarningCount = 0
-            var generationQualityWarningCount = 0
-
-            for object in stderrObjects where requestIDSet.contains(object["request_id"] as? String ?? "") {
-                guard object["level"] as? String == "warning" else { continue }
-
-                warningCount += 1
-                let event = object["event"] as? String ?? "unknown"
-                if event.hasPrefix("playback_") {
-                    playbackWarningCount += 1
-                }
-                if event == "playback_generation_quality_warning" {
-                    generationQualityWarningCount += 1
-                }
-
-                let details = object["details"] as? [String: Any]
-                let reason = details?["reason"] as? String ?? event
-                reasons[reason, default: 0] += 1
-            }
-
-            return BenchmarkWarningSummary(
-                warningCount: warningCount,
-                playbackWarningCount: playbackWarningCount,
-                generationQualityWarningCount: generationQualityWarningCount,
-                reasons: reasons,
-            )
-        }
-    }
-
-    func peakResourceSnapshot() -> BenchmarkResourceSnapshot {
-        lock.withLock {
-            var processResidentBytes: Int?
-            var processPhysFootprintBytes: Int?
-            var processCPUTimeNS: Int?
-            var mlxActiveMemoryBytes: Int?
-            var mlxCacheMemoryBytes: Int?
-            var mlxPeakMemoryBytes: Int?
-
-            for object in stderrObjects {
-                guard let details = object["details"] as? [String: Any] else { continue }
-
-                processResidentBytes = Self.max(processResidentBytes, Self.int(details["process_resident_bytes"]))
-                processPhysFootprintBytes = Self.max(processPhysFootprintBytes, Self.int(details["process_phys_footprint_bytes"]))
-                let userCPUTimeNS = Self.int(details["process_user_cpu_time_ns"]) ?? 0
-                let systemCPUTimeNS = Self.int(details["process_system_cpu_time_ns"]) ?? 0
-                if userCPUTimeNS > 0 || systemCPUTimeNS > 0 {
-                    processCPUTimeNS = Self.max(processCPUTimeNS, userCPUTimeNS + systemCPUTimeNS)
-                }
-                mlxActiveMemoryBytes = Self.max(mlxActiveMemoryBytes, Self.int(details["mlx_active_memory_bytes"]))
-                mlxCacheMemoryBytes = Self.max(mlxCacheMemoryBytes, Self.int(details["mlx_cache_memory_bytes"]))
-                mlxPeakMemoryBytes = Self.max(mlxPeakMemoryBytes, Self.int(details["mlx_peak_memory_bytes"]))
-            }
-
-            return BenchmarkResourceSnapshot(
-                processResidentBytes: processResidentBytes,
-                processPhysFootprintBytes: processPhysFootprintBytes,
-                processCPUTimeMS: processCPUTimeNS.map { Double($0) / 1_000_000 },
-                mlxActiveMemoryBytes: mlxActiveMemoryBytes,
-                mlxCacheMemoryBytes: mlxCacheMemoryBytes,
-                mlxPeakMemoryBytes: mlxPeakMemoryBytes,
-            )
-        }
-    }
 }
 
 enum BenchmarkHarness {
     static func effectivePlaybackMode() -> BenchmarkPlaybackMode {
-        speakSwiftlyAudibleE2ETestsEnabled() ? .audible : .silent
+        speakSwiftlyBackendBenchmarkAudibleEnabled() ? .audible : .silent
     }
 
     static func withBenchmarkRuntime<T>(
         profileRootURL: URL,
         backend: SpeakSwiftly.SpeechBackend,
         qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
+        marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy = .dualResidentSerialized,
         playbackMode: BenchmarkPlaybackMode = .silent,
         playbackTrace: Bool = false,
         operation: @escaping @Sendable (BenchmarkRuntimeSession) async throws -> T,
@@ -461,6 +432,7 @@ enum BenchmarkHarness {
             profileRootURL: profileRootURL,
             backend: backend,
             qwenConditioningStrategy: qwenConditioningStrategy,
+            marvisResidentPolicy: marvisResidentPolicy,
             playbackMode: playbackMode,
             playbackTrace: playbackTrace,
         )
@@ -479,6 +451,7 @@ enum BenchmarkHarness {
         profileRootURL: URL,
         backend: SpeakSwiftly.SpeechBackend,
         qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
+        marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy,
         playbackMode: BenchmarkPlaybackMode,
         playbackTrace: Bool,
     ) async throws -> BenchmarkRuntimeSession {
@@ -487,6 +460,10 @@ enum BenchmarkHarness {
 
         let liveDependencies = WorkerDependencies.live()
         let logRecorder = BenchmarkLogRecorder()
+        let signposts = BenchmarkSignpostRecorder(
+            backend: backend,
+            playbackMode: playbackMode,
+        )
         let dependencies = WorkerDependencies(
             fileManager: liveDependencies.fileManager,
             loadResidentModels: liveDependencies.loadResidentModels,
@@ -507,7 +484,6 @@ enum BenchmarkHarness {
                 logRecorder.appendStderr(message)
                 fputs("SpeakSwiftly benchmark runtime stderr: \(message)\n", stderr)
             },
-            writeSystemLog: liveDependencies.writeSystemLog,
             now: liveDependencies.now,
             readRuntimeMemory: liveDependencies.readRuntimeMemory,
         )
@@ -536,6 +512,7 @@ enum BenchmarkHarness {
             dependencies: dependencies,
             speechBackend: backend,
             qwenConditioningStrategy: qwenConditioningStrategy,
+            marvisResidentPolicy: marvisResidentPolicy,
             profileStore: profileStore,
             generatedFileStore: generatedFileStore,
             generationJobStore: generationJobStore,
@@ -543,13 +520,22 @@ enum BenchmarkHarness {
             playbackQueue: playbackQueue,
         )
         await runtime.installPlaybackHooks()
-        return BenchmarkRuntimeSession(runtime: runtime, logRecorder: logRecorder)
+        return BenchmarkRuntimeSession(
+            runtime: runtime,
+            logRecorder: logRecorder,
+            signposts: signposts,
+        )
     }
 
-    static func awaitResidentReady(on runtime: SpeakSwiftly.Runtime) async throws -> Double {
+    static func awaitResidentReady(
+        on runtime: SpeakSwiftly.Runtime,
+        signposts: BenchmarkSignpostRecorder,
+    ) async throws -> Double {
         let clock = ContinuousClock()
         let startedAt = clock.now
         let updates = await runtime.updates()
+        let interval = signposts.beginResidentPreload()
+        defer { interval.end() }
 
         await runtime.start()
 
@@ -575,36 +561,44 @@ enum BenchmarkHarness {
 
     static func runRequestBenchmark(
         handle: SpeakSwiftly.RequestHandle,
+        signposts: BenchmarkSignpostRecorder,
         logRecorder: BenchmarkLogRecorder? = nil,
-        signposts: BenchmarkSignpostRecorder? = nil,
     ) async throws -> BenchmarkRequest {
         let clock = ContinuousClock()
         let submittedAt = clock.now
-        let signpostInterval = signposts?.beginRequest()
+        let requestInterval = signposts.beginRequest()
+        defer { requestInterval.end() }
+        let submittedSnapshot = resourceSnapshot(
+            label: "request_submitted",
+            submittedAt: submittedAt,
+            clock: clock,
+        )
 
         async let lifecycle = collectLifecycleMetrics(
             from: handle.events,
             submittedAt: submittedAt,
             clock: clock,
             signposts: signposts,
-            signpostID: signpostInterval?.id,
+            signpostID: requestInterval.id,
         )
         async let generation = collectGenerationMetrics(
             from: handle.synthesisUpdates,
             submittedAt: submittedAt,
             clock: clock,
             signposts: signposts,
-            signpostID: signpostInterval?.id,
+            signpostID: requestInterval.id,
         )
 
-        let (lifecycleMetrics, success) = try await lifecycle
-        let generationMetrics = try await generation
+        let (lifecycleMetrics, success, lifecycleSnapshots) = try await lifecycle
+        let (generationMetrics, generationSnapshots) = try await generation
+        let resourceMetrics = BenchmarkRequestResourceMetrics.make(
+            from: [submittedSnapshot] + lifecycleSnapshots + generationSnapshots,
+        )
         let playbackMetrics = try await awaitPlaybackMetrics(
             for: handle.id,
             operation: handle.kind.rawValue,
             logRecorder: logRecorder,
         )
-        signpostInterval?.end()
 
         return BenchmarkRequest(
             requestID: handle.id,
@@ -612,6 +606,7 @@ enum BenchmarkHarness {
             generatedArtifactID: generatedArtifactID(from: success),
             lifecycle: lifecycleMetrics,
             generation: generationMetrics,
+            resources: resourceMetrics,
             playback: playbackMetrics,
         )
     }
@@ -621,13 +616,9 @@ enum BenchmarkHarness {
         timestampedStem: String,
         latestFilename: String,
         generatedAt: Date,
-        subdirectory: String? = nil,
     ) throws -> URL {
-        var benchmarksRoot = try packageRootURL()
+        let benchmarksRoot = try packageRootURL()
             .appendingPathComponent(".local/benchmarks", isDirectory: true)
-        if let subdirectory, !subdirectory.isEmpty {
-            benchmarksRoot = benchmarksRoot.appendingPathComponent(subdirectory, isDirectory: true)
-        }
         try FileManager.default.createDirectory(at: benchmarksRoot, withIntermediateDirectories: true)
 
         let formatter = ISO8601DateFormatter()
@@ -686,10 +677,11 @@ enum BenchmarkHarness {
         from events: AsyncThrowingStream<SpeakSwiftly.RequestEvent, any Swift.Error>,
         submittedAt: ContinuousClock.Instant,
         clock: ContinuousClock,
-        signposts: BenchmarkSignpostRecorder?,
-        signpostID: OSSignpostID?,
-    ) async throws -> (BenchmarkRequestLifecycleMetrics, SpeakSwiftly.RequestCompletion) {
+        signposts: BenchmarkSignpostRecorder,
+        signpostID: OSSignpostID,
+    ) async throws -> (BenchmarkRequestLifecycleMetrics, SpeakSwiftly.RequestCompletion, [BenchmarkResourceSnapshot]) {
         var metrics = BenchmarkRequestLifecycleMetrics()
+        var resourceSnapshots = [BenchmarkResourceSnapshot]()
 
         for try await event in events {
             let elapsedMS = milliseconds(since: submittedAt, clock: clock)
@@ -699,30 +691,38 @@ enum BenchmarkHarness {
                     metrics.queuedAtMS = metrics.queuedAtMS ?? elapsedMS
                     metrics.queueReason = queued.reason.rawValue
                     metrics.queuePosition = queued.queuePosition
-                    if let signpostID { signposts?.emitQueued(id: signpostID) }
+                    signposts.emitQueued(id: signpostID)
+                    resourceSnapshots.append(resourceSnapshot(label: "queued", submittedAt: submittedAt, clock: clock))
                 case .acknowledged:
                     metrics.acknowledgedAtMS = metrics.acknowledgedAtMS ?? elapsedMS
-                    if let signpostID { signposts?.emitAcknowledged(id: signpostID) }
+                    signposts.emitAcknowledged(id: signpostID)
+                    resourceSnapshots.append(resourceSnapshot(label: "acknowledged", submittedAt: submittedAt, clock: clock))
                 case .started:
                     metrics.startedAtMS = metrics.startedAtMS ?? elapsedMS
-                    if let signpostID { signposts?.emitStarted(id: signpostID) }
+                    signposts.emitStarted(id: signpostID)
+                    resourceSnapshots.append(resourceSnapshot(label: "started", submittedAt: submittedAt, clock: clock))
                 case let .progress(progress):
                     switch progress.stage {
                         case .bufferingAudio:
                             metrics.bufferingAudioAtMS = metrics.bufferingAudioAtMS ?? elapsedMS
+                            signposts.emitBufferingAudio(id: signpostID)
+                            resourceSnapshots.append(resourceSnapshot(label: "buffering_audio", submittedAt: submittedAt, clock: clock))
                         case .prerollReady:
                             metrics.prerollReadyAtMS = metrics.prerollReadyAtMS ?? elapsedMS
-                            if let signpostID { signposts?.emitPrerollReady(id: signpostID) }
+                            signposts.emitPrerollReady(id: signpostID)
+                            resourceSnapshots.append(resourceSnapshot(label: "preroll_ready", submittedAt: submittedAt, clock: clock))
                         case .playbackFinished:
                             metrics.playbackFinishedAtMS = metrics.playbackFinishedAtMS ?? elapsedMS
-                            if let signpostID { signposts?.emitPlaybackFinished(id: signpostID) }
+                            signposts.emitPlaybackFinished(id: signpostID)
+                            resourceSnapshots.append(resourceSnapshot(label: "playback_finished", submittedAt: submittedAt, clock: clock))
                         default:
                             continue
                     }
                 case let .completed(completion):
                     metrics.completedAtMS = metrics.completedAtMS ?? elapsedMS
-                    if let signpostID { signposts?.emitCompleted(id: signpostID) }
-                    return (metrics, completion)
+                    signposts.emitCompleted(id: signpostID)
+                    resourceSnapshots.append(resourceSnapshot(label: "completed", submittedAt: submittedAt, clock: clock))
+                    return (metrics, completion, resourceSnapshots)
             }
         }
 
@@ -733,20 +733,22 @@ enum BenchmarkHarness {
         from events: AsyncThrowingStream<SpeakSwiftly.SynthesisUpdate, any Swift.Error>,
         submittedAt: ContinuousClock.Instant,
         clock: ContinuousClock,
-        signposts: BenchmarkSignpostRecorder?,
-        signpostID: OSSignpostID?,
-    ) async throws -> BenchmarkRequestGenerationMetrics {
+        signposts: BenchmarkSignpostRecorder,
+        signpostID: OSSignpostID,
+    ) async throws -> (BenchmarkRequestGenerationMetrics, [BenchmarkResourceSnapshot]) {
         var metrics = BenchmarkRequestGenerationMetrics()
+        var resourceSnapshots = [BenchmarkResourceSnapshot]()
 
         for try await update in events {
             let elapsedMS = milliseconds(since: submittedAt, clock: clock)
 
             switch update.event {
                 case .token:
-                    if metrics.firstTokenAtMS == nil, let signpostID {
-                        signposts?.emitFirstToken(id: signpostID)
+                    if metrics.firstTokenAtMS == nil {
+                        metrics.firstTokenAtMS = elapsedMS
+                        signposts.emitFirstToken(id: signpostID)
+                        resourceSnapshots.append(resourceSnapshot(label: "first_token", submittedAt: submittedAt, clock: clock))
                     }
-                    metrics.firstTokenAtMS = metrics.firstTokenAtMS ?? elapsedMS
                     metrics.observedTokenCount += 1
                 case let .info(info):
                     metrics.infoAtMS = metrics.infoAtMS ?? elapsedMS
@@ -756,17 +758,48 @@ enum BenchmarkHarness {
                     metrics.generateTimeMS = info.generateTime * 1000
                     metrics.tokensPerSecond = info.tokensPerSecond
                     metrics.peakMemoryUsageGB = info.peakMemoryUsage
+                    signposts.emitGenerationInfo(id: signpostID)
+                    resourceSnapshots.append(resourceSnapshot(label: "generation_info", submittedAt: submittedAt, clock: clock))
                 case let .audioChunk(sampleCount):
-                    if metrics.firstAudioChunkAtMS == nil, let signpostID {
-                        signposts?.emitFirstAudioChunk(id: signpostID)
+                    if metrics.firstAudioChunkAtMS == nil {
+                        metrics.firstAudioChunkAtMS = elapsedMS
+                        signposts.emitFirstAudioChunk(id: signpostID)
+                        resourceSnapshots.append(resourceSnapshot(label: "first_audio_chunk", submittedAt: submittedAt, clock: clock))
                     }
-                    metrics.firstAudioChunkAtMS = metrics.firstAudioChunkAtMS ?? elapsedMS
                     metrics.audioChunkCount += 1
                     metrics.totalAudioSampleCount += sampleCount
             }
         }
 
-        return metrics
+        return (metrics, resourceSnapshots)
+    }
+
+    private static func resourceSnapshot(
+        label: String,
+        submittedAt: ContinuousClock.Instant,
+        clock: ContinuousClock,
+    ) -> BenchmarkResourceSnapshot {
+        let mlxSnapshot = Memory.snapshot()
+        var usage = rusage_info_current()
+        let usageResult = withUnsafeMutablePointer(to: &usage) { pointer in
+            pointer.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { rebound in
+                proc_pid_rusage(getpid(), RUSAGE_INFO_CURRENT, rebound)
+            }
+        }
+
+        return BenchmarkResourceSnapshot(
+            label: label,
+            elapsedMS: milliseconds(since: submittedAt, clock: clock),
+            processResidentBytes: usageResult == 0 ? Int(usage.ri_resident_size) : nil,
+            processPhysFootprintBytes: usageResult == 0 ? Int(usage.ri_phys_footprint) : nil,
+            processUserCPUTimeNS: usageResult == 0 ? Int(usage.ri_user_time) : nil,
+            processSystemCPUTimeNS: usageResult == 0 ? Int(usage.ri_system_time) : nil,
+            mlxActiveMemoryBytes: mlxSnapshot.activeMemory,
+            mlxCacheMemoryBytes: mlxSnapshot.cacheMemory,
+            mlxPeakMemoryBytes: mlxSnapshot.peakMemory,
+            mlxCacheLimitBytes: Memory.cacheLimit,
+            mlxMemoryLimitBytes: Memory.memoryLimit,
+        )
     }
 
     private static func awaitPlaybackMetrics(

--- a/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift
@@ -202,6 +202,13 @@ struct BenchmarkResourceSnapshot: Codable {
     }
 }
 
+struct BenchmarkWarningSummary: Codable {
+    let warningCount: Int
+    let playbackWarningCount: Int
+    let generationQualityWarningCount: Int
+    let reasons: [String: Int]
+}
+
 struct BenchmarkRequestResourceMetrics: Codable {
     let snapshots: [BenchmarkResourceSnapshot]
     let processCPUTimeDeltaMS: Double?
@@ -353,6 +360,32 @@ final class BenchmarkLogRecorder: @unchecked Sendable {
         }
     }
 
+    private static func int(_ value: Any?) -> Int? {
+        switch value {
+            case let int as Int:
+                int
+            case let double as Double:
+                Int(double)
+            case let number as NSNumber:
+                number.intValue
+            default:
+                nil
+        }
+    }
+
+    private static func max(_ lhs: Int?, _ rhs: Int?) -> Int? {
+        switch (lhs, rhs) {
+            case let (lhs?, rhs?):
+                Swift.max(lhs, rhs)
+            case let (lhs?, nil):
+                lhs
+            case let (nil, rhs?):
+                rhs
+            case (nil, nil):
+                nil
+        }
+    }
+
     func appendStderr(_ message: String) {
         let lines = message
             .split(separator: "\n", omittingEmptySubsequences: true)
@@ -412,6 +445,84 @@ final class BenchmarkLogRecorder: @unchecked Sendable {
             )
         }
     }
+
+    func warningSummary(for requestID: String) -> BenchmarkWarningSummary {
+        warningSummary(for: [requestID])
+    }
+
+    func warningSummary(for requestIDs: [String]) -> BenchmarkWarningSummary {
+        let requestIDSet = Set(requestIDs)
+        return lock.withLock {
+            var reasons = [String: Int]()
+            var warningCount = 0
+            var playbackWarningCount = 0
+            var generationQualityWarningCount = 0
+
+            for object in stderrObjects where requestIDSet.contains(object["request_id"] as? String ?? "") {
+                guard object["level"] as? String == "warning" else { continue }
+
+                warningCount += 1
+                let event = object["event"] as? String ?? "unknown"
+                if event.hasPrefix("playback_") {
+                    playbackWarningCount += 1
+                }
+                if event == "playback_generation_quality_warning" {
+                    generationQualityWarningCount += 1
+                }
+
+                let details = object["details"] as? [String: Any]
+                let reason = details?["reason"] as? String ?? event
+                reasons[reason, default: 0] += 1
+            }
+
+            return BenchmarkWarningSummary(
+                warningCount: warningCount,
+                playbackWarningCount: playbackWarningCount,
+                generationQualityWarningCount: generationQualityWarningCount,
+                reasons: reasons,
+            )
+        }
+    }
+
+    func peakResourceSnapshot() -> BenchmarkResourceSnapshot {
+        lock.withLock {
+            var processResidentBytes: Int?
+            var processPhysFootprintBytes: Int?
+            var processCPUTimeNS: Int?
+            var mlxActiveMemoryBytes: Int?
+            var mlxCacheMemoryBytes: Int?
+            var mlxPeakMemoryBytes: Int?
+
+            for object in stderrObjects {
+                guard let details = object["details"] as? [String: Any] else { continue }
+
+                processResidentBytes = Self.max(processResidentBytes, Self.int(details["process_resident_bytes"]))
+                processPhysFootprintBytes = Self.max(processPhysFootprintBytes, Self.int(details["process_phys_footprint_bytes"]))
+                let userCPUTimeNS = Self.int(details["process_user_cpu_time_ns"]) ?? 0
+                let systemCPUTimeNS = Self.int(details["process_system_cpu_time_ns"]) ?? 0
+                if userCPUTimeNS > 0 || systemCPUTimeNS > 0 {
+                    processCPUTimeNS = Self.max(processCPUTimeNS, userCPUTimeNS + systemCPUTimeNS)
+                }
+                mlxActiveMemoryBytes = Self.max(mlxActiveMemoryBytes, Self.int(details["mlx_active_memory_bytes"]))
+                mlxCacheMemoryBytes = Self.max(mlxCacheMemoryBytes, Self.int(details["mlx_cache_memory_bytes"]))
+                mlxPeakMemoryBytes = Self.max(mlxPeakMemoryBytes, Self.int(details["mlx_peak_memory_bytes"]))
+            }
+
+            return BenchmarkResourceSnapshot(
+                label: "peak",
+                elapsedMS: 0,
+                processResidentBytes: processResidentBytes,
+                processPhysFootprintBytes: processPhysFootprintBytes,
+                processUserCPUTimeNS: nil,
+                processSystemCPUTimeNS: processCPUTimeNS,
+                mlxActiveMemoryBytes: mlxActiveMemoryBytes,
+                mlxCacheMemoryBytes: mlxCacheMemoryBytes,
+                mlxPeakMemoryBytes: mlxPeakMemoryBytes,
+                mlxCacheLimitBytes: nil,
+                mlxMemoryLimitBytes: nil,
+            )
+        }
+    }
 }
 
 enum BenchmarkHarness {
@@ -423,7 +534,6 @@ enum BenchmarkHarness {
         profileRootURL: URL,
         backend: SpeakSwiftly.SpeechBackend,
         qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
-        marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy = .dualResidentSerialized,
         playbackMode: BenchmarkPlaybackMode = .silent,
         playbackTrace: Bool = false,
         operation: @escaping @Sendable (BenchmarkRuntimeSession) async throws -> T,
@@ -432,7 +542,6 @@ enum BenchmarkHarness {
             profileRootURL: profileRootURL,
             backend: backend,
             qwenConditioningStrategy: qwenConditioningStrategy,
-            marvisResidentPolicy: marvisResidentPolicy,
             playbackMode: playbackMode,
             playbackTrace: playbackTrace,
         )
@@ -451,7 +560,6 @@ enum BenchmarkHarness {
         profileRootURL: URL,
         backend: SpeakSwiftly.SpeechBackend,
         qwenConditioningStrategy: SpeakSwiftly.QwenConditioningStrategy,
-        marvisResidentPolicy: SpeakSwiftly.MarvisResidentPolicy,
         playbackMode: BenchmarkPlaybackMode,
         playbackTrace: Bool,
     ) async throws -> BenchmarkRuntimeSession {
@@ -484,6 +592,7 @@ enum BenchmarkHarness {
                 logRecorder.appendStderr(message)
                 fputs("SpeakSwiftly benchmark runtime stderr: \(message)\n", stderr)
             },
+            writeSystemLog: liveDependencies.writeSystemLog,
             now: liveDependencies.now,
             readRuntimeMemory: liveDependencies.readRuntimeMemory,
         )
@@ -512,7 +621,6 @@ enum BenchmarkHarness {
             dependencies: dependencies,
             speechBackend: backend,
             qwenConditioningStrategy: qwenConditioningStrategy,
-            marvisResidentPolicy: marvisResidentPolicy,
             profileStore: profileStore,
             generatedFileStore: generatedFileStore,
             generationJobStore: generationJobStore,
@@ -551,6 +659,18 @@ enum BenchmarkHarness {
         }
 
         throw BenchmarkError("SpeakSwiftly benchmark runtime stopped emitting status updates before reporting resident_model_ready.")
+    }
+
+    static func awaitResidentReady(
+        on runtime: SpeakSwiftly.Runtime,
+    ) async throws -> Double {
+        try await awaitResidentReady(
+            on: runtime,
+            signposts: BenchmarkSignpostRecorder(
+                backend: .qwen3_smol,
+                playbackMode: effectivePlaybackMode(),
+            ),
+        )
     }
 
     static func awaitSuccess(
@@ -611,14 +731,30 @@ enum BenchmarkHarness {
         )
     }
 
+    static func runRequestBenchmark(
+        handle: SpeakSwiftly.RequestHandle,
+        logRecorder: BenchmarkLogRecorder? = nil,
+        signposts: BenchmarkSignpostRecorder,
+    ) async throws -> BenchmarkRequest {
+        try await runRequestBenchmark(
+            handle: handle,
+            signposts: signposts,
+            logRecorder: logRecorder,
+        )
+    }
+
     static func writeSummary(
         _ summary: some Encodable,
         timestampedStem: String,
         latestFilename: String,
         generatedAt: Date,
+        subdirectory: String? = nil,
     ) throws -> URL {
-        let benchmarksRoot = try packageRootURL()
+        var benchmarksRoot = try packageRootURL()
             .appendingPathComponent(".local/benchmarks", isDirectory: true)
+        if let subdirectory {
+            benchmarksRoot = benchmarksRoot.appendingPathComponent(subdirectory, isDirectory: true)
+        }
         try FileManager.default.createDirectory(at: benchmarksRoot, withIntermediateDirectories: true)
 
         let formatter = ISO8601DateFormatter()

--- a/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift
@@ -75,7 +75,10 @@ private extension QwenBenchmarkE2ETests {
             backend: .qwen3_smol,
             qwenConditioningStrategy: .preparedConditioning,
         ) { session in
-            _ = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
+            _ = try await BenchmarkHarness.awaitResidentReady(
+                on: session.runtime,
+                signposts: session.signposts,
+            )
 
             let handle = await session.runtime.voices.create(
                 design: benchmarkProfileName,
@@ -98,12 +101,19 @@ private extension QwenBenchmarkE2ETests {
             qwenConditioningStrategy: strategy,
             playbackMode: BenchmarkHarness.effectivePlaybackMode(),
         ) { session in
-            let preloadMS = try await BenchmarkHarness.awaitResidentReady(on: session.runtime)
+            let sampleSignpost = session.signposts.beginSample()
+            defer { sampleSignpost.end() }
+
+            let preloadMS = try await BenchmarkHarness.awaitResidentReady(
+                on: session.runtime,
+                signposts: session.signposts,
+            )
             let generatedFile = try await BenchmarkHarness.runRequestBenchmark(
                 handle: session.runtime.generate.audio(
                     text: E2EHarness.testingPlaybackText,
                     voiceProfile: benchmarkProfileName,
                 ),
+                signposts: session.signposts,
                 logRecorder: session.logRecorder,
             )
             let liveSpeech = try await BenchmarkHarness.runRequestBenchmark(
@@ -111,6 +121,7 @@ private extension QwenBenchmarkE2ETests {
                     text: E2EHarness.testingPlaybackText,
                     voiceProfile: benchmarkProfileName,
                 ),
+                signposts: session.signposts,
                 logRecorder: session.logRecorder,
             )
 

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
@@ -1,6 +1,5 @@
 #if os(macOS)
 import Foundation
-@testable import SpeakSwiftly
 
 func speakSwiftlyE2ETestsEnabled() -> Bool {
     ProcessInfo.processInfo.environment["SPEAKSWIFTLY_E2E"] == "1"
@@ -19,11 +18,9 @@ func speakSwiftlyDeepTraceE2ETestsEnabled() -> Bool {
 }
 
 func speakSwiftlyQwenBenchmarkE2ETestsEnabled() -> Bool {
-    ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_BENCHMARK_E2E"] == "1"
-}
-
-func speakSwiftlyQwenQuantBenchmarkE2ETestsEnabled() -> Bool {
-    ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_E2E"] == "1"
+    let environment = ProcessInfo.processInfo.environment
+    return environment["SPEAKSWIFTLY_QWEN_BENCHMARK_E2E"] == "1"
+        || environment["SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E"] == "1"
 }
 
 func speakSwiftlyQwenLongFormE2ETestsEnabled() -> Bool {
@@ -36,44 +33,34 @@ func speakSwiftlyQwenBackendE2ETestsEnabled() -> Bool {
 
 func speakSwiftlyQwenBenchmarkIterations() -> Int {
     let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS"] ?? ""
+    if let parsed = Int(rawValue) {
+        return max(1, parsed)
+    }
+
+    return speakSwiftlyBackendBenchmarkIterations()
+}
+
+func speakSwiftlyBackendBenchmarkE2ETestsEnabled() -> Bool {
+    speakSwiftlyBackendBenchmarkComparisonEnabled()
+        || speakSwiftlyQwenQuantizationBenchmarkE2ETestsEnabled()
+}
+
+func speakSwiftlyBackendBenchmarkComparisonEnabled() -> Bool {
+    ProcessInfo.processInfo.environment["SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E"] == "1"
+}
+
+func speakSwiftlyQwenQuantizationBenchmarkE2ETestsEnabled() -> Bool {
+    ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANTIZATION_BENCHMARK_E2E"] == "1"
+}
+
+func speakSwiftlyBackendBenchmarkIterations() -> Int {
+    let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS"] ?? ""
     return max(1, Int(rawValue) ?? 1)
 }
 
-func speakSwiftlyQwenQuantBenchmarkBackends() -> [SpeakSwiftly.SpeechBackend] {
-    let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_BACKENDS"] ?? ""
-    let requestedBackends = rawValue
-        .split(separator: ",")
-        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
-
-    guard !requestedBackends.isEmpty else {
-        return SpeakSwiftly.SpeechBackend.qwenFamilyBackends
-    }
-
-    var backends = [SpeakSwiftly.SpeechBackend]()
-    var invalidBackends = [String]()
-    for requestedBackend in requestedBackends {
-        if let backend = SpeakSwiftly.SpeechBackend.normalized(rawValue: requestedBackend) {
-            backends.append(backend)
-        } else {
-            invalidBackends.append(requestedBackend)
-        }
-    }
-
-    precondition(
-        invalidBackends.isEmpty,
-        """
-        SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_BACKENDS contains unsupported backend value(s): \(invalidBackends.joined(separator: ", ")). \
-        Use one or more SpeechBackend.qwenFamilyBackends raw values separated by commas.
-        """,
-    )
-    return backends
+func speakSwiftlyBackendBenchmarkAudibleEnabled() -> Bool {
+    let environment = ProcessInfo.processInfo.environment
+    return environment["SPEAKSWIFTLY_BACKEND_BENCHMARK_AUDIBLE"] == "1"
+        || environment["SPEAKSWIFTLY_AUDIBLE_E2E"] == "1"
 }
-
-func speakSwiftlyQwenQuantBenchmarkDeviceLabel() -> String? {
-    let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_DEVICE_LABEL"] ?? ""
-    let label = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-    return label.isEmpty ? nil : label
-}
-
 #endif

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import Foundation
+@testable import SpeakSwiftly
 
 func speakSwiftlyE2ETestsEnabled() -> Bool {
     ProcessInfo.processInfo.environment["SPEAKSWIFTLY_E2E"] == "1"
@@ -51,6 +52,48 @@ func speakSwiftlyBackendBenchmarkComparisonEnabled() -> Bool {
 
 func speakSwiftlyQwenQuantizationBenchmarkE2ETestsEnabled() -> Bool {
     ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANTIZATION_BENCHMARK_E2E"] == "1"
+}
+
+func speakSwiftlyQwenQuantBenchmarkE2ETestsEnabled() -> Bool {
+    speakSwiftlyQwenQuantizationBenchmarkE2ETestsEnabled()
+        || ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_E2E"] == "1"
+}
+
+func speakSwiftlyQwenQuantBenchmarkBackends() -> [SpeakSwiftly.SpeechBackend] {
+    let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_BACKENDS"] ?? ""
+    let requestedBackends = rawValue
+        .split(separator: ",")
+        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+
+    guard !requestedBackends.isEmpty else {
+        return SpeakSwiftly.SpeechBackend.qwenFamilyBackends
+    }
+
+    var backends = [SpeakSwiftly.SpeechBackend]()
+    var invalidBackends = [String]()
+    for requestedBackend in requestedBackends {
+        if let backend = SpeakSwiftly.SpeechBackend.normalized(rawValue: requestedBackend) {
+            backends.append(backend)
+        } else {
+            invalidBackends.append(requestedBackend)
+        }
+    }
+
+    precondition(
+        invalidBackends.isEmpty,
+        """
+        SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_BACKENDS contains unsupported backend value(s): \(invalidBackends.joined(separator: ", ")). \
+        Use one or more SpeechBackend.qwenFamilyBackends raw values separated by commas.
+        """,
+    )
+    return backends
+}
+
+func speakSwiftlyQwenQuantBenchmarkDeviceLabel() -> String? {
+    let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_DEVICE_LABEL"] ?? ""
+    let label = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    return label.isEmpty ? nil : label
 }
 
 func speakSwiftlyBackendBenchmarkIterations() -> Int {

--- a/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
+++ b/docs/maintainers/backend-benchmarking-plan-2026-04-20.md
@@ -1,0 +1,523 @@
+# Backend Benchmarking Plan
+
+## Status
+
+This note started as a design plan for a repo-native benchmark suite. Parts of
+that plan are now implemented, but the longer-term GPU profiling and deeper
+playback-analysis story still remains incomplete.
+
+What exists already:
+
+- one shared benchmark harness under
+  `Tests/SpeakSwiftlyTests/E2E/Benchmarks/BenchmarkSupport.swift`
+- one opt-in backend-wide benchmark suite under
+  `Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift`
+- one opt-in Qwen resident benchmark suite under
+  `Tests/SpeakSwiftlyTests/E2E/Qwen/QwenBenchmarkE2ETests.swift`
+- per-request generation event metrics such as prefill time, generation time,
+  tokens per second, and model-reported peak memory
+- runtime memory snapshots for process CPU time, process memory footprint, and
+  MLX memory usage
+- per-request benchmark resource snapshots at named request milestones, with
+  aggregate process CPU-time delta and peak process/MLX memory fields
+- a narrow Qwen 0.6B quantization lane comparing `qwen3_smol_6bit` against
+  `qwen3_smol_8bit`
+- Instruments signpost anchors for benchmark samples, resident preload, request
+  duration, request lifecycle milestones, and generation milestones
+- playback summary and playback trace surfaces that already report queue-depth,
+  rebuffer, starvation, and scheduling behavior
+- one repo-maintenance benchmark wrapper under
+  `scripts/repo-maintenance/run-benchmark.sh`
+- one repo-maintenance Instruments capture wrapper under
+  `scripts/repo-maintenance/run-benchmark-trace.sh`
+
+What does not exist yet:
+
+- one deeper retained playback-analysis report beyond the current per-request
+  playback summary aggregates
+- one broader benchmark history or comparison tool that diff-checks retained
+  JSON summaries across runs
+
+## Why This Exists
+
+The package already has several useful performance surfaces, but they are still
+split across different seams:
+
+- Qwen has a dedicated benchmark suite
+- playback quality shows up in playback summaries and trace events
+- runtime resource usage shows up in runtime memory snapshots
+- backend-generation timing shows up in generation event info
+
+That is enough to support real benchmarking work. The missing piece is one
+maintainer-owned benchmark model that asks every backend to do the same job and
+stores the results in one comparable shape.
+
+The immediate goal is not abstract benchmarking infrastructure for its own
+future sake. The immediate goal is simpler:
+
+- run the same standard speech-generation workload on `qwen3`,
+  `chatterbox_turbo`, and `marvis`
+- capture speed, throughput, memory pressure, CPU load, and playback stability
+- see what changes between backends and between queued job positions
+- keep the results durable enough that later optimization work is based on
+  evidence instead of recollection
+
+## The Standard Scenario
+
+The benchmark suite should standardize around one package-owned scenario:
+
+- one resident runtime per benchmark sample
+- one selected backend
+- one stored benchmark voice profile
+- two live speech requests submitted back-to-back
+- each request contains two paragraphs of fixed benchmark text
+- the second request should be accepted while the first request is still active
+  so the queue path is exercised on purpose
+
+This is the core scenario because it exercises the part of the package that is
+most likely to feel slow or unstable to a real caller:
+
+- resident model warmup
+- first live playback startup
+- queue admission and waiting behavior
+- overlap between generation and playback
+- contention effects on the second request
+
+The benchmark text should stay checked in and stable. Do not let ad hoc local
+paragraphs drift between runs.
+
+Recommended benchmark fixture shape:
+
+- paragraph 1: normal prose with ordinary sentence structure
+- paragraph 2: slightly denser prose with longer clauses and punctuation
+
+That gives us something closer to real operator usage than a single short
+sentence while avoiding a bizarre stress-only corpus that no one would actually
+send to the package.
+
+## Recommended Benchmark Lanes
+
+The benchmark suite should be split into three lanes with different goals.
+
+### Lane 1: Canonical Backend Comparison
+
+This should become the default backend-comparison lane.
+
+Shape:
+
+- real models
+- real resident runtime
+- silent playback driver
+- the standard two-job live scenario
+- multiple iterations
+
+Why it exists:
+
+- it keeps backend-to-backend comparisons relatively stable
+- it avoids host speaker routing and output-device quirks dominating the numbers
+- it still exercises live generation, preroll, queueing, and drain behavior
+
+This lane should be the source of truth for:
+
+- timing regressions
+- throughput changes
+- process and MLX memory changes
+- queue and playback stability changes
+
+### Lane 2: Audible Stress Lane
+
+This should run the same standard scenario, but through real audible playback.
+
+Shape:
+
+- real models
+- real resident runtime
+- audible playback enabled
+- the standard two-job live scenario
+- fewer iterations than the canonical lane
+
+Why it exists:
+
+- it answers the real-world question "does this sound stable on the machine"
+- it catches rebuffering, underruns, and device-specific playback pain that a
+  silent driver can hide
+- it gives maintainers a deliberate path for "is the package usable right now"
+  verification without confusing those runs with the cleaner backend-comparison
+  numbers
+
+Do not treat this lane as the primary regression baseline unless the package
+later grows a more controlled audio-device test environment. It is important,
+but it is noisier.
+
+### Lane 3: Instruments and GPU Profiling Lane
+
+This lane should stay separate from the ordinary benchmark suite.
+
+Shape:
+
+- one targeted scenario at a time
+- Xcode-backed or Instruments-driven profiling session
+- signposts and trace alignment when deeper diagnosis is needed
+
+Why it exists:
+
+- immediate package-side benchmark runs can tell us that one backend got slower
+  or more memory-hungry
+- they cannot fully answer where Apple-silicon GPU time went in a clean,
+  per-test, package-native way
+
+Use this lane when a canonical benchmark already proved that a regression
+exists and we need to inspect CPU hot spots, Metal scheduling pressure, or
+unified-memory pressure in more depth.
+
+## Why XCTest Performance Metrics Are Not The Primary Plan
+
+Apple's XCTest performance APIs can directly measure:
+
+- elapsed wall time
+- CPU activity
+- memory deltas
+- signposted regions
+
+That is useful, but it is not the best primary fit here.
+
+This package is already structured around worker-backed e2e flows, async event
+streams, runtime-owned playback, and retained JSON benchmark output. A plain
+`measure { ... }` block would not capture the package's real request lifecycle
+as cleanly as the existing event-driven harness can.
+
+More importantly, the GPU story is different:
+
+- MetricKit exposes GPU metrics, including cumulative GPU time
+- MetricKit reports are app-delivered and aggregate over time
+- that makes MetricKit a poor primary source for one immediate package test run
+
+So the practical design should be:
+
+- package-native benchmark harness first
+- XCTest performance metrics only if we later want one smaller host-process
+  microbenchmark around a narrow operation
+- Instruments or app-hosted profiling as the GPU-deep-dive lane
+
+## Metrics To Capture
+
+The benchmark result model should separate:
+
+- suite-level settings
+- per-sample host details
+- per-request lifecycle metrics
+- per-request generation metrics
+- per-request resource metrics
+- per-request playback metrics
+- backend-level aggregate summaries
+
+### Required Metrics
+
+These should be present for every backend benchmark sample.
+
+Timing:
+
+- resident preload time
+- queue admission time
+- queue wait time
+- time to acknowledged
+- time to started
+- time to first token
+- time to first audio chunk
+- time to buffering
+- time to preroll ready
+- time to playback finished
+- total completion time
+
+Generation:
+
+- observed token count
+- prompt token count when available
+- generation token count when available
+- prefill time when available
+- generation time when available
+- tokens per second when available
+
+Runtime resource usage:
+
+- process resident bytes before and after request
+- process physical footprint bytes before and after request
+- process user CPU time before and after request
+- process system CPU time before and after request
+- MLX active memory before and after request
+- MLX cache memory before and after request
+- MLX peak memory after request
+
+Playback stability:
+
+- startup buffered audio
+- time to first chunk
+- time to preroll ready
+- min queued audio
+- max queued audio
+- average queued audio
+- queue depth sample count
+- rebuffer event count
+- total rebuffer duration
+- longest rebuffer duration
+- starvation event count
+- max and average inter-chunk gap
+- max and average schedule gap
+
+### Optional Metrics
+
+These should be recorded when the backend or lane can support them cleanly.
+
+- generated artifact ID for retained file outputs
+- model-native peak memory usage from generation info
+- host audio-device metadata for audible runs
+- signpost-linked region durations for Instruments-oriented captures
+
+Optional metrics should be explicit `null` values in JSON, not silently missing
+fields, so later comparison code can tell the difference between "not provided"
+and "forgotten in this schema version."
+
+## How To Treat The Second Job
+
+The second request is not just another sample. It is the most important part of
+the scenario.
+
+For each benchmark sample, store metrics for:
+
+- job 1
+- job 2
+- sample-level aggregate comparisons
+
+The suite should call out at least these derived values:
+
+- job 2 queue wait minus job 1 queue wait
+- job 2 first-audio latency minus job 1 first-audio latency
+- job 2 completion time minus job 1 completion time
+- job 2 rebuffer count minus job 1 rebuffer count
+
+That makes the queued-request tax obvious instead of forcing maintainers to
+infer it from two large JSON blobs.
+
+## Expected Backend Differences
+
+The benchmark suite should not force every backend into fake symmetry.
+
+`qwen3` can already surface richer generation info and should continue doing so.
+
+`chatterbox_turbo` and `marvis` may not currently produce the same info payload
+shape on every run. That is acceptable as long as:
+
+- the shared benchmark schema keeps the fields stable
+- optional metrics are recorded explicitly when unavailable
+- the suite still captures the common timing, process-resource, and playback
+  metrics for all backends
+
+The benchmark model should prefer honest partial comparison over flattening the
+backend differences into misleading generic numbers.
+
+## Result Storage
+
+The current Qwen benchmark already writes JSON summaries under `.local/benchmarks`.
+The generalized backend suite should keep that storage root and adopt a stable
+family naming pattern such as:
+
+- `backend-live-benchmark-<ISO8601>.json`
+- `backend-live-benchmark-latest.json`
+- `backend-live-audible-benchmark-<ISO8601>.json`
+- `backend-live-audible-benchmark-latest.json`
+
+The summary should record:
+
+- schema version
+- generation timestamp
+- host machine description
+- backend list
+- iteration count
+- playback mode
+- benchmark text fixture identity
+- profile identity
+- all sample results
+- aggregate reports per backend
+
+Keep the schema versioned so comparison tooling can evolve without corrupting
+older retained runs.
+
+## Near-Term Follow-Up
+
+Investigate the Qwen long-form volume-decay regression soon as a dedicated
+follow-up pass.
+
+- Re-run the retained-file `volume-probe` path after dependency updates, profile
+  rerolls, and any upstream `mlx-audio-swift` changes that could affect Qwen
+  decode behavior.
+- Use `compare-volume` only when its artifact proves matched analyzed spans, or
+  when `--matched-duration trim-to-shorter` was explicitly selected and the
+  shortened comparison span is acceptable for the question being asked.
+- Keep comparing saved profiles against fresh voice-design profiles so prompt
+  content and profile materialization changes can be separated from model-side
+  drift.
+- Record whether the decay is present in direct non-stream decode, streamed
+  retained-file generation, or both before attributing regressions to playback
+  shaping.
+
+## Suggested Test Layout
+
+The current Qwen benchmark suite proved the basic shape. The repository now has
+the generalized backend benchmark harness, and the next useful widening is
+Marvis-specific comparison work inside that shared harness instead of spinning
+up a second unrelated benchmark system.
+
+Recommended test layout:
+
+- `Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkE2ETests.swift`
+- `Tests/SpeakSwiftlyTests/E2E/Benchmarks/BackendBenchmarkSupport.swift`
+- `Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift`
+  extended with backend-benchmark environment gates
+
+Recommended policy flags:
+
+- `SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1`
+- `SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS=<n>`
+- `SPEAKSWIFTLY_BACKEND_BENCHMARK_AUDIBLE=1`
+
+Recommended suite tags:
+
+- `.e2e`
+- `.benchmark`
+- backend-specific tags when useful
+
+Keep the suite serialized. This repository already treats heavy worker-backed
+model tests as strictly one-at-a-time work.
+
+## Suggested Implementation Slices
+
+### Slice 1: Generalize The Existing Qwen Benchmark Harness
+
+Goal:
+
+- extract shared benchmark support from the current Qwen suite
+- preserve the current Qwen lane while moving common code into reusable support
+
+What to move into shared support:
+
+- benchmark runtime bootstrapping
+- request lifecycle collection
+- generation metric collection
+- benchmark summary writing
+- host and settings capture
+
+### Slice 2: Add A Shared Two-Job Live Scenario
+
+Goal:
+
+- replace the current one-request Qwen benchmark shape with the standard
+  two-queued-job scenario
+
+Important rule:
+
+- submit job 2 while job 1 is still active
+- do not wait for job 1 to finish first
+
+That is the only way the benchmark can honestly claim it measures queue
+behavior.
+
+### Slice 3: Add Playback Summary Capture Per Request
+
+Goal:
+
+- attach playback summary data to each benchmarked request
+
+This is the slice that makes the benchmark useful for "speed" and "did the user
+actually hear stable audio" at the same time.
+
+### Slice 4: Widen The Suite To All Backends
+
+Goal:
+
+- run the same scenario against `.qwen3`, `.chatterboxTurbo`, and `.marvis`
+
+Do not wait for every backend to surface identical model-native metrics before
+landing this slice. The comparison is still valuable with the shared timing,
+process-resource, and playback metrics.
+
+Status:
+
+- landed as `BackendBenchmarkE2ETests`
+
+### Slice 5: Add Marvis Resident-Policy Comparison Inside The Shared Harness
+
+Goal:
+
+- compare `dual_resident_serialized` against `single_resident_dynamic`
+- use one Marvis-specific three-request voice order that goes
+  `femme` -> `masc` -> `femme`
+- keep the result shape inside the same benchmark-summary and retention model
+
+Status:
+
+- landed as a Marvis-specific benchmark inside `BackendBenchmarkE2ETests`
+
+### Slice 5: Add The Audible Lane
+
+Goal:
+
+- add a deliberate audible variant of the same suite
+
+Keep this lane opt-in and lower-iteration.
+
+### Slice 6: Add Repo-Maintenance Commands
+
+Goal:
+
+- make the benchmark suite easy to discover and re-run
+
+Recommended shape:
+
+- one repo-maintenance wrapper for canonical backend comparison
+- one repo-maintenance wrapper or flag for audible backend comparison
+
+## GPU Strategy
+
+The benchmark suite should report what it can measure directly now, and it
+should be explicit about the GPU boundary.
+
+What the package can measure directly today:
+
+- MLX memory state
+- process CPU time
+- process memory footprint
+- end-to-end timing
+- playback stability
+- signpost-aligned benchmark intervals and milestone events for Instruments
+
+What the package should not pretend it already has:
+
+- clean immediate per-sample GPU time per request from a plain package test
+
+If we need deeper GPU visibility, the next honest step is:
+
+- reuse the benchmark signposts around resident preload, first token, first
+  audio chunk, preroll ready, and playback drain
+- run `scripts/repo-maintenance/run-benchmark-trace.sh` with one Instruments
+  template at a time
+- keep that workflow documented as a profiling lane, not as the ordinary
+  backend benchmark suite
+
+## Recommended Outcome
+
+The best immediate path is:
+
+1. generalize the current Qwen benchmark harness
+2. standardize on the two-queued-live-job scenario
+3. make the silent canonical lane the default backend-comparison source of truth
+4. add the audible lane as a second opt-in benchmark story
+5. keep GPU-deep-dive work in a separate profiling workflow
+
+That gives the package one benchmark system that matches the real runtime job
+it is doing for Gale:
+
+- speak two substantial requests
+- queue the second one behind the first
+- show how fast each backend starts speaking
+- show how hard each backend pushes the machine
+- show whether playback stays stable while it happens

--- a/docs/maintainers/validation-lanes.md
+++ b/docs/maintainers/validation-lanes.md
@@ -27,7 +27,7 @@ reason to jump straight to `xcodebuild`.
 
 ## Historical SwiftPM Snag
 
-The current `mlx-audio-swift` `0.100.0` fork release preserves the ordinary
+The current `mlx-audio-swift` `0.79.0` fork release preserves the ordinary
 SwiftPM lane for this repository. The notes below are retained because earlier
 pins could fail under plain SwiftPM with parser errors in `EnglishG2P.swift`,
 and we may need the same fallback again if a future toolchain regression
@@ -51,6 +51,7 @@ Use this fallback for:
 
 - release hardening
 - standalone-worker validation
+- Marvis overlap investigation
 - any validation pass blocked by the SwiftPM parser failure
 
 Build once:
@@ -80,20 +81,47 @@ For GitHub Actions, keep the manifest sanity check as:
 swift package dump-package
 ```
 
-GitHub Actions keeps the default Swift workflow intentionally light because
-ordinary changes run the thorough `swift build`, `swift test`, and
-repo-maintenance checks locally before commit. The remote Swift package smoke
-lane is:
+GitHub Actions currently keeps build-and-test coverage on the Xcode-backed
+package lane even though local ordinary package work starts with SwiftPM. The
+current macOS CI target set is:
+
+- `SpeakSwiftlyTests/WorkerRuntimePlaybackTests`
+- `SpeakSwiftlyTests/LibrarySurfaceTests`
+- `SpeakSwiftlyTests/ModelClientsTests`
+
+## iOS Compile-And-Smoke Lane
+
+The iOS lane is intentionally smaller than the macOS package lane. Its job is
+to prove that:
+
+- the package resolves for iOS
+- the shared library and playback-environment code compile for iOS Simulator
+- a small library-first smoke slice still runs under Simulator
+
+Build once:
 
 ```bash
-swift package dump-package
-swift build
+xcodebuild build-for-testing -quiet \
+  -scheme SpeakSwiftly-Package \
+  -destination 'platform=iOS Simulator,id=<simulator-udid>' \
+  -derivedDataPath .local/derived-data/ios-smoke \
+  -clonedSourcePackagesDirPath .local/source-packages
 ```
 
-The separate `validate` workflow remains the remote repo-maintenance check for
-formatting, linting, toolkit shape, and resource layout. Use the Xcode-backed
-fallback lane locally, in release hardening, or in manually triggered
-investigations when SwiftPM stops being the best signal.
+Then run the current smoke slice:
+
+```bash
+xcodebuild test-without-building -quiet \
+  -xctestrun "$(find .local/derived-data/ios-smoke/Build/Products -name '*.xctestrun' -maxdepth 1 | head -n 1)" \
+  -destination 'platform=iOS Simulator,id=<simulator-udid>' \
+  -only-testing:'SpeakSwiftlyTests/LibrarySurfaceTests' \
+  -only-testing:'SpeakSwiftlyTests/SupportResourcesTests' \
+  -only-testing:'SpeakSwiftlyTests/ProfileStoreTests'
+```
+
+Keep this lane library-first. The worker-driven e2e harness is macOS-only and
+should stay out of the iOS simulator smoke path unless we deliberately create an
+app-hosted iOS e2e story later.
 
 ## E2E and Real-Model Notes
 
@@ -179,19 +207,26 @@ xcodebuild test-without-building -quiet \
   -destination 'platform=macOS' \
   -only-testing:'SpeakSwiftlyTests/GeneratedFileE2ETests' \
   -only-testing:'SpeakSwiftlyTests/GeneratedBatchE2ETests' \
+  -only-testing:'SpeakSwiftlyTests/ChatterboxE2ETests' \
   -only-testing:'SpeakSwiftlyTests/QueueControlE2ETests' \
+  -only-testing:'SpeakSwiftlyTests/MarvisE2ETests' \
   -only-testing:'SpeakSwiftlyTests/QwenE2ETests'
 ```
 
 That lane excludes the opt-in `DeepTraceE2ETests` and `QwenBenchmarkE2ETests`
 families unless you deliberately inject their extra environment flags too.
 
-The package also has an opt-in Qwen benchmark suite behind:
+For the broader backend-comparison benchmark design that should eventually
+replace the Qwen-only benchmark as the main package benchmark lane, see:
+
+- [backend-benchmarking-plan-2026-04-20.md](backend-benchmarking-plan-2026-04-20.md)
+
+The package now also has an opt-in backend-wide benchmark suite behind:
 
 - `SPEAKSWIFTLY_E2E=1`
-- `SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1`
-- optional `SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS=<n>`
-- optional `SPEAKSWIFTLY_AUDIBLE_E2E=1`
+- `SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1`
+- optional `SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS=<n>`
+- optional `SPEAKSWIFTLY_BACKEND_BENCHMARK_AUDIBLE=1`
 
 Prefer the repo-maintenance wrapper instead of exporting those by hand:
 
@@ -199,21 +234,73 @@ Prefer the repo-maintenance wrapper instead of exporting those by hand:
 sh scripts/repo-maintenance/run-benchmark.sh
 sh scripts/repo-maintenance/run-benchmark.sh --audible --iterations 3
 sh scripts/repo-maintenance/run-benchmark.sh --qwen --iterations 5
+sh scripts/repo-maintenance/run-benchmark.sh --qwen-quantization --iterations 3
 ```
 
-For repeatable local Instruments captures, wrap one benchmark run with one
-template at a time:
+Use the Qwen quantization lane when the question is specifically about the
+0.6B 6-bit build versus the 0.6B 8-bit build. That lane writes
+`qwen-0-6b-quantization-benchmark-latest.json` under `.local/benchmarks` and
+keeps the workload to the same two queued live requests used by the backend
+benchmark suite.
+
+The benchmark harness also emits `OSSignposter` timeline markers under the
+`com.gaelic-ghost.SpeakSwiftly.benchmarks` subsystem. Use those markers when
+capturing the benchmark in Instruments. Categories follow
+`benchmark.<backend>.<playback-mode>`, such as
+`benchmark.qwen3_smol_6bit.silent`.
+
+Important signpost intervals:
+
+- `Benchmark Sample`
+- `Resident Preload`
+- `Benchmark Request`
+
+Important signpost events:
+
+- `Request Queued`
+- `Request Acknowledged`
+- `Request Started`
+- `First Token`
+- `Generation Info`
+- `First Audio Chunk`
+- `Buffering Audio`
+- `Preroll Ready`
+- `Playback Finished`
+- `Request Completed`
+
+For the Qwen 0.6B quantization deep dive, capture one Instruments template at a
+time. Start with Time Profiler for CPU hot spots, then Metal System Trace for
+GPU scheduling and unified-memory pressure, then Allocations or VM Tracker when
+memory growth is the question. Line the Instruments timeline up against the
+retained `.local/benchmarks` JSON by matching the same milestone names.
+
+Prefer the repo-maintenance wrapper for repeatable local trace captures:
 
 ```bash
-sh scripts/repo-maintenance/run-benchmark-trace.sh --backend qwen3_smol_8bit --iterations 1
-sh scripts/repo-maintenance/run-benchmark-trace.sh --metal-system-trace --backend qwen3_smol_8bit --iterations 1
-sh scripts/repo-maintenance/run-benchmark-trace.sh --allocations --backend qwen3_smol_8bit --iterations 1
-sh scripts/repo-maintenance/run-benchmark-trace.sh --template "VM Tracker" --backend qwen3_smol_8bit --iterations 1
+sh scripts/repo-maintenance/run-benchmark-trace.sh --iterations 1
+sh scripts/repo-maintenance/run-benchmark-trace.sh --metal-system-trace --iterations 1
+sh scripts/repo-maintenance/run-benchmark-trace.sh --allocations --iterations 1
+sh scripts/repo-maintenance/run-benchmark-trace.sh --template "VM Tracker" --iterations 1
 ```
 
-The trace wrapper stores `.trace` files under `.local/traces` and leaves
-benchmark JSON summaries under `.local/benchmarks`. Do not run more than one
-trace template at the same time.
+The trace wrapper stores `.trace` files under `.local/traces/qwen-quantization`
+and leaves benchmark JSON summaries under `.local/benchmarks`. Do not run more
+than one trace template at the same time.
+
+For the Marvis-specific resident-policy comparison lane, run the benchmark test
+directly so the filter stays narrow:
+
+```bash
+SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1 SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS=1 swift test --filter 'BackendBenchmarkE2ETests/compare marvis resident policies with three queued voice switches'
+```
+
+That lane compares `dual_resident_serialized` against
+`single_resident_dynamic` with a three-request voice order that goes
+`femme` -> `masc` -> `femme` again.
+
+For Marvis profiling, throughput investigation, and trace work, prefer the dedicated runbook:
+
+- [marvis-overlap-profiling-runbook-2026-04-16.md](marvis-overlap-profiling-runbook-2026-04-16.md)
 
 ## Practical Rules
 

--- a/scripts/repo-maintenance/run-benchmark-trace.sh
+++ b/scripts/repo-maintenance/run-benchmark-trace.sh
@@ -8,24 +8,18 @@ export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 load_env_file "$SELF_DIR/config/validation.env"
 ensure_git_repo
 
-benchmark_target="qwen-quant"
+benchmark_target="qwen-quantization"
 template="Time Profiler"
 audible="false"
 playback_trace="false"
 iterations=""
-qwen_quant_backends=""
-device_label=""
 time_limit=""
 output_root="$REPO_ROOT/.local/traces"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --qwen)
-      benchmark_target="qwen"
-      shift
-      ;;
-    --qwen-quant)
-      benchmark_target="qwen-quant"
+    --qwen-quantization)
+      benchmark_target="qwen-quantization"
       shift
       ;;
     --template)
@@ -62,21 +56,6 @@ while [ "$#" -gt 0 ]; do
       [ -n "$iterations" ] || die "Pass a benchmark iteration count after --iterations."
       shift 2
       ;;
-    --backend)
-      qwen_quant_backends="${2:-}"
-      [ -n "$qwen_quant_backends" ] || die "Pass a backend name after --backend."
-      shift 2
-      ;;
-    --backends)
-      qwen_quant_backends="${2:-}"
-      [ -n "$qwen_quant_backends" ] || die "Pass comma-separated backend names after --backends."
-      shift 2
-      ;;
-    --device-label)
-      device_label="${2:-}"
-      [ -n "$device_label" ] || die "Pass a non-empty device label after --device-label."
-      shift 2
-      ;;
     --time-limit)
       time_limit="${2:-}"
       [ -n "$time_limit" ] || die "Pass an xctrace time limit such as 5m after --time-limit."
@@ -90,20 +69,19 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
       cat <<'USAGE'
 Usage:
-  run-benchmark-trace.sh [--qwen|--qwen-quant] [--time-profiler|--metal-system-trace|--allocations|--vm-tracker]
-                         [--template <name>] [--iterations <count>] [--backend <backend>|--backends <names>]
-                         [--device-label <label>] [--audible] [--playback-trace]
+  run-benchmark-trace.sh [--qwen-quantization] [--time-profiler|--metal-system-trace|--allocations|--vm-tracker]
+                         [--template <name>] [--iterations <count>] [--audible] [--playback-trace]
                          [--time-limit <duration>] [--output-root <path>]
 
 Defaults:
-  --qwen-quant is the default benchmark target.
+  --qwen-quantization is the default benchmark target.
   --time-profiler is the default Instruments template.
 
 Examples:
-  sh scripts/repo-maintenance/run-benchmark-trace.sh --backend qwen3_smol_8bit --iterations 1
-  sh scripts/repo-maintenance/run-benchmark-trace.sh --metal-system-trace --backend qwen3_smol_8bit --iterations 1
-  sh scripts/repo-maintenance/run-benchmark-trace.sh --allocations --backend qwen3_smol_8bit --iterations 1
-  sh scripts/repo-maintenance/run-benchmark-trace.sh --template "VM Tracker" --backend qwen3_smol_8bit --iterations 1
+  sh scripts/repo-maintenance/run-benchmark-trace.sh --iterations 1
+  sh scripts/repo-maintenance/run-benchmark-trace.sh --metal-system-trace --iterations 1
+  sh scripts/repo-maintenance/run-benchmark-trace.sh --allocations --iterations 1
+  sh scripts/repo-maintenance/run-benchmark-trace.sh --template "VM Tracker" --iterations 1
 USAGE
       exit 0
       ;;
@@ -139,12 +117,6 @@ if [ "$playback_trace" = "true" ]; then
 fi
 if [ -n "$iterations" ]; then
   set -- "$@" --iterations "$iterations"
-fi
-if [ -n "$qwen_quant_backends" ]; then
-  set -- "$@" --backends "$qwen_quant_backends"
-fi
-if [ -n "$device_label" ]; then
-  set -- "$@" --device-label "$device_label"
 fi
 
 log "Recording SpeakSwiftly benchmark '$benchmark_target' with Instruments template '$template'."

--- a/scripts/repo-maintenance/run-benchmark.sh
+++ b/scripts/repo-maintenance/run-benchmark.sh
@@ -8,21 +8,23 @@ export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/lib"
 load_env_file "$SELF_DIR/config/validation.env"
 ensure_git_repo
 
-benchmark_target="qwen"
+benchmark_target="backend"
 audible="false"
 playback_trace="false"
 iterations=""
-qwen_quant_backends=""
-device_label=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    --backend)
+      benchmark_target="backend"
+      shift
+      ;;
     --qwen)
       benchmark_target="qwen"
       shift
       ;;
-    --qwen-quant)
-      benchmark_target="qwen-quant"
+    --qwen-quantization)
+      benchmark_target="qwen-quantization"
       shift
       ;;
     --audible)
@@ -37,32 +39,19 @@ while [ "$#" -gt 0 ]; do
       iterations="${2:-}"
       shift 2
       ;;
-    --backend)
-      qwen_quant_backends="${2:-}"
-      shift 2
-      ;;
-    --backends)
-      qwen_quant_backends="${2:-}"
-      shift 2
-      ;;
-    --device-label)
-      device_label="${2:-}"
-      shift 2
-      ;;
     -h|--help)
       cat <<'USAGE'
 Usage:
-  run-benchmark.sh [--qwen|--qwen-quant] [--audible] [--playback-trace] [--iterations <count>]
-                   [--backend <backend>|--backends <comma-separated-backends>] [--device-label <label>]
+  run-benchmark.sh [--backend|--qwen|--qwen-quantization] [--audible] [--playback-trace] [--iterations <count>]
 
 Defaults:
-  --qwen is the default benchmark target.
+  --backend is the default benchmark target.
 
 Examples:
   sh scripts/repo-maintenance/run-benchmark.sh
   sh scripts/repo-maintenance/run-benchmark.sh --audible --iterations 3
   sh scripts/repo-maintenance/run-benchmark.sh --qwen --iterations 5
-  sh scripts/repo-maintenance/run-benchmark.sh --qwen-quant --backend qwen3_smol_8bit --iterations 1
+  sh scripts/repo-maintenance/run-benchmark.sh --qwen-quantization --iterations 3
 USAGE
       exit 0
       ;;
@@ -72,17 +61,13 @@ USAGE
   esac
 done
 
-case "$benchmark_target" in
-  qwen)
-    suite_name="qwen-benchmark"
-    ;;
-  qwen-quant)
-    suite_name="qwen-quant-benchmark"
-    ;;
-  *)
-    die "Unsupported benchmark target '$benchmark_target'."
-    ;;
-esac
+suite_name="backend-benchmark"
+if [ "$benchmark_target" = "qwen" ]; then
+  suite_name="qwen-benchmark"
+fi
+if [ "$benchmark_target" = "qwen-quantization" ]; then
+  suite_name="qwen-quantization-benchmark"
+fi
 
 suite_args=""
 if [ "$audible" = "true" ]; then
@@ -93,15 +78,6 @@ if [ "$playback_trace" = "true" ]; then
 fi
 if [ -n "$iterations" ]; then
   suite_args="$suite_args --benchmark-iterations $iterations"
-fi
-if [ "$benchmark_target" = "qwen-quant" ]; then
-  suite_args="$suite_args --qwen-quant-benchmark"
-  if [ -n "$qwen_quant_backends" ]; then
-    suite_args="$suite_args --qwen-quant-backends $qwen_quant_backends"
-  fi
-  if [ -n "$device_label" ]; then
-    suite_args="$suite_args --device-label $device_label"
-  fi
 fi
 
 log "Running SpeakSwiftly benchmark target '$benchmark_target' via suite '$suite_name'."

--- a/scripts/repo-maintenance/run-e2e.sh
+++ b/scripts/repo-maintenance/run-e2e.sh
@@ -14,9 +14,6 @@ playback_trace="false"
 deep_trace="false"
 benchmark="false"
 benchmark_iterations=""
-qwen_quant_benchmark="false"
-qwen_quant_benchmark_backends=""
-qwen_quant_benchmark_device_label=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -40,20 +37,8 @@ while [ "$#" -gt 0 ]; do
       benchmark="true"
       shift
       ;;
-    --qwen-quant-benchmark)
-      qwen_quant_benchmark="true"
-      shift
-      ;;
     --benchmark-iterations)
       benchmark_iterations="${2:-}"
-      shift 2
-      ;;
-    --qwen-quant-backends)
-      qwen_quant_benchmark_backends="${2:-}"
-      shift 2
-      ;;
-    --device-label)
-      qwen_quant_benchmark_device_label="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -65,6 +50,8 @@ Suite names:
   quick | GeneratedFileE2ETests
   generated-file | GeneratedFileE2ETests
   generated-batch | GeneratedBatchE2ETests
+  chatterbox | ChatterboxE2ETests
+  marvis | MarvisE2ETests
   qwen | QwenE2ETests
   qwen-backends | QwenE2ETests with backend-variant coverage enabled
   queue-control | QueueControlE2ETests
@@ -72,17 +59,15 @@ Suite names:
   trace | TraceCaptureE2ETests
   deep-trace | DeepTraceE2ETests
   qwen-benchmark | QwenBenchmarkE2ETests
-  qwen-quant-benchmark | QwenQuantizationBenchmarkE2ETests
+  backend-benchmark | BackendBenchmarkE2ETests
+  qwen-quantization-benchmark | BackendBenchmarkE2ETests narrow 0.6B 6-bit versus 8-bit comparison
 
 Flags:
   --audible
   --playback-trace
   --deep-trace
   --benchmark
-  --qwen-quant-benchmark
   --benchmark-iterations <count>
-  --qwen-quant-backends <comma-separated-backends>
-  --device-label <label>
 USAGE
       exit 0
       ;;
@@ -99,13 +84,15 @@ resolve_suite_name() {
     quick|QuickE2ETests) printf '%s\n' "GeneratedFileE2ETests" ;;
     generated-file|GeneratedFileE2ETests) printf '%s\n' "GeneratedFileE2ETests" ;;
     generated-batch|GeneratedBatchE2ETests) printf '%s\n' "GeneratedBatchE2ETests" ;;
+    chatterbox|ChatterboxE2ETests) printf '%s\n' "ChatterboxE2ETests" ;;
+    marvis|MarvisE2ETests) printf '%s\n' "MarvisE2ETests" ;;
     qwen|qwen-backends|QwenE2ETests) printf '%s\n' "QwenE2ETests" ;;
     queue-control|QueueControlE2ETests) printf '%s\n' "QueueControlE2ETests" ;;
     qwen-longform|QwenLongFormE2ETests) printf '%s\n' "QwenLongFormE2ETests" ;;
     trace|TraceCaptureE2ETests) printf '%s\n' "TraceCaptureE2ETests" ;;
     deep-trace|DeepTraceE2ETests) printf '%s\n' "DeepTraceE2ETests" ;;
     qwen-benchmark|QwenBenchmarkE2ETests) printf '%s\n' "QwenBenchmarkE2ETests" ;;
-    qwen-quant-benchmark|QwenQuantizationBenchmarkE2ETests) printf '%s\n' "QwenQuantizationBenchmarkE2ETests" ;;
+    backend-benchmark|qwen-quantization-benchmark|BackendBenchmarkE2ETests) printf '%s\n' "BackendBenchmarkE2ETests" ;;
     *)
       return 1
       ;;
@@ -116,7 +103,7 @@ suite_name=$(resolve_suite_name "$suite_arg") \
   || die "Unsupported E2E suite '$suite_arg'. Use --help to see the supported top-level suite names."
 
 case "$suite_name" in
-  GeneratedFileE2ETests|GeneratedBatchE2ETests|QwenE2ETests|QueueControlE2ETests|QwenLongFormE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests|QwenQuantizationBenchmarkE2ETests)
+  GeneratedFileE2ETests|GeneratedBatchE2ETests|ChatterboxE2ETests|MarvisE2ETests|QwenE2ETests|QueueControlE2ETests|QwenLongFormE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests|BackendBenchmarkE2ETests)
     ;;
   *)
     die "Refusing to run '$suite_name' because only one top-level E2E suite may run per invocation."
@@ -145,10 +132,6 @@ if [ "$benchmark" = "true" ] || [ "$suite_name" = "QwenBenchmarkE2ETests" ]; the
   export SPEAKSWIFTLY_QWEN_BENCHMARK_E2E=1
 fi
 
-if [ "$qwen_quant_benchmark" = "true" ] || [ "$suite_name" = "QwenQuantizationBenchmarkE2ETests" ]; then
-  export SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_E2E=1
-fi
-
 if [ "$suite_name" = "QwenLongFormE2ETests" ]; then
   export SPEAKSWIFTLY_QWEN_LONGFORM_E2E=1
 fi
@@ -159,14 +142,19 @@ fi
 
 if [ -n "$benchmark_iterations" ]; then
   export SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS="$benchmark_iterations"
+  export SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS="$benchmark_iterations"
 fi
 
-if [ -n "$qwen_quant_benchmark_backends" ]; then
-  export SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_BACKENDS="$qwen_quant_benchmark_backends"
+if [ "$suite_name" = "BackendBenchmarkE2ETests" ] && [ "$suite_arg" != "qwen-quantization-benchmark" ]; then
+  export SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1
 fi
 
-if [ -n "$qwen_quant_benchmark_device_label" ]; then
-  export SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_DEVICE_LABEL="$qwen_quant_benchmark_device_label"
+if [ "$suite_arg" = "qwen-quantization-benchmark" ]; then
+  export SPEAKSWIFTLY_QWEN_QUANTIZATION_BENCHMARK_E2E=1
+fi
+
+if [ "$suite_name" = "BackendBenchmarkE2ETests" ] && [ "$audible" = "true" ]; then
+  export SPEAKSWIFTLY_BACKEND_BENCHMARK_AUDIBLE=1
 fi
 
 restore_status=0


### PR DESCRIPTION
## Summary
- add opt-in Qwen quantization/backend benchmark coverage
- add benchmark signpost support and trace wrappers
- align the rebased benchmark helpers with the current runtime APIs

## Verification
- swift test --filter BackendBenchmarkE2ETests
- swift test --filter QwenQuantizationBenchmarkE2ETests
- commit hook: repo-maintenance validation and SwiftLint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backend benchmarking test suite with concurrent request performance metrics and resource tracking.

* **Tests**
  * Enhanced benchmark harness with improved resource snapshot collection and signpost recording.
  * Updated environment variable configuration for benchmark enablement and iteration control.

* **Documentation**
  * Added backend benchmarking implementation plan and guidance.
  * Updated validation lane instructions with expanded benchmark procedures.

* **Chores**
  * Updated benchmark execution scripts to support new target naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->