### PR TITLE
ci: install Metal Toolchain for tagged runtimes

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Install Metal Toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
+
       - name: Publish runtime
         run: sh scripts/repo-maintenance/publish-runtime.sh --configuration "${{ matrix.configuration }}"
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -62,7 +62,10 @@ jobs:
           xcode-version: latest-stable
 
       - name: Install Metal Toolchain
-        run: xcodebuild -downloadComponent MetalToolchain
+        run: |
+          set -euo pipefail
+          xcodebuild -downloadComponent MetalToolchain
+          xcrun --find metal >/dev/null
 
       - name: Publish runtime
         run: sh scripts/repo-maintenance/publish-runtime.sh --configuration "${{ matrix.configuration }}"


### PR DESCRIPTION
## Summary
- install the Metal Toolchain in the tag-only runtime publication job before building runtime artifacts
- keep the package smoke job unchanged

## Verification
- sh scripts/repo-maintenance/validate-all.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to include an additional prerequisite step before publishing and verifying the runtime, helping avoid build or packaging issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->