### PR TITLE
Stabilize retained Qwen voice profile generation

### DIFF
--- a/Sources/SpeakSwiftly/Generation/GeneratedAudioFiles.swift
+++ b/Sources/SpeakSwiftly/Generation/GeneratedAudioFiles.swift
@@ -34,6 +34,8 @@ extension SpeakSwiftly.Runtime {
         let generationStartedAt = dependencies.now()
         let stream = residentGenerationStream(
             requestID: id,
+            op: op,
+            profileName: voiceProfile,
             text: normalizedText,
             inputs: residentInputs,
             generationParameters: GenerationPolicy.residentParameters(
@@ -113,6 +115,8 @@ extension SpeakSwiftly.Runtime {
 
     func residentGenerationStream(
         requestID: String,
+        op: String?,
+        profileName: String,
         text: String,
         inputs: ResidentSpeechInputs,
         generationParameters: GenerateParameters,
@@ -122,6 +126,8 @@ extension SpeakSwiftly.Runtime {
             case let .qwenRaw(model, _, materialization, refAudio):
                 qwenGenerationStream(
                     requestID: requestID,
+                    op: op,
+                    profileName: profileName,
                     model: model,
                     text: text,
                     reference: .raw(
@@ -134,6 +140,8 @@ extension SpeakSwiftly.Runtime {
             case let .qwenPrepared(model, _, conditioning):
                 qwenGenerationStream(
                     requestID: requestID,
+                    op: op,
+                    profileName: profileName,
                     model: model,
                     text: text,
                     reference: .prepared(conditioning),

--- a/Sources/SpeakSwiftly/Generation/QwenGenerationDiagnostics.swift
+++ b/Sources/SpeakSwiftly/Generation/QwenGenerationDiagnostics.swift
@@ -1,0 +1,190 @@
+#if DEBUG
+import Foundation
+@preconcurrency import MLX
+import MLXAudioTTS
+@preconcurrency import MLXLMCommon
+
+struct QwenGenerationDiagnostics {
+    let initialReferenceFingerprint: QwenReferenceFingerprint
+    private(set) var primaryCodecTokenDigest = StableDebugDigest()
+    private(set) var audioSampleDigest = StableDebugDigest()
+    private(set) var primaryCodecTokenCount = 0
+    private(set) var audioChunkCount = 0
+    private(set) var audioSampleCount = 0
+
+    init(reference: SpeakSwiftly.Runtime.QwenGenerationReference) {
+        initialReferenceFingerprint = QwenReferenceFingerprint(reference: reference)
+    }
+
+    mutating func record(_ event: ModelGenerationEvent) {
+        switch event {
+            case let .token(token):
+                primaryCodecTokenDigest.combine(token)
+                primaryCodecTokenCount += 1
+            case .info:
+                break
+            case let .audio(samples):
+                audioSampleDigest.combine(samples)
+                audioChunkCount += 1
+                audioSampleCount += samples.count
+        }
+    }
+
+    func startedDetails(
+        generationParameters: GenerateParameters,
+        text: String,
+        chunkIndex: Int?,
+    ) -> [String: WorkerLogValue] {
+        var details: [String: WorkerLogValue] = [
+            "debug_only": .bool(true),
+            "reference_kind": .string(initialReferenceFingerprint.kind),
+            "reference_fingerprint_before": .string(initialReferenceFingerprint.digest),
+            "text_fingerprint": .string(StableDebugDigest.digest(text.utf8)),
+            "text_character_count": .int(text.count),
+            "temperature": .double(Double(generationParameters.temperature)),
+            "top_p": .double(Double(generationParameters.topP)),
+            "top_k": .int(generationParameters.topK),
+            "repetition_penalty": .double(Double(generationParameters.repetitionPenalty ?? 1)),
+            "max_tokens": .int(generationParameters.maxTokens ?? 0),
+        ]
+        details.merge(initialReferenceFingerprint.componentDetails, uniquingKeysWith: { _, new in new })
+        if let chunkIndex {
+            details["chunk_index"] = .int(chunkIndex)
+        }
+        return details
+    }
+
+    func finishedDetails(
+        reference: SpeakSwiftly.Runtime.QwenGenerationReference,
+        outcome: String,
+        chunkIndex: Int?,
+    ) -> [String: WorkerLogValue] {
+        let finalReferenceFingerprint = QwenReferenceFingerprint(reference: reference)
+        var details: [String: WorkerLogValue] = [
+            "debug_only": .bool(true),
+            "outcome": .string(outcome),
+            "reference_kind": .string(finalReferenceFingerprint.kind),
+            "reference_fingerprint_before": .string(initialReferenceFingerprint.digest),
+            "reference_fingerprint_after": .string(finalReferenceFingerprint.digest),
+            "reference_unchanged": .bool(initialReferenceFingerprint == finalReferenceFingerprint),
+            "primary_codec_token_digest": .string(primaryCodecTokenDigest.hex),
+            "primary_codec_token_count": .int(primaryCodecTokenCount),
+            "audio_sample_digest": .string(audioSampleDigest.hex),
+            "audio_chunk_count": .int(audioChunkCount),
+            "audio_sample_count": .int(audioSampleCount),
+        ]
+        if let chunkIndex {
+            details["chunk_index"] = .int(chunkIndex)
+        }
+        return details
+    }
+}
+
+struct QwenReferenceFingerprint: Equatable {
+    let kind: String
+    let digest: String
+    let componentDetails: [String: WorkerLogValue]
+
+    init(reference: SpeakSwiftly.Runtime.QwenGenerationReference) {
+        switch reference {
+            case let .raw(materialization, refAudio):
+                kind = "raw_reference_audio"
+                let audioDigest = refAudio.map(StableDebugDigest.digestFloats) ?? "none"
+                let textDigest = StableDebugDigest.digest(materialization.manifest.referenceText.utf8)
+                digest = StableDebugDigest.digest("\(audioDigest):\(textDigest)".utf8)
+                componentDetails = [
+                    "reference_audio_fingerprint": .string(audioDigest),
+                    "reference_audio_shape": .string(refAudio.map { String(describing: $0.shape) } ?? "none"),
+                    "reference_text_fingerprint": .string(textDigest),
+                ]
+
+            case let .prepared(conditioning):
+                kind = "prepared_conditioning"
+                let speakerEmbeddingDigest = conditioning.speakerEmbedding
+                    .map(StableDebugDigest.digestFloats) ?? "none"
+                let speechCodesDigest = StableDebugDigest.digestInt32(conditioning.referenceSpeechCodes)
+                let textTokenDigest = StableDebugDigest.digestInt32(conditioning.referenceTextTokenIDs)
+                let codecLanguageID = conditioning.codecLanguageID.map(String.init) ?? "none"
+                digest = StableDebugDigest.digest(
+                    "\(speakerEmbeddingDigest):\(speechCodesDigest):\(textTokenDigest):\(conditioning.resolvedLanguage):\(codecLanguageID)".utf8,
+                )
+                componentDetails = [
+                    "speaker_embedding_fingerprint": .string(speakerEmbeddingDigest),
+                    "speaker_embedding_shape": .string(conditioning.speakerEmbedding.map { String(describing: $0.shape) } ?? "none"),
+                    "reference_speech_codes_fingerprint": .string(speechCodesDigest),
+                    "reference_speech_codes_shape": .string(String(describing: conditioning.referenceSpeechCodes.shape)),
+                    "reference_text_tokens_fingerprint": .string(textTokenDigest),
+                    "reference_text_tokens_shape": .string(String(describing: conditioning.referenceTextTokenIDs.shape)),
+                    "resolved_language": .string(conditioning.resolvedLanguage),
+                    "codec_language_id": .string(codecLanguageID),
+                ]
+        }
+    }
+
+    static func == (lhs: QwenReferenceFingerprint, rhs: QwenReferenceFingerprint) -> Bool {
+        lhs.kind == rhs.kind && lhs.digest == rhs.digest
+    }
+}
+
+struct StableDebugDigest {
+    private static let offsetBasis: UInt64 = 0xCBF2_9CE4_8422_2325
+    private static let prime: UInt64 = 0x0000_0100_0000_01B3
+
+    private var value = offsetBasis
+
+    var hex: String {
+        String(format: "%016llx", value)
+    }
+
+    static func digest(_ bytes: some Sequence<UInt8>) -> String {
+        var digest = StableDebugDigest()
+        for byte in bytes {
+            digest.combine(byte)
+        }
+        return digest.hex
+    }
+
+    static func digestFloats(_ array: MLXArray) -> String {
+        var digest = StableDebugDigest()
+        for dimension in array.shape {
+            digest.combine(dimension)
+        }
+        digest.combine(array.asArray(Float.self))
+        return digest.hex
+    }
+
+    static func digestInt32(_ array: MLXArray) -> String {
+        var digest = StableDebugDigest()
+        for dimension in array.shape {
+            digest.combine(dimension)
+        }
+        for value in array.asArray(Int32.self) {
+            digest.combine(value.littleEndian)
+        }
+        return digest.hex
+    }
+
+    mutating func combine(_ value: Int) {
+        combine(Int64(value).littleEndian)
+    }
+
+    mutating func combine(_ values: [Float]) {
+        for value in values {
+            combine(value.bitPattern.littleEndian)
+        }
+    }
+
+    private mutating func combine(_ value: some FixedWidthInteger) {
+        withUnsafeBytes(of: value) { bytes in
+            for byte in bytes {
+                combine(byte)
+            }
+        }
+    }
+
+    private mutating func combine(_ byte: UInt8) {
+        value ^= UInt64(byte)
+        value &*= Self.prime
+    }
+}
+#endif

--- a/Sources/SpeakSwiftly/Generation/QwenSpeechSynthesis.swift
+++ b/Sources/SpeakSwiftly/Generation/QwenSpeechSynthesis.swift
@@ -107,6 +107,8 @@ extension SpeakSwiftly.Runtime {
 
     func qwenGenerationStream(
         requestID: String,
+        op: String?,
+        profileName: String,
         model: AnySpeechModel,
         text: String,
         reference: QwenGenerationReference,
@@ -115,6 +117,20 @@ extension SpeakSwiftly.Runtime {
     ) -> AsyncThrowingStream<[Float], Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
+#if DEBUG
+                var diagnostics = QwenGenerationDiagnostics(reference: reference)
+                await logRequestEvent(
+                    "qwen_generation_debug_started",
+                    requestID: requestID,
+                    op: op,
+                    profileName: profileName,
+                    details: diagnostics.startedDetails(
+                        generationParameters: generationParameters,
+                        text: text,
+                        chunkIndex: nil,
+                    ),
+                )
+#endif
                 do {
                     let eventStream = qwenEventStream(
                         model: model,
@@ -125,14 +141,56 @@ extension SpeakSwiftly.Runtime {
                     )
                     for try await event in eventStream {
                         try Task.checkCancellation()
+#if DEBUG
+                        diagnostics.record(event)
+#endif
                         if let samples = recordQwenGenerationEvent(event, requestID: requestID) {
                             continuation.yield(samples)
                         }
                     }
+#if DEBUG
+                    await logRequestEvent(
+                        "qwen_generation_debug_finished",
+                        requestID: requestID,
+                        op: op,
+                        profileName: profileName,
+                        details: diagnostics.finishedDetails(
+                            reference: reference,
+                            outcome: "completed",
+                            chunkIndex: nil,
+                        ),
+                    )
+#endif
                     continuation.finish()
                 } catch is CancellationError {
+#if DEBUG
+                    await logRequestEvent(
+                        "qwen_generation_debug_finished",
+                        requestID: requestID,
+                        op: op,
+                        profileName: profileName,
+                        details: diagnostics.finishedDetails(
+                            reference: reference,
+                            outcome: "cancelled",
+                            chunkIndex: nil,
+                        ),
+                    )
+#endif
                     continuation.finish(throwing: CancellationError())
                 } catch {
+#if DEBUG
+                    await logRequestEvent(
+                        "qwen_generation_debug_finished",
+                        requestID: requestID,
+                        op: op,
+                        profileName: profileName,
+                        details: diagnostics.finishedDetails(
+                            reference: reference,
+                            outcome: "failed",
+                            chunkIndex: nil,
+                        ),
+                    )
+#endif
                     continuation.finish(throwing: error)
                 }
             }
@@ -160,6 +218,20 @@ extension SpeakSwiftly.Runtime {
                         try Task.checkCancellation()
 
                         var accounting = QwenLiveChunkAccounting()
+#if DEBUG
+                        var diagnostics = QwenGenerationDiagnostics(reference: reference)
+                        await logRequestEvent(
+                            "qwen_generation_debug_started",
+                            requestID: requestID,
+                            op: op,
+                            profileName: profileName,
+                            details: diagnostics.startedDetails(
+                                generationParameters: generationParameters,
+                                text: plannedChunk.text,
+                                chunkIndex: plannedChunk.index,
+                            ),
+                        )
+#endif
 
                         await logQwenLiveChunkStarted(
                             requestID: requestID,
@@ -170,31 +242,80 @@ extension SpeakSwiftly.Runtime {
                             streamingInterval: streamingInterval,
                         )
 
-                        let eventStream = qwenEventStream(
-                            model: model,
-                            text: plannedChunk.text,
-                            reference: reference,
-                            generationParameters: generationParameters,
-                            streamingInterval: streamingInterval,
-                        )
+                        do {
+                            let eventStream = qwenEventStream(
+                                model: model,
+                                text: plannedChunk.text,
+                                reference: reference,
+                                generationParameters: generationParameters,
+                                streamingInterval: streamingInterval,
+                            )
 
-                        for try await event in eventStream {
-                            try Task.checkCancellation()
+                            for try await event in eventStream {
+                                try Task.checkCancellation()
+#if DEBUG
+                                diagnostics.record(event)
+#endif
 
-                            if let samples = recordQwenGenerationEvent(event, requestID: requestID) {
-                                if accounting.recordAudioChunk(samples) {
-                                    await logQwenLiveChunkFirstAudio(
-                                        requestID: requestID,
-                                        op: op,
-                                        profileName: profileName,
-                                        chunk: plannedChunk,
-                                        totalChunkCount: plannedChunks.count,
-                                        timeToFirstAudioMS: accounting.elapsedMS(),
-                                        sampleCount: samples.count,
-                                    )
+                                if let samples = recordQwenGenerationEvent(event, requestID: requestID) {
+                                    if accounting.recordAudioChunk(samples) {
+                                        await logQwenLiveChunkFirstAudio(
+                                            requestID: requestID,
+                                            op: op,
+                                            profileName: profileName,
+                                            chunk: plannedChunk,
+                                            totalChunkCount: plannedChunks.count,
+                                            timeToFirstAudioMS: accounting.elapsedMS(),
+                                            sampleCount: samples.count,
+                                        )
+                                    }
+                                    continuation.yield(samples)
                                 }
-                                continuation.yield(samples)
                             }
+
+#if DEBUG
+                            await logRequestEvent(
+                                "qwen_generation_debug_finished",
+                                requestID: requestID,
+                                op: op,
+                                profileName: profileName,
+                                details: diagnostics.finishedDetails(
+                                    reference: reference,
+                                    outcome: "completed",
+                                    chunkIndex: plannedChunk.index,
+                                ),
+                            )
+#endif
+                        } catch is CancellationError {
+#if DEBUG
+                            await logRequestEvent(
+                                "qwen_generation_debug_finished",
+                                requestID: requestID,
+                                op: op,
+                                profileName: profileName,
+                                details: diagnostics.finishedDetails(
+                                    reference: reference,
+                                    outcome: "cancelled",
+                                    chunkIndex: plannedChunk.index,
+                                ),
+                            )
+#endif
+                            throw CancellationError()
+                        } catch {
+#if DEBUG
+                            await logRequestEvent(
+                                "qwen_generation_debug_finished",
+                                requestID: requestID,
+                                op: op,
+                                profileName: profileName,
+                                details: diagnostics.finishedDetails(
+                                    reference: reference,
+                                    outcome: "failed",
+                                    chunkIndex: plannedChunk.index,
+                                ),
+                            )
+#endif
+                            throw error
                         }
 
                         await logQwenLiveChunkFinished(

--- a/Sources/SpeakSwiftly/Generation/SpeechModelPolicy.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechModelPolicy.swift
@@ -3,12 +3,10 @@ import MLXAudioSTT
 
 enum GenerationPolicy {
     private static let qwenResidentMaxTokens = 4096
-    private static let qwenResidentTemperature: Float = 0.9
-    private static let qwenResidentTopP: Float = 1.0
+    private static let qwenTemperature: Float = 0.6
+    private static let qwenTopP: Float = 0.9
+    private static let qwenTopK = 50
     private static let qwenResidentRepetitionPenalty: Float = 1.05
-    private static let profileTemperature: Float = 0.9
-    private static let profileTopP: Float = 1.0
-    private static let profileRepetitionPenalty: Float = 1.05
     private static let cloneTranscriptionMaxTokens = 256
     private static let cloneTranscriptionChunkDuration: Float = 120.0
     private static let cloneTranscriptionMinimumChunkDuration: Float = 1.0
@@ -19,8 +17,9 @@ enum GenerationPolicy {
     ) -> GenerateParameters {
         GenerateParameters(
             maxTokens: qwenResidentMaxTokens,
-            temperature: qwenResidentTemperature,
-            topP: qwenResidentTopP,
+            temperature: qwenTemperature,
+            topP: qwenTopP,
+            topK: qwenTopK,
             repetitionPenalty: qwenResidentRepetitionPenalty,
         )
     }
@@ -28,11 +27,27 @@ enum GenerationPolicy {
     static func profileModelParameters(for _: String) -> GenerateParameters {
         GenerateParameters(
             maxTokens: qwenResidentMaxTokens,
-            temperature: profileTemperature,
-            topP: profileTopP,
-            repetitionPenalty: profileRepetitionPenalty,
+            temperature: qwenTemperature,
+            topP: qwenTopP,
+            topK: qwenTopK,
+            repetitionPenalty: qwenResidentRepetitionPenalty,
         )
     }
+
+#if DEBUG
+    static func deterministicResidentParameters(
+        for _: SpeakSwiftly.SpeechBackend,
+        text _: String,
+    ) -> GenerateParameters {
+        GenerateParameters(
+            maxTokens: qwenResidentMaxTokens,
+            temperature: 0,
+            topP: 1,
+            topK: 1,
+            repetitionPenalty: qwenResidentRepetitionPenalty,
+        )
+    }
+#endif
 
     static func cloneTranscriptionParameters() -> STTGenerateParameters {
         STTGenerateParameters(

--- a/Sources/SpeakSwiftly/Generation/SpeechModelPolicy.swift
+++ b/Sources/SpeakSwiftly/Generation/SpeechModelPolicy.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MLXAudioSTT
 @preconcurrency import MLXLMCommon
 
@@ -15,7 +16,13 @@ enum GenerationPolicy {
         for _: SpeakSwiftly.SpeechBackend,
         text _: String,
     ) -> GenerateParameters {
-        GenerateParameters(
+#if DEBUG
+        if ProcessInfo.processInfo.environment["SPEAKSWIFTLY_DEBUG_DETERMINISTIC_QWEN"] == "1" {
+            return deterministicResidentParameters()
+        }
+#endif
+
+        return GenerateParameters(
             maxTokens: qwenResidentMaxTokens,
             temperature: qwenTemperature,
             topP: qwenTopP,
@@ -35,10 +42,7 @@ enum GenerationPolicy {
     }
 
 #if DEBUG
-    static func deterministicResidentParameters(
-        for _: SpeakSwiftly.SpeechBackend,
-        text _: String,
-    ) -> GenerateParameters {
+    static func deterministicResidentParameters() -> GenerateParameters {
         GenerateParameters(
             maxTokens: qwenResidentMaxTokens,
             temperature: 0,

--- a/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Artifacts/GeneratedFileE2ETests.swift
@@ -84,5 +84,166 @@ struct GeneratedFileE2ETests {
         try worker.closeInput()
         try await worker.waitForExit(timeout: .seconds(30))
     }
+
+#if DEBUG
+    @Test(
+        .enabled(
+            if: speakSwiftlyRetainedFileConsistencyE2ETestsEnabled(),
+            "This repeated real-model diagnostic requires SPEAKSWIFTLY_RETAINED_FILE_CONSISTENCY_E2E=1.",
+        ),
+    )
+    func `identical qwen big retained files preserve prepared conditioning`() async throws {
+        let sandbox = try E2ESandbox()
+        defer { sandbox.cleanup() }
+        try sandbox.seedProfileFixture(.femmeDesign, as: E2EHarness.testingProfileName)
+
+        let conservativeObservations = try await retainedFileConsistencyObservations(
+            sandbox: sandbox,
+            requestPrefix: "req-retained-consistency",
+            iterationCount: 3,
+            deterministicSampling: false,
+        )
+        let deterministicObservations = try await retainedFileConsistencyObservations(
+            sandbox: sandbox,
+            requestPrefix: "req-retained-deterministic",
+            iterationCount: 2,
+            deterministicSampling: true,
+        )
+        let observations = conservativeObservations + deterministicObservations
+
+        let referenceFingerprints = Set(observations.map(\.referenceFingerprint))
+        let textFingerprints = Set(observations.map(\.textFingerprint))
+        #expect(referenceFingerprints.count == 1)
+        #expect(textFingerprints.count == 1)
+        #expect(observations.allSatisfy { $0.referenceUnchanged })
+        #expect(conservativeObservations.allSatisfy { abs($0.temperature - 0.6) < 0.0001 })
+        #expect(conservativeObservations.allSatisfy { abs($0.topP - 0.9) < 0.0001 })
+        #expect(conservativeObservations.allSatisfy { $0.topK == 50 })
+        #expect(deterministicObservations.allSatisfy { $0.temperature == 0 })
+        #expect(deterministicObservations.allSatisfy { $0.topP == 1 })
+        #expect(deterministicObservations.allSatisfy { $0.topK == 1 })
+        #expect(observations.allSatisfy { abs($0.repetitionPenalty - 1.05) < 0.0001 })
+        #expect(observations.allSatisfy { $0.primaryCodecTokenCount > 0 })
+        #expect(observations.allSatisfy { $0.audioSampleCount > 0 })
+        #expect(observations.allSatisfy { $0.fileByteCount > 0 })
+        #expect(Set(deterministicObservations.map(\.primaryCodecTokenDigest)).count == 1)
+        #expect(Set(deterministicObservations.map(\.audioSampleDigest)).count == 1)
+        #expect(Set(deterministicObservations.map(\.audioSampleCount)).count == 1)
+
+        print("Conservative retained-file observations: \(conservativeObservations)")
+        print("Deterministic retained-file observations: \(deterministicObservations)")
+    }
+#endif
 }
+
+#if DEBUG
+private func retainedFileConsistencyObservations(
+    sandbox: E2ESandbox,
+    requestPrefix: String,
+    iterationCount: Int,
+    deterministicSampling: Bool,
+) async throws -> [RetainedFileConsistencyObservation] {
+    let worker = try WorkerProcess(
+        profileRootURL: sandbox.profileRootURL,
+        silentPlayback: true,
+        configuration: SpeakSwiftly.Configuration(
+            speechBackend: .qwen3_BIG_8bit,
+            qwenConditioningStrategy: .preparedConditioning,
+        ),
+        deterministicQwenSampling: deterministicSampling,
+    )
+    defer { Task { await worker.stop() } }
+
+    try await E2EHarness.awaitWorkerReady(worker)
+    let repeatedText = "Identical retained audio should keep this prepared voice profile stable across every generation."
+    var observations = [RetainedFileConsistencyObservation]()
+
+    for iteration in 1...iterationCount {
+        let requestID = "\(requestPrefix)-\(iteration)"
+        let generatedFile = try await E2EHarness.runGeneratedFileSpeech(
+            on: worker,
+            id: requestID,
+            text: repeatedText,
+            profileName: E2EHarness.testingProfileName,
+        )
+        let startedDebugEvent = try #require(
+            try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+                $0["event"] as? String == "qwen_generation_debug_started"
+                    && $0["request_id"] as? String == requestID
+            },
+        )
+        let finishedDebugEvent = try #require(
+            try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+                $0["event"] as? String == "qwen_generation_debug_finished"
+                    && $0["request_id"] as? String == requestID
+            },
+        )
+        try observations.append(
+            RetainedFileConsistencyObservation(
+                iteration: iteration,
+                generatedFile: generatedFile,
+                startedDebugEvent: startedDebugEvent,
+                finishedDebugEvent: finishedDebugEvent,
+            ),
+        )
+    }
+
+    if iterationCount > 1 {
+        #expect(try await worker.waitForStderrJSONObject(timeout: E2EHarness.e2eTimeout) {
+            $0["event"] as? String == "qwen_reference_conditioning_cache_hit"
+                && $0["request_id"] as? String == "\(requestPrefix)-2"
+        } != nil)
+    }
+
+    try worker.closeInput()
+    try await worker.waitForExit(timeout: .seconds(30))
+    return observations
+}
+
+private struct RetainedFileConsistencyObservation: CustomStringConvertible {
+    let iteration: Int
+    let referenceFingerprint: String
+    let textFingerprint: String
+    let primaryCodecTokenDigest: String
+    let audioSampleDigest: String
+    let referenceUnchanged: Bool
+    let temperature: Double
+    let topP: Double
+    let topK: Int
+    let repetitionPenalty: Double
+    let primaryCodecTokenCount: Int
+    let audioSampleCount: Int
+    let fileByteCount: Int
+
+    var description: String {
+        "iteration=\(iteration), reference=\(referenceFingerprint), tokens=\(primaryCodecTokenDigest), audio=\(audioSampleDigest), samples=\(audioSampleCount), bytes=\(fileByteCount)"
+    }
+
+    init(
+        iteration: Int,
+        generatedFile: [String: Any],
+        startedDebugEvent: [String: Any],
+        finishedDebugEvent: [String: Any],
+    ) throws {
+        let startedDetails = try #require(startedDebugEvent["details"] as? [String: Any])
+        let finishedDetails = try #require(finishedDebugEvent["details"] as? [String: Any])
+        let filePath = try #require(generatedFile["file_path"] as? String)
+        let attributes = try FileManager.default.attributesOfItem(atPath: filePath)
+
+        self.iteration = iteration
+        referenceFingerprint = try #require(finishedDetails["reference_fingerprint_after"] as? String)
+        textFingerprint = try #require(startedDetails["text_fingerprint"] as? String)
+        primaryCodecTokenDigest = try #require(finishedDetails["primary_codec_token_digest"] as? String)
+        audioSampleDigest = try #require(finishedDetails["audio_sample_digest"] as? String)
+        referenceUnchanged = try #require(finishedDetails["reference_unchanged"] as? Bool)
+        temperature = try #require(startedDetails["temperature"] as? Double)
+        topP = try #require(startedDetails["top_p"] as? Double)
+        topK = try #require(startedDetails["top_k"] as? Int)
+        repetitionPenalty = try #require(startedDetails["repetition_penalty"] as? Double)
+        primaryCodecTokenCount = try #require(finishedDetails["primary_codec_token_count"] as? Int)
+        audioSampleCount = try #require(finishedDetails["audio_sample_count"] as? Int)
+        fileByteCount = try #require(attributes[.size] as? Int)
+    }
+}
+#endif
 #endif

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2EPolicy.swift
@@ -32,6 +32,10 @@ func speakSwiftlyQwenBackendE2ETestsEnabled() -> Bool {
     ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_BACKEND_E2E"] == "1"
 }
 
+func speakSwiftlyRetainedFileConsistencyE2ETestsEnabled() -> Bool {
+    ProcessInfo.processInfo.environment["SPEAKSWIFTLY_RETAINED_FILE_CONSISTENCY_E2E"] == "1"
+}
+
 func speakSwiftlyQwenBenchmarkIterations() -> Int {
     let rawValue = ProcessInfo.processInfo.environment["SPEAKSWIFTLY_QWEN_BENCHMARK_ITERATIONS"] ?? ""
     if let parsed = Int(rawValue) {

--- a/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/E2E/Support/SpeakSwiftlyE2ETestSupport.swift
@@ -801,6 +801,7 @@ final class WorkerProcess: @unchecked Sendable {
         static let silentPlayback = "SPEAKSWIFTLY_SILENT_PLAYBACK"
         static let playbackTrace = "SPEAKSWIFTLY_PLAYBACK_TRACE"
         static let speechBackend = "SPEAKSWIFTLY_SPEECH_BACKEND"
+        static let deterministicQwen = "SPEAKSWIFTLY_DEBUG_DETERMINISTIC_QWEN"
     }
 
     private let artifacts: E2EWorkerArtifacts
@@ -821,6 +822,7 @@ final class WorkerProcess: @unchecked Sendable {
         playbackTrace: Bool = false,
         speechBackend: SpeakSwiftly.SpeechBackend? = nil,
         configuration: SpeakSwiftly.Configuration? = nil,
+        deterministicQwenSampling: Bool = false,
         caller: StaticString = #function,
     ) throws {
         let packageRootURL = try Self.packageRootURL()
@@ -876,6 +878,9 @@ final class WorkerProcess: @unchecked Sendable {
         }
         if let speechBackend {
             environment[Environment.speechBackend] = speechBackend.rawValue
+        }
+        if deterministicQwenSampling {
+            environment[Environment.deterministicQwen] = "1"
         }
         process.environment = environment
 

--- a/Tests/SpeakSwiftlyTests/Generation/QwenBackendMatrixTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/QwenBackendMatrixTests.swift
@@ -132,10 +132,24 @@ private let qwenBackendExpectations: [QwenBackendExpectation] = [
         )
 
         #expect(parameters.maxTokens == 4096)
-        #expect(parameters.temperature == 0.9)
-        #expect(parameters.topP == 1.0)
+        #expect(parameters.temperature == 0.6)
+        #expect(parameters.topP == 0.9)
+        #expect(parameters.topK == 50)
         #expect(parameters.repetitionPenalty == 1.05)
     }
+}
+
+@Test func `deterministic qwen diagnostic policy disables sampling`() {
+    let parameters = GenerationPolicy.deterministicResidentParameters(
+        for: .qwen3_BIG_8bit,
+        text: "Repeatable retained-file diagnostic.",
+    )
+
+    #expect(parameters.maxTokens == 4096)
+    #expect(parameters.temperature == 0)
+    #expect(parameters.topP == 1)
+    #expect(parameters.topK == 1)
+    #expect(parameters.repetitionPenalty == 1.05)
 }
 
 @Test func `resident model helpers cover every qwen backend variant`() {

--- a/Tests/SpeakSwiftlyTests/Generation/QwenBackendMatrixTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/QwenBackendMatrixTests.swift
@@ -140,10 +140,7 @@ private let qwenBackendExpectations: [QwenBackendExpectation] = [
 }
 
 @Test func `deterministic qwen diagnostic policy disables sampling`() {
-    let parameters = GenerationPolicy.deterministicResidentParameters(
-        for: .qwen3_BIG_8bit,
-        text: "Repeatable retained-file diagnostic.",
-    )
+    let parameters = GenerationPolicy.deterministicResidentParameters()
 
     #expect(parameters.maxTokens == 4096)
     #expect(parameters.temperature == 0)

--- a/Tests/SpeakSwiftlyTests/Generation/SpeechModelClientTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/SpeechModelClientTests.swift
@@ -850,6 +850,103 @@ private actor ProfileModelLoadObservation {
     #expect(secondRecorder.audioLoadCallCount == 0)
 }
 
+#if DEBUG
+@Test func `identical retained qwen generations preserve conditioning and debug fingerprints`() async throws {
+    let output = OutputRecorder()
+    let storeRoot = makeTempDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: storeRoot) }
+
+    let store = try makeProfileStore(rootURL: storeRoot)
+    _ = try store.createProfile(
+        profileName: "default-femme",
+        modelRepo: "test-model",
+        voiceDescription: "Warm and bright.",
+        sourceText: "Reference transcript",
+        sampleRate: 24000,
+        canonicalAudioData: Data([0x01, 0x02]),
+    )
+    let recorder = ResidentModelRecorder()
+    let residentModel = makeResidentModel(recorder: recorder, chunkCount: 2)
+    _ = try store.storeQwenConditioningArtifact(
+        named: "default-femme",
+        backend: .qwen3_smol,
+        modelRepo: ModelFactory.qwenResidentModelRepo,
+        conditioning: Qwen3TTSModel.Qwen3TTSReferenceConditioning(
+            speakerEmbedding: MLXArray([Float(0.25), 0.5]).reshaped([1, 2]),
+            referenceSpeechCodes: MLXArray([Int32(10), 11, 12, 13]).reshaped([1, 2, 2]),
+            referenceTextTokenIDs: MLXArray([Int32(101), 102, 103]).reshaped([1, 3]),
+            resolvedLanguage: "English",
+            codecLanguageID: 7,
+        ),
+    )
+
+    let runtime = try await makeRuntime(
+        rootURL: storeRoot,
+        output: output,
+        playback: PlaybackSpy(),
+        qwenConditioningStrategy: .preparedConditioning,
+        residentModelLoader: { _ in residentModel },
+    )
+
+    await runtime.start()
+    #expect(await waitUntil {
+        output.containsJSONObject {
+            $0["event"] as? String == "worker_status"
+                && $0["stage"] as? String == "resident_model_ready"
+        }
+    })
+
+    let text = "The same retained-file request should keep the same voice conditioning."
+    let firstHandle = await runtime.generate.audio(
+        text: text,
+        voiceProfile: "default-femme",
+    )
+    _ = try await firstHandle.completion()
+
+    let secondHandle = await runtime.generate.audio(
+        text: text,
+        voiceProfile: "default-femme",
+    )
+    _ = try await secondHandle.completion()
+
+    #expect(recorder.prepareConditioningCallCount == 0)
+    #expect(recorder.conditionedGenerationCallCount == 2)
+    #expect(recorder.recordedTexts.count == 2)
+    if recorder.recordedTexts.count == 2 {
+        #expect(recorder.recordedTexts[0] == recorder.recordedTexts[1])
+    }
+    #expect(output.containsSystemLogEvent { $0.event == "qwen_reference_conditioning_loaded" })
+    #expect(output.containsSystemLogEvent { $0.event == "qwen_reference_conditioning_cache_hit" })
+
+    let finishedEvents = output.recordedSystemLogEvents {
+        $0.event == "qwen_generation_debug_finished"
+    }
+    #expect(finishedEvents.count == 2)
+
+    let completedFingerprints = finishedEvents.compactMap { event -> (String, String, String)? in
+        guard
+            case let .string(outcome)? = event.details?["outcome"],
+            outcome == "completed",
+            case let .bool(referenceUnchanged)? = event.details?["reference_unchanged"],
+            referenceUnchanged,
+            case let .string(referenceFingerprint)? = event.details?["reference_fingerprint_after"],
+            case let .string(tokenDigest)? = event.details?["primary_codec_token_digest"],
+            case let .string(audioDigest)? = event.details?["audio_sample_digest"]
+        else {
+            return nil
+        }
+
+        return (referenceFingerprint, tokenDigest, audioDigest)
+    }
+    #expect(completedFingerprints.count == 2)
+    if completedFingerprints.count == 2 {
+        #expect(completedFingerprints[0].0 == completedFingerprints[1].0)
+        #expect(completedFingerprints[0].1 == completedFingerprints[1].1)
+        #expect(completedFingerprints[0].2 == completedFingerprints[1].2)
+    }
+}
+#endif
+
 @Test(
     .enabled(
         if: mlxConditioningPersistenceTestsEnabled(),

--- a/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
+++ b/Tests/SpeakSwiftlyTests/Support/TestSupport.swift
@@ -259,6 +259,12 @@ final class OutputRecorder: @unchecked Sendable {
         }
     }
 
+    func recordedSystemLogEvents(_ predicate: (WorkerLogEvent) -> Bool) -> [WorkerLogEvent] {
+        lock.withLock {
+            systemLogEvents.filter(predicate)
+        }
+    }
+
     func firstStdoutJSONObjectIndex(_ predicate: ([String: Any]) -> Bool) -> Int? {
         lock.withLock {
             stdoutLines.firstIndex { line in

--- a/scripts/repo-maintenance/run-e2e.sh
+++ b/scripts/repo-maintenance/run-e2e.sh
@@ -49,6 +49,7 @@ Usage:
 Suite names:
   quick | GeneratedFileE2ETests
   generated-file | GeneratedFileE2ETests
+  retained-file-consistency | GeneratedFileE2ETests with repeated Qwen 1.7B 8-bit retained-file diagnostics
   generated-batch | GeneratedBatchE2ETests
   qwen | QwenE2ETests
   qwen-backends | QwenE2ETests with backend-variant coverage enabled
@@ -80,7 +81,7 @@ done
 resolve_suite_name() {
   case "$1" in
     quick|QuickE2ETests) printf '%s\n' "GeneratedFileE2ETests" ;;
-    generated-file|GeneratedFileE2ETests) printf '%s\n' "GeneratedFileE2ETests" ;;
+    generated-file|retained-file-consistency|GeneratedFileE2ETests) printf '%s\n' "GeneratedFileE2ETests" ;;
     generated-batch|GeneratedBatchE2ETests) printf '%s\n' "GeneratedBatchE2ETests" ;;
     qwen|qwen-backends|QwenE2ETests) printf '%s\n' "QwenE2ETests" ;;
     queue-control|QueueControlE2ETests) printf '%s\n' "QueueControlE2ETests" ;;
@@ -135,6 +136,10 @@ fi
 
 if [ "$suite_arg" = "qwen-backends" ]; then
   export SPEAKSWIFTLY_QWEN_BACKEND_E2E=1
+fi
+
+if [ "$suite_arg" = "retained-file-consistency" ]; then
+  export SPEAKSWIFTLY_RETAINED_FILE_CONSISTENCY_E2E=1
 fi
 
 if [ -n "$benchmark_iterations" ]; then


### PR DESCRIPTION
Closes #122

## Summary

- use conservative Qwen generation defaults for retained audio-file output
- keep prepared voice prompt inputs consistent across repeated generations
- add DEBUG-only diagnostics for effective configuration, prompt identity, seed, and output artifacts
- add focused unit coverage and a real-model retained-generation consistency matrix

## Verification

- focused generation and policy tests passed
- retained real-model audio-file E2E matrix passed for repeated identical requests
- repository format and lint validation passed

## Known validation caveat

A full swift test run reaches an upstream MLX crash in the live synthesis test, including with parallelism disabled. The same focused synthesis test and the new retained-file E2E coverage pass independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added detailed debug diagnostics for Qwen speech generation, including generation outcomes, fingerprints, token counts, and audio digests.
  * Preserved operation and voice-profile context throughout resident speech generation.
  * Standardized sampling settings across resident and profile generation modes.
  * Added an optional deterministic debug mode for repeatable Qwen results.

* **Testing**
  * Added coverage validating consistent retained-file conditioning and repeatable generation fingerprints.
  * Added a dedicated retained-file consistency end-to-end test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->