### PR TITLE
release: prepare v11.0.1

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build package
         run: swift build
 
+      - name: Test package
+        run: swift test
+
   tagged-runtime-publication:
     name: Tagged Runtime Publication (${{ matrix.configuration }})
     if: startsWith(github.ref, 'refs/tags/')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,17 @@ swift build
 swift test
 ```
 
+Opt-in MLX conditioning persistence checks:
+
+```bash
+SPEAKSWIFTLY_MLX_PERSISTENCE_TESTS=1 swift test --filter ProfileStoreTests
+SPEAKSWIFTLY_MLX_PERSISTENCE_TESTS=1 swift test --filter SpeechModelClientTests
+```
+
+Keep this lane separate from the baseline package checks. It exercises prepared
+Qwen conditioning persistence and may touch heavier MLX-backed code paths than
+the ordinary fast SwiftPM lane.
+
 Full repo-maintenance validation:
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -305,6 +305,7 @@ In Progress
 - [x] Add `generate.audioStream(...)` so host boundaries can consume successful canonical chunk streams instead of failed request handles.
 - [x] Add memory-backed recent generated-audio replay on `runtime.playback`, including replay-one, replay-all, bounded retention configuration, and JSONL/tool controls.
 - [x] Remove the local `request_context.reqPurpose: "audioStream"` rejection guard after TextForSpeech removed `RequestPurpose.audioStream` in [gaelic-ghost/TextForSpeech#33](https://github.com/gaelic-ghost/TextForSpeech/issues/33).
+- [ ] Review and intentionally document the remaining non-playback output semantics: retained file generation should not inherit live-playback backpressure accidentally, while `generate.audioStream(...)` should define host-consumer cancellation, buffering, and slow-reader behavior explicitly before the next implementation pass.
 - [x] Add tests for canonical chunks, local playback chunk consumption, HTTP frames, Network frame round trips, Bonjour metadata, discovered-destination selection, and removed backend rejection.
 - [x] Add organized unit and integration matrix coverage for every Qwen3 size and quant variant so routing, decoding, configuration, resident repo mapping, generation policy, and runtime scheduling stay covered without real-model downloads in the default suite.
 - [x] Add runtime routing tests for request-scoped nonlocal output failure paths until real transports are wired.

--- a/Tests/SpeakSwiftlyTests/Output/GeneratedAudioOutputTests.swift
+++ b/Tests/SpeakSwiftlyTests/Output/GeneratedAudioOutputTests.swift
@@ -137,7 +137,8 @@ import Testing
     let drainedFastChunks = try await fastChunks
 
     #expect(drainedFastChunks.map(\.sequenceNumber) == Array(0...8))
-    #expect(slowChunks.count <= 2)
+    #expect(slowChunks.count < drainedFastChunks.count)
+    #expect(slowChunks.count <= 3)
     #expect(slowChunks.last?.isFinal == true)
 }
 

--- a/Tests/SpeakSwiftlyTests/Output/NetworkAudioOutputTests.swift
+++ b/Tests/SpeakSwiftlyTests/Output/NetworkAudioOutputTests.swift
@@ -286,13 +286,20 @@ import Testing
 }
 
 private func waitForListeningPort(_ listener: NetworkAudioStreamListener) async throws -> UInt16 {
-    for _ in 0..<100 {
-        if case let .listening(port?) = await listener.state {
-            return port
+    var lastState = await listener.state
+    for _ in 0..<1000 {
+        lastState = await listener.state
+        switch lastState {
+            case let .listening(port?):
+                return port
+            case let .failed(message):
+                Issue.record("Network audio listener failed before reporting a loopback port: \(message)")
+                throw CancellationError()
+            default:
+                try await Task.sleep(for: .milliseconds(10))
         }
-        try await Task.sleep(for: .milliseconds(10))
     }
 
-    Issue.record("Network audio listener did not report a loopback port in time.")
+    Issue.record("Network audio listener did not report a loopback port in time. Last observed state: \(lastState).")
     throw CancellationError()
 }

--- a/Tests/SpeakSwiftlyTests/Output/NetworkAudioOutputTests.swift
+++ b/Tests/SpeakSwiftlyTests/Output/NetworkAudioOutputTests.swift
@@ -121,7 +121,7 @@ import Testing
 
 @Test func `network audio sender streams chunks to loopback listener`() async throws {
     let listener = NetworkAudioStreamListener(
-        advertisement: NetworkAudioServiceAdvertisement(name: "Loopback receiver"),
+        advertisement: uniqueLoopbackAdvertisement(),
         port: 0,
         sharedToken: "secret",
     )
@@ -226,7 +226,7 @@ import Testing
 
 @Test func `network audio listener rejects wrong shared token`() async throws {
     let listener = NetworkAudioStreamListener(
-        advertisement: NetworkAudioServiceAdvertisement(name: "Loopback receiver"),
+        advertisement: uniqueLoopbackAdvertisement(),
         port: 0,
         sharedToken: "secret",
     )
@@ -302,4 +302,8 @@ private func waitForListeningPort(_ listener: NetworkAudioStreamListener) async 
 
     Issue.record("Network audio listener did not report a loopback port in time. Last observed state: \(lastState).")
     throw CancellationError()
+}
+
+private func uniqueLoopbackAdvertisement() -> NetworkAudioServiceAdvertisement {
+    NetworkAudioServiceAdvertisement(name: "Loopback receiver \(UUID().uuidString)")
 }

--- a/Tests/SpeakSwiftlyTests/Support/SupportResourcesTests.swift
+++ b/Tests/SpeakSwiftlyTests/Support/SupportResourcesTests.swift
@@ -30,8 +30,16 @@ import Testing
 
     for profileName in expectedProfiles {
         let profileURL = profilesURL.appendingPathComponent(profileName, isDirectory: true)
-        #expect(FileManager.default.fileExists(atPath: profileURL.appendingPathComponent("profile.json").path))
+        let manifestURL = profileURL.appendingPathComponent("profile.json", isDirectory: false)
+        #expect(FileManager.default.fileExists(atPath: manifestURL.path))
         #expect(FileManager.default.fileExists(atPath: profileURL.appendingPathComponent("reference.wav").path))
+
+        let manifestData = try Data(contentsOf: manifestURL)
+        let manifest = try JSONDecoder().decode(E2EProfileResourceManifest.self, from: manifestData)
+        for artifact in manifest.qwenConditioningArtifacts {
+            let artifactURL = profileURL.appendingPathComponent(artifact.artifactFile, isDirectory: false)
+            #expect(FileManager.default.fileExists(atPath: artifactURL.path))
+        }
     }
 }
 
@@ -40,4 +48,12 @@ import Testing
     #expect(rootURL.lastPathComponent == "profiles")
     #expect(rootURL.deletingLastPathComponent().lastPathComponent == "SystemProfiles")
     #expect(FileManager.default.fileExists(atPath: rootURL.path))
+}
+
+private struct E2EProfileResourceManifest: Decodable {
+    let qwenConditioningArtifacts: [E2EProfileQwenConditioningArtifact]
+}
+
+private struct E2EProfileQwenConditioningArtifact: Decodable {
+    let artifactFile: String
 }

--- a/docs/maintainers/validation-lanes.md
+++ b/docs/maintainers/validation-lanes.md
@@ -81,13 +81,18 @@ For GitHub Actions, keep the manifest sanity check as:
 swift package dump-package
 ```
 
-GitHub Actions currently keeps build-and-test coverage on the Xcode-backed
-package lane even though local ordinary package work starts with SwiftPM. The
-current macOS CI target set is:
+GitHub Actions currently keeps the ordinary macOS package lane on SwiftPM:
 
-- `SpeakSwiftlyTests/WorkerRuntimePlaybackTests`
-- `SpeakSwiftlyTests/LibrarySurfaceTests`
-- `SpeakSwiftlyTests/ModelClientsTests`
+```bash
+swift package dump-package
+swift build
+swift test
+```
+
+That CI lane intentionally leaves real-model E2E suites behind their explicit
+environment gates. If CI moves back to an Xcode-backed package lane, update this
+section and `.github/workflows/swift.yml` together so the documented lane and the
+actual workflow stay in sync.
 
 ## iOS Compile-And-Smoke Lane
 
@@ -134,6 +139,7 @@ sh scripts/repo-maintenance/run-e2e.sh --suite quick
 sh scripts/repo-maintenance/run-e2e.sh --suite qwen
 sh scripts/repo-maintenance/run-e2e.sh --suite qwen-backends
 sh scripts/repo-maintenance/run-e2e.sh --suite qwen-longform
+sh scripts/repo-maintenance/run-e2e.sh --suite qwen-quantization-benchmark
 sh scripts/repo-maintenance/run-e2e-full.sh
 ```
 
@@ -207,10 +213,9 @@ xcodebuild test-without-building -quiet \
   -destination 'platform=macOS' \
   -only-testing:'SpeakSwiftlyTests/GeneratedFileE2ETests' \
   -only-testing:'SpeakSwiftlyTests/GeneratedBatchE2ETests' \
-  -only-testing:'SpeakSwiftlyTests/ChatterboxE2ETests' \
   -only-testing:'SpeakSwiftlyTests/QueueControlE2ETests' \
-  -only-testing:'SpeakSwiftlyTests/MarvisE2ETests' \
-  -only-testing:'SpeakSwiftlyTests/QwenE2ETests'
+  -only-testing:'SpeakSwiftlyTests/QwenE2ETests' \
+  -only-testing:'SpeakSwiftlyTests/QwenQuantizationBenchmarkE2ETests'
 ```
 
 That lane excludes the opt-in `DeepTraceE2ETests` and `QwenBenchmarkE2ETests`
@@ -238,10 +243,36 @@ sh scripts/repo-maintenance/run-benchmark.sh --qwen-quantization --iterations 3
 ```
 
 Use the Qwen quantization lane when the question is specifically about the
-0.6B 6-bit build versus the 0.6B 8-bit build. That lane writes
-`qwen-0-6b-quantization-benchmark-latest.json` under `.local/benchmarks` and
-keeps the workload to the same two queued live requests used by the backend
-benchmark suite.
+Qwen backend quantization matrix. That lane runs `QwenQuantizationBenchmarkE2ETests`
+with `SPEAKSWIFTLY_QWEN_QUANTIZATION_BENCHMARK_E2E=1` and writes timestamped
+plus `latest.json` summaries under `.local/benchmarks/qwen-quant/<device>/`.
+
+For the friendly Qwen-quant wrapper, pass backend and device filters to
+`run-qwen-quant-benchmark.sh`; it translates those options into the environment
+variables read by the test suite:
+
+```bash
+sh scripts/repo-maintenance/run-qwen-quant-benchmark.sh --backend qwen3_smol_8bit --iterations 1
+sh scripts/repo-maintenance/run-qwen-quant-benchmark.sh --all --device-label macbook-pro-m4-pro-24gb
+```
+
+The lower-level generic benchmark wrapper keeps one canonical target spelling:
+`--qwen-quantization`.
+
+## Opt-In MLX Persistence Lane
+
+The baseline `swift test` run deliberately skips MLX conditioning persistence
+round trips. Use this opt-in lane when changing profile storage, prepared Qwen
+conditioning artifacts, or resident speech input loading:
+
+```bash
+SPEAKSWIFTLY_MLX_PERSISTENCE_TESTS=1 swift test --filter ProfileStoreTests
+SPEAKSWIFTLY_MLX_PERSISTENCE_TESTS=1 swift test --filter SpeechModelClientTests
+```
+
+Run the filters one at a time when the machine is already under model-memory
+pressure. They are still ordinary SwiftPM tests, but they exercise heavier
+conditioning persistence paths than the default unit lane.
 
 The benchmark harness also emits `OSSignposter` timeline markers under the
 `com.gaelic-ghost.SpeakSwiftly.benchmarks` subsystem. Use those markers when
@@ -286,21 +317,6 @@ sh scripts/repo-maintenance/run-benchmark-trace.sh --template "VM Tracker" --ite
 The trace wrapper stores `.trace` files under `.local/traces/qwen-quantization`
 and leaves benchmark JSON summaries under `.local/benchmarks`. Do not run more
 than one trace template at the same time.
-
-For the Marvis-specific resident-policy comparison lane, run the benchmark test
-directly so the filter stays narrow:
-
-```bash
-SPEAKSWIFTLY_E2E=1 SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1 SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS=1 swift test --filter 'BackendBenchmarkE2ETests/compare marvis resident policies with three queued voice switches'
-```
-
-That lane compares `dual_resident_serialized` against
-`single_resident_dynamic` with a three-request voice order that goes
-`femme` -> `masc` -> `femme` again.
-
-For Marvis profiling, throughput investigation, and trace work, prefer the dedicated runbook:
-
-- [marvis-overlap-profiling-runbook-2026-04-16.md](marvis-overlap-profiling-runbook-2026-04-16.md)
 
 ## Practical Rules
 

--- a/scripts/repo-maintenance/run-e2e.sh
+++ b/scripts/repo-maintenance/run-e2e.sh
@@ -50,8 +50,6 @@ Suite names:
   quick | GeneratedFileE2ETests
   generated-file | GeneratedFileE2ETests
   generated-batch | GeneratedBatchE2ETests
-  chatterbox | ChatterboxE2ETests
-  marvis | MarvisE2ETests
   qwen | QwenE2ETests
   qwen-backends | QwenE2ETests with backend-variant coverage enabled
   queue-control | QueueControlE2ETests
@@ -60,7 +58,7 @@ Suite names:
   deep-trace | DeepTraceE2ETests
   qwen-benchmark | QwenBenchmarkE2ETests
   backend-benchmark | BackendBenchmarkE2ETests
-  qwen-quantization-benchmark | BackendBenchmarkE2ETests narrow 0.6B 6-bit versus 8-bit comparison
+  qwen-quantization-benchmark | QwenQuantizationBenchmarkE2ETests
 
 Flags:
   --audible
@@ -84,15 +82,14 @@ resolve_suite_name() {
     quick|QuickE2ETests) printf '%s\n' "GeneratedFileE2ETests" ;;
     generated-file|GeneratedFileE2ETests) printf '%s\n' "GeneratedFileE2ETests" ;;
     generated-batch|GeneratedBatchE2ETests) printf '%s\n' "GeneratedBatchE2ETests" ;;
-    chatterbox|ChatterboxE2ETests) printf '%s\n' "ChatterboxE2ETests" ;;
-    marvis|MarvisE2ETests) printf '%s\n' "MarvisE2ETests" ;;
     qwen|qwen-backends|QwenE2ETests) printf '%s\n' "QwenE2ETests" ;;
     queue-control|QueueControlE2ETests) printf '%s\n' "QueueControlE2ETests" ;;
     qwen-longform|QwenLongFormE2ETests) printf '%s\n' "QwenLongFormE2ETests" ;;
     trace|TraceCaptureE2ETests) printf '%s\n' "TraceCaptureE2ETests" ;;
     deep-trace|DeepTraceE2ETests) printf '%s\n' "DeepTraceE2ETests" ;;
     qwen-benchmark|QwenBenchmarkE2ETests) printf '%s\n' "QwenBenchmarkE2ETests" ;;
-    backend-benchmark|qwen-quantization-benchmark|BackendBenchmarkE2ETests) printf '%s\n' "BackendBenchmarkE2ETests" ;;
+    backend-benchmark|BackendBenchmarkE2ETests) printf '%s\n' "BackendBenchmarkE2ETests" ;;
+    qwen-quantization-benchmark|QwenQuantizationBenchmarkE2ETests) printf '%s\n' "QwenQuantizationBenchmarkE2ETests" ;;
     *)
       return 1
       ;;
@@ -103,7 +100,7 @@ suite_name=$(resolve_suite_name "$suite_arg") \
   || die "Unsupported E2E suite '$suite_arg'. Use --help to see the supported top-level suite names."
 
 case "$suite_name" in
-  GeneratedFileE2ETests|GeneratedBatchE2ETests|ChatterboxE2ETests|MarvisE2ETests|QwenE2ETests|QueueControlE2ETests|QwenLongFormE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests|BackendBenchmarkE2ETests)
+  GeneratedFileE2ETests|GeneratedBatchE2ETests|QwenE2ETests|QueueControlE2ETests|QwenLongFormE2ETests|TraceCaptureE2ETests|DeepTraceE2ETests|QwenBenchmarkE2ETests|BackendBenchmarkE2ETests|QwenQuantizationBenchmarkE2ETests)
     ;;
   *)
     die "Refusing to run '$suite_name' because only one top-level E2E suite may run per invocation."
@@ -145,11 +142,11 @@ if [ -n "$benchmark_iterations" ]; then
   export SPEAKSWIFTLY_BACKEND_BENCHMARK_ITERATIONS="$benchmark_iterations"
 fi
 
-if [ "$suite_name" = "BackendBenchmarkE2ETests" ] && [ "$suite_arg" != "qwen-quantization-benchmark" ]; then
+if [ "$suite_name" = "BackendBenchmarkE2ETests" ]; then
   export SPEAKSWIFTLY_BACKEND_BENCHMARK_E2E=1
 fi
 
-if [ "$suite_arg" = "qwen-quantization-benchmark" ]; then
+if [ "$suite_name" = "QwenQuantizationBenchmarkE2ETests" ]; then
   export SPEAKSWIFTLY_QWEN_QUANTIZATION_BENCHMARK_E2E=1
 fi
 

--- a/scripts/repo-maintenance/run-qwen-quant-benchmark.sh
+++ b/scripts/repo-maintenance/run-qwen-quant-benchmark.sh
@@ -67,13 +67,14 @@ USAGE
   esac
 done
 
-set -- "$SELF_DIR/run-benchmark.sh" --qwen-quant --iterations "$iterations"
 if [ -n "$backends" ]; then
-  set -- "$@" --backends "$backends"
+  export SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_BACKENDS="$backends"
 fi
 if [ -n "$device_label" ]; then
-  set -- "$@" --device-label "$device_label"
+  export SPEAKSWIFTLY_QWEN_QUANT_BENCHMARK_DEVICE_LABEL="$device_label"
 fi
+
+set -- "$SELF_DIR/run-benchmark.sh" --qwen-quantization --iterations "$iterations"
 if [ "$audible" = "true" ]; then
   set -- "$@" --audible
 fi


### PR DESCRIPTION
## Release

- prepares v11.0.1 from branch `tests/align-validation-lanes`
- keeps protected `main` updates behind pull request review and CI
- release tag `v11.0.1` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
