### PR TITLE
normalize: project Markdown tables for speech

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,7 @@ This roadmap now keeps active milestones and the current release-hardening queue
 - [Milestone 32: Qwen-Only Output Modularization](#milestone-32-qwen-only-output-modularization)
 - [Milestone 33: First-Party Core ML Qwen3-TTS Port](#milestone-33-first-party-core-ml-qwen3-tts-port)
 - [Milestone 34: First-Party Apple Speech Pipeline Ownership](#milestone-34-first-party-apple-speech-pipeline-ownership)
+- [Milestone 35: Normalization Consolidation Follow-Through](#milestone-35-normalization-consolidation-follow-through)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
 
@@ -53,6 +54,7 @@ This roadmap now keeps active milestones and the current release-hardening queue
 - Milestone 32: Qwen-Only Output Modularization - In Progress
 - Milestone 33: First-Party Core ML Qwen3-TTS Port - Research
 - Milestone 34: First-Party Apple Speech Pipeline Ownership - Planned
+- Milestone 35: Normalization Consolidation Follow-Through - In Progress
 
 ## Active Milestones
 
@@ -559,6 +561,40 @@ Planned
   the default answer.
 - [ ] Removing `mlx-audio-swift` is either scheduled behind concrete remaining
   blockers or completed with replacement validation.
+
+## Milestone 35: Normalization Consolidation Follow-Through
+
+### Status
+
+In Progress
+
+### Scope
+
+- [ ] Finish moving reusable Markdown-to-speech behavior out of downstream hooks and into the internal `SpeakSwiftlyNormalization` target.
+- [ ] Preserve every unfinished TextForSpeech roadmap decision in this repository without reviving a second package or adding compatibility shims.
+- [ ] Keep normalization deterministic, namespace-first, SourceKit-discoverable, and driven by explicit detection and style behavior.
+- [ ] Keep persistence lifecycle ownership on `SpeakSwiftly.Normalizer` while pure normalization, summarization, and value models stay in `SpeakSwiftlyNormalization`.
+
+The exhaustive retirement-to-issue mapping lives in
+`docs/maintainers/textforspeech-roadmap-migration-2026-07-19.md`.
+
+### Tickets
+
+- [ ] Project Markdown tables into speech-safe labeled prose and remove the temporary hook-side implementation after adoption. ([#111](https://github.com/gaelic-ghost/SpeakSwiftly/issues/111))
+- [ ] Make Markdown section exclusion a reusable, caller-configured speech projection. ([#112](https://github.com/gaelic-ghost/SpeakSwiftly/issues/112))
+- [ ] Add structured Swift source normalization while preserving the generic fallback and extensible source API. ([#114](https://github.com/gaelic-ghost/SpeakSwiftly/issues/114))
+- [ ] Add opt-in live summarization-provider checks and decide whether model selection belongs in the public configuration. ([#115](https://github.com/gaelic-ghost/SpeakSwiftly/issues/115))
+- [ ] Clarify the persistence archive contract and simplify common replacement authoring. ([#116](https://github.com/gaelic-ghost/SpeakSwiftly/issues/116))
+- [ ] Finish semantic-token classification and document compact, balanced, and explicit URL, Markdown-link, and path behavior. ([#117](https://github.com/gaelic-ghost/SpeakSwiftly/issues/117))
+- [ ] Audit normalization source responsibilities and docs after the v12 consolidation. ([#118](https://github.com/gaelic-ghost/SpeakSwiftly/issues/118))
+- [ ] Preserve conditional extension decisions without implementing speculative public surface. ([#119](https://github.com/gaelic-ghost/SpeakSwiftly/issues/119))
+
+### Exit Criteria
+
+- [ ] SpeakSwiftly is the only active implementation and planning home for normalization and summarization work.
+- [ ] Downstream consumers no longer duplicate shared Markdown projection behavior.
+- [ ] Every unfinished TextForSpeech roadmap item is implemented, explicitly retired, or linked to one canonical SpeakSwiftly issue.
+- [ ] The standalone TextForSpeech repository remains frozen and unarchived until Gale separately approves GitHub archival.
 
 ## Backlog Candidates
 

--- a/Sources/SpeakSwiftlyNormalization/Normalization/MarkdownNormalizationPasses.swift
+++ b/Sources/SpeakSwiftlyNormalization/Normalization/MarkdownNormalizationPasses.swift
@@ -45,6 +45,39 @@ extension TextNormalizer {
         return applyingMarkdownReplacements(replacements, to: text)
     }
 
+    static func normalizeMarkdownTablesForSpeech(_ text: String) -> String {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var normalizedLines: [String] = []
+        var index = lines.startIndex
+
+        while index < lines.endIndex {
+            let header = lines[index]
+            let dividerIndex = lines.index(after: index)
+
+            guard header.contains("|"),
+                  dividerIndex < lines.endIndex,
+                  isMarkdownTableDivider(lines[dividerIndex]) else {
+                normalizedLines.append(header)
+                index = dividerIndex
+                continue
+            }
+
+            let headerCells = markdownTableCells(in: header)
+            var rows: [[String]] = []
+            var rowIndex = lines.index(after: dividerIndex)
+
+            while rowIndex < lines.endIndex, lines[rowIndex].contains("|") {
+                rows.append(markdownTableCells(in: lines[rowIndex]))
+                rowIndex = lines.index(after: rowIndex)
+            }
+
+            normalizedLines.append(spokenMarkdownTable(headerCells: headerCells, rows: rows))
+            index = rowIndex
+        }
+
+        return normalizedLines.joined(separator: "\n")
+    }
+
     // MARK: Markdown Replacement Collection
 
     private static func codeBlockReplacements(
@@ -108,6 +141,65 @@ extension TextNormalizer {
         }
 
         return result
+    }
+
+    private static func isMarkdownTableDivider(_ line: String) -> Bool {
+        line.firstMatch(of: /^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$/) != nil
+    }
+
+    private static func markdownTableCells(in line: String) -> [String] {
+        let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+        var cells: [String] = []
+        var cell = ""
+        var escaped = false
+
+        for character in trimmedLine {
+            if escaped {
+                cell.append(character)
+                escaped = false
+            } else if character == "\\" {
+                escaped = true
+            } else if character == "|" {
+                cells.append(cell.trimmingCharacters(in: .whitespaces))
+                cell = ""
+            } else {
+                cell.append(character)
+            }
+        }
+
+        if escaped {
+            cell.append("\\")
+        }
+        cells.append(cell.trimmingCharacters(in: .whitespaces))
+
+        if trimmedLine.hasPrefix("|") {
+            cells.removeFirst()
+        }
+        if trimmedLine.hasSuffix("|") {
+            cells.removeLast()
+        }
+
+        return cells
+    }
+
+    private static func spokenMarkdownTable(
+        headerCells: [String],
+        rows: [[String]],
+    ) -> String {
+        let columns = headerCells.filter { !$0.isEmpty }
+        let intro = columns.isEmpty ? "Table." : "Table columns: \(columns.joined(separator: ", "))."
+        let spokenRows = rows.compactMap { row -> String? in
+            let values = columns.enumerated().compactMap { index, column -> String? in
+                guard index < row.count else { return nil }
+
+                let value = row[index].trimmingCharacters(in: .whitespaces)
+                return value.isEmpty ? nil : "\(column): \(value)"
+            }
+
+            return values.isEmpty ? nil : values.joined(separator: "; ")
+        }
+
+        return ([intro] + spokenRows).joined(separator: "\n")
     }
 
     private static func trimmedPriorityRemainder(_ remainder: Substring) -> String {

--- a/Sources/SpeakSwiftlyNormalization/Normalization/TextNormalizer.swift
+++ b/Sources/SpeakSwiftlyNormalization/Normalization/TextNormalizer.swift
@@ -69,6 +69,7 @@ enum TextNormalizer {
                     profile: profile,
                 )
             },
+            { text, _, _, _ in normalizeMarkdownTablesForSpeech(text) },
             { text, requestContext, profile, _ in
                 normalizeInlineCodeSpans(
                     text,

--- a/Tests/SpeakSwiftlyNormalizationTests/Normalization/MarkdownAndURLNormalizationTests.swift
+++ b/Tests/SpeakSwiftlyNormalizationTests/Normalization/MarkdownAndURLNormalizationTests.swift
@@ -90,6 +90,64 @@ import Testing
     #expect(normalized.contains("repo, link https://github.com/example/repo"))
 }
 
+@Test func `markdown tables become labeled speech rows`() {
+    let text = """
+    | Scenario | Expected speech |
+    |:---|---:|
+    | Simple table | Headers then values |
+    | Inline code | `status = "ready"` |
+    """
+
+    let normalized = TextNormalizer.normalizeMarkdownTablesForSpeech(text)
+
+    #expect(normalized.contains("Table columns: Scenario, Expected speech."))
+    #expect(normalized.contains("Scenario: Simple table; Expected speech: Headers then values"))
+    #expect(normalized.contains("Scenario: Inline code; Expected speech: `status = \"ready\"`"))
+    #expect(!normalized.contains("|:---|---:|"))
+    #expect(!normalized.contains("| Scenario |"))
+}
+
+@Test func `markdown tables preserve escaped pipes as cell content`() {
+    let text = """
+    | Surface | Value |
+    |---|---|
+    | Transport | HTTP \\| MCP |
+    """
+
+    let normalized = TextNormalizer.normalizeMarkdownTablesForSpeech(text)
+
+    #expect(normalized == "Table columns: Surface, Value.\nSurface: Transport; Value: HTTP | MCP")
+}
+
+@Test func `markdown table normalization preserves inline pipes and malformed tables`() {
+    let text = """
+    The transport choice is HTTP | MCP | CLI, based on the caller.
+    | Not | A table |
+    |--|--|
+    | Still | prose |
+    """
+
+    let normalized = TextNormalizer.normalizeMarkdownTablesForSpeech(text)
+
+    #expect(normalized == text)
+}
+
+@Test func `markdown table speech projection composes with the normalization pipeline`() async throws {
+    let text = """
+    | Surface | Value |
+    |---|---|
+    | State | `status = "ready"` |
+    """
+
+    let normalized = try await SpeakSwiftlyNormalization.Normalize.text(text)
+
+    #expect(normalized.contains("Table columns: Surface, Value."))
+    #expect(normalized.contains("Surface: State; Value: status equals"))
+    #expect(normalized.contains("ready"))
+    #expect(!normalized.contains("|---|"))
+    #expect(!normalized.contains("`"))
+}
+
 @Test func `priority bullets become spoken levels`() {
     let text = """
     - [P1] Fix the crash

--- a/docs/maintainers/slices.md
+++ b/docs/maintainers/slices.md
@@ -122,6 +122,8 @@ For one request, the normalizer:
 
 Generation callers use `textProfile` to select a stored profile by stable identifier and `requestContext` to carry caller metadata and path context. They do not provide source-format hints through the worker. SpeakSwiftly detects ordinary input structure from text and path context; direct Swift callers can use `speechSource(_:as:...)` when they intentionally possess a whole-source language type.
 
+Markdown tables are projected before inline-code and link normalization. A recognized header and delimiter become a concise column introduction, and each data row becomes labeled speech. Visual pipe and alignment syntax is removed, escaped cell pipes remain content, and ordinary non-table pipe prose is left unchanged.
+
 Summarization is opt-in per normalization call through `summarize: true`. Provider selection remains independent:
 
 - `normalizer.summarization.get()`

--- a/docs/maintainers/textforspeech-roadmap-migration-2026-07-19.md
+++ b/docs/maintainers/textforspeech-roadmap-migration-2026-07-19.md
@@ -1,0 +1,45 @@
+# TextForSpeech Roadmap Migration
+
+This ledger records where every unfinished item in the frozen TextForSpeech
+`ROADMAP.md` moved after normalization and summarization became the internal
+`SpeakSwiftlyNormalization` target in SpeakSwiftly 12.
+
+## Issue Inventory
+
+TextForSpeech has no open GitHub issues. Its only historical issue, #33,
+was already closed before retirement. SpeakSwiftly issues
+[#111](https://github.com/gaelic-ghost/SpeakSwiftly/issues/111) and
+[#112](https://github.com/gaelic-ghost/SpeakSwiftly/issues/112) already tracked
+the two downstream Markdown projection requests and were updated in place
+instead of duplicated.
+
+## Roadmap Mapping
+
+| TextForSpeech source | SpeakSwiftly destination | Coverage |
+| --- | --- | --- |
+| Product principles | Milestone 35 and issues [#114](https://github.com/gaelic-ghost/SpeakSwiftly/issues/114), [#116](https://github.com/gaelic-ghost/SpeakSwiftly/issues/116), and [#117](https://github.com/gaelic-ghost/SpeakSwiftly/issues/117) | Deterministic shared normalization, namespace-first API discovery, and detection plus documented style behavior are acceptance constraints rather than separate feature work. |
+| Milestone 5: Structured Source Normalization | [#114](https://github.com/gaelic-ghost/SpeakSwiftly/issues/114) | SwiftSyntax adoption, structured Swift traversal, generic fallback, representative tests, Python and Rust category decision, documentation, and future language-lane extensibility. |
+| Milestone 7: Release and Maintainability Polish | [#118](https://github.com/gaelic-ghost/SpeakSwiftly/issues/118) | Post-consolidation source-role audit, scanability, and current public and maintainer architecture docs. |
+| Milestone 8: Summary-Aware Normalization Requests | [#115](https://github.com/gaelic-ghost/SpeakSwiftly/issues/115) | Live provider checks or examples, caller guidance, and the first-class summary-model-selection decision. |
+| Milestone 8.1 deferred follow-up | [#119](https://github.com/gaelic-ghost/SpeakSwiftly/issues/119) | Conditional Foundation Models prompt-risk preflight with its downstream-need trigger preserved. |
+| Milestone 9: Public API Model Cleanup | [#116](https://github.com/gaelic-ghost/SpeakSwiftly/issues/116) | Persistence archive contract, narrower lifecycle APIs, common replacement authoring, advanced rule access, docs, tests, and release guidance. |
+| Milestone 10: Style-Based Normalization Behavior | [#117](https://github.com/gaelic-ghost/SpeakSwiftly/issues/117) | Semantic-run audit, additional `NSDataDetector` kinds, default-spoken-kind decision, developer-token independence, per-family tests, and compact, balanced, and explicit behavior. |
+| Milestone 10: Codex Hook Review | [#111](https://github.com/gaelic-ghost/SpeakSwiftly/issues/111), [#112](https://github.com/gaelic-ghost/SpeakSwiftly/issues/112), and [#119](https://github.com/gaelic-ghost/SpeakSwiftly/issues/119) | Proven shared Markdown table and section projection needs are concrete issues; any additional hook behavior remains trigger-gated. |
+| Backlog: languages beyond Swift | [#119](https://github.com/gaelic-ghost/SpeakSwiftly/issues/119), with implementation shaped by [#114](https://github.com/gaelic-ghost/SpeakSwiftly/issues/114) | Preserve the decision without adding speculative parsers before Swift proves the shared shape. |
+| Backlog: public nested source-format inspection | [#119](https://github.com/gaelic-ghost/SpeakSwiftly/issues/119) | Preserve the concrete-caller trigger without expanding the public API now. |
+
+## Explicitly Retired Items
+
+- The TextForSpeech “next minor release” work completed with the final
+  `v0.23.0` retirement release. It is not carried forward as a false
+  SpeakSwiftly task.
+- GitHub repository archival remains unchecked in TextForSpeech because it
+  requires separate explicit approval. It is not part of Milestone 35 and this
+  migration does not archive, delete, or rewrite the frozen repository.
+
+## Completion Rule
+
+Milestone 35 is complete when each mapped issue is implemented, explicitly
+retired with durable rationale, or remains intentionally trigger-gated in
+#119, and when an organization-wide dependency audit confirms no active
+consumer still resolves or imports TextForSpeech.

--- a/scripts/repo-maintenance/release.sh
+++ b/scripts/repo-maintenance/release.sh
@@ -273,7 +273,8 @@ defer_remote_ci_if_requested() {
   log "Remote CI mode is defer, so release.sh is pausing after local validation, branch push, PR creation, and initial check discovery."
   log "Release is not complete yet. Let GitHub finish CI for PR #$pr_number, then continue from branch $branch_name with:"
   log "  bash scripts/repo-maintenance/release.sh --mode standard --version $RELEASE_TAG"
-  log "Codex should use a native thread Timer/Wakeup or heartbeat automation for this wait when available, then resume by checking $pr_url and rerunning the command above instead of leaving a shell script open to poll GitHub."
+  log "Codex should create a same-thread heartbeat automation for this wait when available, then resume by checking $pr_url and rerunning the command above instead of leaving a shell script open to poll GitHub."
+  log "The heartbeat should also wait for review-bot status contexts such as CodeRabbit to finish before merging; pending review contexts are not a clean merge signal."
   return 0
 }
 


### PR DESCRIPTION
## Summary

- move Markdown table speech projection from the Server hook into `SpeakSwiftlyNormalization`
- preserve escaped pipes and ordinary non-table pipe prose
- add full-pipeline and malformed-table coverage
- migrate the complete unfinished TextForSpeech roadmap into Milestone 35 and canonical issues

Refs #111 — completes the shared-normalizer implementation; keep the issue open until downstream adoption removes the temporary Server hook.

## Verification

- `swift test --filter MarkdownAndURLNormalizationTests` — 21 passed
- `swift test --filter SpeakSwiftlyNormalizationTests` — 122 passed
- repository-maintenance validation — passed
- SwiftFormat and SwiftLint — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown tables are now converted into clear, labeled spoken text.
  * Table headers and row values are presented naturally, including support for escaped pipe characters.

* **Bug Fixes**
  * Malformed or non-table Markdown remains unchanged.
  * Raw table formatting and inline-code markers are removed from speech output when appropriate.

* **Documentation**
  * Updated normalization guidance and roadmap migration documentation to describe Markdown table handling and related progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->