### PR TITLE
Add Higgs codec and serving comparison fixtures

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -524,6 +524,9 @@ Planned
   plain and control-tag prompt shapes.
 - [x] Add a no-weight Higgs Audio v3 synthetic delay-pattern fixture for
   eight-codebook row ordering and BOC/EOC placement.
+- [x] Add a no-weight Higgs Audio v3 codec/vocoder boundary fixture for bundled
+  codec prefix counts, decode-boundary constants, streaming chunk defaults, and
+  waveform metadata gates.
 
 ### Stage Notes
 
@@ -549,6 +552,10 @@ Planned
 - `docs/research/speech-pipelines/lanes/higgs-audio-v3/codebook-delay-fixture-2026-06-26.json` is
   the first checked-in no-weight parity artifact for eight-codebook
   delay-pattern layout.
+- `docs/research/speech-pipelines/lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json`
+  records the first no-weight codec/vocoder boundary artifact and keeps runtime
+  integration blocked until official serving comparison captures waveform
+  metadata.
 
 ### Exit Criteria
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -527,6 +527,9 @@ Planned
 - [x] Add a no-weight Higgs Audio v3 codec/vocoder boundary fixture for bundled
   codec prefix counts, decode-boundary constants, streaming chunk defaults, and
   waveform metadata gates.
+- [x] Start the no-weight Higgs Audio v3 official-serving comparison fixture
+  for archived 24 kHz PCM serving signals and remaining waveform metadata
+  gates.
 
 ### Stage Notes
 
@@ -556,6 +559,10 @@ Planned
   records the first no-weight codec/vocoder boundary artifact and keeps runtime
   integration blocked until official serving comparison captures waveform
   metadata.
+- `docs/research/speech-pipelines/lanes/higgs-audio-v3/official-serving-comparison-fixture-2026-06-29.json`
+  starts the no-weight official-serving comparison for the plain prompt and
+  keeps runtime integration blocked until an executed official serving request
+  captures decoded sample count, dtype, channel count, and container behavior.
 
 ### Exit Criteria
 

--- a/Tests/SpeakSwiftlyTests/Generation/HiggsAudio/HiggsAudioV3CodecVocoderBoundaryFixtureTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/HiggsAudio/HiggsAudioV3CodecVocoderBoundaryFixtureTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+
+@Test func `higgs audio v3 codec vocoder fixture pins source boundaries`() throws {
+    let fixture = try HiggsAudioV3CodecVocoderBoundaryFixture.load()
+
+    #expect(fixture.schemaVersion == 1)
+    #expect(fixture.createdAtUtc == "2026-06-28T00:00:00Z")
+    #expect(fixture.source.noModelWeightsDownloaded)
+    #expect(fixture.source.officialSources.codecVocoder.contains("model.safetensors.index.json bundled codec prefix"))
+    #expect(fixture.source.officialSources.outputContainer.contains("Boson create-speech API"))
+}
+
+@Test func `higgs audio v3 codec vocoder fixture pins bundled codec weight prefix`() throws {
+    let fixture = try HiggsAudioV3CodecVocoderBoundaryFixture.load()
+    let boundary = fixture.codecVocoderWeightBoundary
+
+    #expect(boundary.codecCheckpointPrefix == "tied.embedding.modality_embeddings.0.model.")
+    #expect(boundary.codecWeightEntryCount == 528)
+    #expect(boundary.totalWeightEntryCount == 927)
+    #expect(boundary.totalWeightSizeBytes == 8_489_763_794)
+    #expect(boundary.textBodyPrefix == "body.layers.")
+    #expect(boundary.textBodyWeightEntryCount == 396)
+    #expect(boundary.audioEmbeddingPrefix == "tied.embedding.modality_embeddings.0.embedding")
+    #expect(boundary.audioEmbeddingWeightEntryCount == 1)
+    #expect(boundary.separateTiedHeadWeightEntryCount == 0)
+    #expect(boundary.usefulBackendRequiresCodecVocoder)
+    #expect(boundary.codecWeightExamples.first == "tied.embedding.modality_embeddings.0.model.acoustic_decoder.block.0.conv_t1.bias")
+}
+
+@Test func `higgs audio v3 codec vocoder fixture pins decode boundary constants`() throws {
+    let fixture = try HiggsAudioV3CodecVocoderBoundaryFixture.load()
+    let boundary = fixture.codebookDecodeBoundary
+
+    #expect(boundary.rawCodesShape == [3, 8])
+    #expect(boundary.delayedCodesShape == [10, 8])
+    #expect(boundary.reversedCodesShape == [3, 8])
+    #expect(boundary.codebookAxisOrder == "frame_major_rows_codebook_columns")
+    #expect(boundary.bocId == 1024)
+    #expect(boundary.eocId == 1025)
+    #expect(boundary.filteringRule == "reverse_delay_pattern_then_remove_boc_eoc_markers_before_codec_decode")
+    #expect(boundary.sampleRateHz == 24000)
+    #expect(boundary.outputSampleCountKnown == false)
+    #expect(boundary.outputDtypeKnown == false)
+    #expect(boundary.outputChannelCountKnown == false)
+}
+
+@Test func `higgs audio v3 codec vocoder fixture blocks runtime promotion`() throws {
+    let fixture = try HiggsAudioV3CodecVocoderBoundaryFixture.load()
+
+    #expect(fixture.outputContainerBoundary.nonStreamingContainerKnown == false)
+    #expect(fixture.outputContainerBoundary.streamingPcmIsCurrentServingSignal)
+    #expect(fixture.outputContainerBoundary.requiresFutureOfficialServingComparison)
+    #expect(fixture.streamingChunkDefaults.codecChunkFrames == 25)
+    #expect(fixture.streamingChunkDefaults.codecLeftContextFrames == 25)
+    #expect(fixture.streamingChunkDefaults.codecRightHoldbackFrames == 4)
+    #expect(fixture.streamingChunkDefaults.initialCodecChunkFrames == 1)
+    #expect(fixture.promotionGate.graphOnlyTextToCodebookIsNotSufficient)
+    #expect(fixture.promotionGate.runtimeIntegrationAllowed == false)
+    #expect(fixture.promotionGate.nextRequiredEvidence.contains("waveform metadata capture"))
+}
+
+private struct HiggsAudioV3CodecVocoderBoundaryFixture: Decodable {
+    struct Source: Decodable {
+        struct OfficialSources: Decodable {
+            let codecVocoder: [String]
+            let outputContainer: [String]
+        }
+
+        let officialSources: OfficialSources
+        let noModelWeightsDownloaded: Bool
+    }
+
+    struct CodecVocoderWeightBoundary: Decodable {
+        let codecCheckpointPrefix: String
+        let codecWeightEntryCount: Int
+        let codecWeightExamples: [String]
+        let totalWeightEntryCount: Int
+        let totalWeightSizeBytes: Int
+        let textBodyPrefix: String
+        let textBodyWeightEntryCount: Int
+        let audioEmbeddingPrefix: String
+        let audioEmbeddingWeightEntryCount: Int
+        let separateTiedHeadWeightEntryCount: Int
+        let usefulBackendRequiresCodecVocoder: Bool
+    }
+
+    struct CodebookDecodeBoundary: Decodable {
+        let rawCodesShape: [Int]
+        let delayedCodesShape: [Int]
+        let reversedCodesShape: [Int]
+        let codebookAxisOrder: String
+        let bocId: Int
+        let eocId: Int
+        let filteringRule: String
+        let sampleRateHz: Int
+        let outputSampleCountKnown: Bool
+        let outputDtypeKnown: Bool
+        let outputChannelCountKnown: Bool
+    }
+
+    struct OutputContainerBoundary: Decodable {
+        let nonStreamingContainerKnown: Bool
+        let streamingPcmIsCurrentServingSignal: Bool
+        let requiresFutureOfficialServingComparison: Bool
+    }
+
+    struct StreamingChunkDefaults: Decodable {
+        let codecChunkFrames: Int
+        let codecLeftContextFrames: Int
+        let codecRightHoldbackFrames: Int
+        let initialCodecChunkFrames: Int
+    }
+
+    struct PromotionGate: Decodable {
+        let graphOnlyTextToCodebookIsNotSufficient: Bool
+        let runtimeIntegrationAllowed: Bool
+        let nextRequiredEvidence: [String]
+    }
+
+    let schemaVersion: Int
+    let createdAtUtc: String
+    let source: Source
+    let codecVocoderWeightBoundary: CodecVocoderWeightBoundary
+    let codebookDecodeBoundary: CodebookDecodeBoundary
+    let outputContainerBoundary: OutputContainerBoundary
+    let streamingChunkDefaults: StreamingChunkDefaults
+    let promotionGate: PromotionGate
+
+    static func load() throws -> Self {
+        let fixtureURL = try higgsAudioV3CodecVocoderFixtureURL(
+            "docs/research/speech-pipelines/lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json",
+        )
+        let data = try Data(contentsOf: fixtureURL)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(Self.self, from: data)
+    }
+}
+
+private func higgsAudioV3CodecVocoderFixtureURL(_ relativePath: String) throws -> URL {
+    try higgsAudioV3CodecVocoderPackageRootURL()
+        .appendingPathComponent(relativePath)
+}
+
+private func higgsAudioV3CodecVocoderPackageRootURL() throws -> URL {
+    let fileManager = FileManager.default
+    var candidateURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+    while true {
+        let manifestURL = candidateURL.appendingPathComponent("Package.swift")
+        if fileManager.fileExists(atPath: manifestURL.path) {
+            return candidateURL
+        }
+
+        let parentURL = candidateURL.deletingLastPathComponent()
+        guard parentURL != candidateURL else {
+            throw HiggsAudioV3CodecVocoderFixtureError(
+                "The Higgs Audio v3 codec/vocoder fixture tests could not find Package.swift while walking upward from '\(#filePath)'.",
+            )
+        }
+
+        candidateURL = parentURL
+    }
+}
+
+private struct HiggsAudioV3CodecVocoderFixtureError: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Tests/SpeakSwiftlyTests/Generation/HiggsAudio/HiggsAudioV3OfficialServingComparisonFixtureTests.swift
+++ b/Tests/SpeakSwiftlyTests/Generation/HiggsAudio/HiggsAudioV3OfficialServingComparisonFixtureTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Testing
+
+@Test func `higgs audio v3 serving comparison fixture pins source scope`() throws {
+    let fixture = try HiggsAudioV3OfficialServingComparisonFixture.load()
+
+    #expect(fixture.schemaVersion == 1)
+    #expect(fixture.createdAtUtc == "2026-06-29T00:00:00Z")
+    #expect(fixture.source.noModelWeightsDownloaded)
+    #expect(fixture.source.noServingRequestExecuted)
+    #expect(fixture.source.officialSources.outputContainer.contains("vLLM deploy YAML and OpenAI adapter"))
+    #expect(fixture.source.officialSources.waveformPostProcessing.contains("SGLang vocoder scheduler"))
+}
+
+@Test func `higgs audio v3 serving comparison fixture uses plain prompt case`() throws {
+    let fixture = try HiggsAudioV3OfficialServingComparisonFixture.load()
+    let prompt = fixture.promptCase
+
+    #expect(prompt.name == "plain-english-tts")
+    #expect(prompt.kind == "plain_tts")
+    #expect(prompt.rawText == "Welcome to SpeakSwiftly. This is the first official Higgs Audio v3 parity fixture.")
+    #expect(prompt.promptShape == "<|tts|> <|text|> target text tokens <|audio|>")
+    #expect(prompt.promptLength == 22)
+}
+
+@Test func `higgs audio v3 serving comparison fixture preserves official output signals`() throws {
+    let fixture = try HiggsAudioV3OfficialServingComparisonFixture.load()
+    let signals = fixture.officialServingSignals.map(\.signal)
+
+    #expect(signals.contains("Talker text-to-eight-codebook rows feed Code2Wav codec-to-24-kHz-PCM output."))
+    #expect(signals.contains("async_chunk streams PCM bytes back to the client as Stage 1 emits each chunk."))
+    #expect(
+        signals.contains(
+            "Some docs mention streaming WAV chunks, while current serving docs emphasize raw PCM for streaming.",
+        ),
+    )
+    #expect(fixture.streamingOutputContract.containerKnown)
+    #expect(fixture.streamingOutputContract.container == "raw_pcm_bytes")
+    #expect(fixture.streamingOutputContract.base64WavSignalStillUnresolved)
+    #expect(fixture.streamingOutputContract.requiresExecutedOfficialServingRequest)
+}
+
+@Test func `higgs audio v3 serving comparison fixture keeps waveform metadata gated`() throws {
+    let fixture = try HiggsAudioV3OfficialServingComparisonFixture.load()
+    let metadata = fixture.waveformMetadata
+
+    #expect(metadata.sampleRateHz == 24000)
+    #expect(metadata.sampleRateConfirmedBySourceMap)
+    #expect(metadata.decodedSampleCountKnown == false)
+    #expect(metadata.decodedDtypeKnown == false)
+    #expect(metadata.decodedChannelCountKnown == false)
+    #expect(metadata.observedDecodedSampleCount == nil)
+    #expect(metadata.observedDecodedDtype == nil)
+    #expect(metadata.observedDecodedChannelCount == nil)
+    #expect(metadata.requiresExecutedOfficialServingRequest)
+}
+
+@Test func `higgs audio v3 serving comparison fixture pins streaming chunk expectations`() throws {
+    let fixture = try HiggsAudioV3OfficialServingComparisonFixture.load()
+    let chunks = fixture.streamingChunkExpectations
+
+    #expect(chunks.codecChunkFrames == 25)
+    #expect(chunks.codecLeftContextFrames == 25)
+    #expect(chunks.codecRightHoldbackFrames == 4)
+    #expect(chunks.initialCodecChunkFrames == 1)
+    #expect(chunks.nominalSecondsPerCodecChunk == 1.0)
+    #expect(chunks.nominalCodecFrameRateHz == 25)
+}
+
+@Test func `higgs audio v3 serving comparison fixture blocks runtime promotion`() throws {
+    let fixture = try HiggsAudioV3OfficialServingComparisonFixture.load()
+
+    #expect(fixture.nonStreamingOutputContract.containerKnown == false)
+    #expect(fixture.nonStreamingOutputContract.container == nil)
+    #expect(fixture.nonStreamingOutputContract.requiresExecutedOfficialServingRequest)
+    #expect(fixture.promotionGate.runtimeIntegrationAllowed == false)
+    #expect(fixture.promotionGate.officialServingComparisonStarted)
+    #expect(fixture.promotionGate.officialServingRequestExecuted == false)
+    #expect(fixture.promotionGate.codecFixtureRuntimePromotionAllowed == false)
+    #expect(fixture.promotionGate.remainingBlockers.contains("capture decoded sample count"))
+    #expect(fixture.promotionGate.remainingBlockers.contains("capture decoded dtype"))
+    #expect(fixture.promotionGate.remainingBlockers.contains("capture decoded channel count"))
+}
+
+private struct HiggsAudioV3OfficialServingComparisonFixture: Decodable {
+    struct Source: Decodable {
+        struct OfficialSources: Decodable {
+            let waveformPostProcessing: [String]
+            let outputContainer: [String]
+        }
+
+        let officialSources: OfficialSources
+        let noModelWeightsDownloaded: Bool
+        let noServingRequestExecuted: Bool
+    }
+
+    struct PromptCase: Decodable {
+        let name: String
+        let kind: String
+        let rawText: String
+        let promptShape: String
+        let promptLength: Int
+    }
+
+    struct OfficialServingSignal: Decodable {
+        let source: String
+        let signal: String
+        let capturedFrom: String
+    }
+
+    struct OutputContract: Decodable {
+        let containerKnown: Bool
+        let container: String?
+        let requiresExecutedOfficialServingRequest: Bool
+    }
+
+    struct StreamingOutputContract: Decodable {
+        let containerKnown: Bool
+        let container: String
+        let base64WavSignalStillUnresolved: Bool
+        let requiresExecutedOfficialServingRequest: Bool
+    }
+
+    struct WaveformMetadata: Decodable {
+        let sampleRateHz: Int
+        let sampleRateConfirmedBySourceMap: Bool
+        let decodedSampleCountKnown: Bool
+        let decodedDtypeKnown: Bool
+        let decodedChannelCountKnown: Bool
+        let observedDecodedSampleCount: Int?
+        let observedDecodedDtype: String?
+        let observedDecodedChannelCount: Int?
+        let requiresExecutedOfficialServingRequest: Bool
+    }
+
+    struct StreamingChunkExpectations: Decodable {
+        let codecChunkFrames: Int
+        let codecLeftContextFrames: Int
+        let codecRightHoldbackFrames: Int
+        let initialCodecChunkFrames: Int
+        let nominalSecondsPerCodecChunk: Double
+        let nominalCodecFrameRateHz: Int
+    }
+
+    struct PromotionGate: Decodable {
+        let runtimeIntegrationAllowed: Bool
+        let officialServingComparisonStarted: Bool
+        let officialServingRequestExecuted: Bool
+        let remainingBlockers: [String]
+        let codecFixtureRuntimePromotionAllowed: Bool
+    }
+
+    let schemaVersion: Int
+    let createdAtUtc: String
+    let source: Source
+    let promptCase: PromptCase
+    let officialServingSignals: [OfficialServingSignal]
+    let nonStreamingOutputContract: OutputContract
+    let streamingOutputContract: StreamingOutputContract
+    let waveformMetadata: WaveformMetadata
+    let streamingChunkExpectations: StreamingChunkExpectations
+    let promotionGate: PromotionGate
+
+    static func load() throws -> Self {
+        let fixtureURL = try higgsAudioV3OfficialServingFixtureURL(
+            "docs/research/speech-pipelines/lanes/higgs-audio-v3/official-serving-comparison-fixture-2026-06-29.json",
+        )
+        let data = try Data(contentsOf: fixtureURL)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(Self.self, from: data)
+    }
+}
+
+private func higgsAudioV3OfficialServingFixtureURL(_ relativePath: String) throws -> URL {
+    try higgsAudioV3OfficialServingPackageRootURL()
+        .appendingPathComponent(relativePath)
+}
+
+private func higgsAudioV3OfficialServingPackageRootURL() throws -> URL {
+    let fileManager = FileManager.default
+    var candidateURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+    while true {
+        let manifestURL = candidateURL.appendingPathComponent("Package.swift")
+        if fileManager.fileExists(atPath: manifestURL.path) {
+            return candidateURL
+        }
+
+        let parentURL = candidateURL.deletingLastPathComponent()
+        guard parentURL != candidateURL else {
+            throw HiggsAudioV3OfficialServingFixtureError(
+                "The Higgs Audio v3 official serving fixture tests could not find Package.swift while walking upward from '\(#filePath)'.",
+            )
+        }
+
+        candidateURL = parentURL
+    }
+}
+
+private struct HiggsAudioV3OfficialServingFixtureError: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/docs/research/speech-pipelines/findings/runtime-constants.md
+++ b/docs/research/speech-pipelines/findings/runtime-constants.md
@@ -18,13 +18,23 @@ The Higgs Audio v3 lane has pinned these checked-in constants:
 - codec checkpoint prefix: `tied.embedding.modality_embeddings.0.model.`
 - bundled codec/vocoder weight entries under that prefix: `528`
 - audio sample rate: `24000`
+- streaming output signal from archived official sources: raw PCM bytes
 - default streaming codec chunk frames: `25`
 - default streaming codec left context frames: `25`
 - default streaming right holdback in the current fixture plan: `4`
 - default initial streaming codec chunk frames: `1`
+
+Still intentionally unpinned until an executed official serving request:
+
+- decoded sample count
+- decoded output dtype
+- decoded channel count
+- non-streaming output container
+- observed resolution of raw PCM versus WAV/base64 streaming language
 
 See these source fixtures:
 
 - [`../lanes/higgs-audio-v3/tokenizer-parity-fixture-2026-06-26.json`](../lanes/higgs-audio-v3/tokenizer-parity-fixture-2026-06-26.json)
 - [`../lanes/higgs-audio-v3/codebook-delay-fixture-2026-06-26.json`](../lanes/higgs-audio-v3/codebook-delay-fixture-2026-06-26.json)
 - [`../lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json`](../lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json)
+- [`../lanes/higgs-audio-v3/official-serving-comparison-fixture-2026-06-29.json`](../lanes/higgs-audio-v3/official-serving-comparison-fixture-2026-06-29.json)

--- a/docs/research/speech-pipelines/findings/runtime-constants.md
+++ b/docs/research/speech-pipelines/findings/runtime-constants.md
@@ -15,10 +15,16 @@ The Higgs Audio v3 lane has pinned these checked-in constants:
 - beginning-of-codebook marker: `1024`
 - end-of-codebook marker: `1025`
 - delay pattern: `[0, 1, 2, 3, 4, 5, 6, 7]`
+- codec checkpoint prefix: `tied.embedding.modality_embeddings.0.model.`
+- bundled codec/vocoder weight entries under that prefix: `528`
+- audio sample rate: `24000`
+- default streaming codec chunk frames: `25`
+- default streaming codec left context frames: `25`
 - default streaming right holdback in the current fixture plan: `4`
+- default initial streaming codec chunk frames: `1`
 
-See
-[`../lanes/higgs-audio-v3/tokenizer-parity-fixture-2026-06-26.json`](../lanes/higgs-audio-v3/tokenizer-parity-fixture-2026-06-26.json)
-and
-[`../lanes/higgs-audio-v3/codebook-delay-fixture-2026-06-26.json`](../lanes/higgs-audio-v3/codebook-delay-fixture-2026-06-26.json)
-for the source fixtures.
+See these source fixtures:
+
+- [`../lanes/higgs-audio-v3/tokenizer-parity-fixture-2026-06-26.json`](../lanes/higgs-audio-v3/tokenizer-parity-fixture-2026-06-26.json)
+- [`../lanes/higgs-audio-v3/codebook-delay-fixture-2026-06-26.json`](../lanes/higgs-audio-v3/codebook-delay-fixture-2026-06-26.json)
+- [`../lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json`](../lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json)

--- a/docs/research/speech-pipelines/lanes/higgs-audio-v3/README.md
+++ b/docs/research/speech-pipelines/lanes/higgs-audio-v3/README.md
@@ -35,6 +35,10 @@ first-party Apple speech pipeline in SpeakSwiftly.
 - [`codec-vocoder-boundary-fixture-2026-06-28.json`](codec-vocoder-boundary-fixture-2026-06-28.json)
   pins the no-weight codec/vocoder weight-prefix boundary, codebook decode
   boundary, streaming chunk defaults, and remaining waveform metadata gates.
+- [`official-serving-comparison-fixture-2026-06-29.json`](official-serving-comparison-fixture-2026-06-29.json)
+  starts the no-weight official-serving comparison for the plain prompt,
+  preserving the PCM streaming signal, unresolved WAV/base64 wording conflict,
+  and remaining decoded waveform metadata gates.
 
 ## Promotion Rule
 

--- a/docs/research/speech-pipelines/lanes/higgs-audio-v3/README.md
+++ b/docs/research/speech-pipelines/lanes/higgs-audio-v3/README.md
@@ -32,6 +32,9 @@ first-party Apple speech pipeline in SpeakSwiftly.
   pins tokenizer, special-token, and prompt-builder constants.
 - [`codebook-delay-fixture-2026-06-26.json`](codebook-delay-fixture-2026-06-26.json)
   pins the synthetic eight-codebook delay-pattern fixture.
+- [`codec-vocoder-boundary-fixture-2026-06-28.json`](codec-vocoder-boundary-fixture-2026-06-28.json)
+  pins the no-weight codec/vocoder weight-prefix boundary, codebook decode
+  boundary, streaming chunk defaults, and remaining waveform metadata gates.
 
 ## Promotion Rule
 

--- a/docs/research/speech-pipelines/lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json
+++ b/docs/research/speech-pipelines/lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "created_at_utc": "2026-06-28T00:00:00Z",
+  "mode": "higgs_audio_v3_codec_vocoder_boundary_fixture",
+  "source": {
+    "source_map_path": "docs/research/speech-pipelines/lanes/higgs-audio-v3/official-pipeline-map-2026-06-24.json",
+    "codebook_delay_fixture_path": "docs/research/speech-pipelines/lanes/higgs-audio-v3/codebook-delay-fixture-2026-06-26.json",
+    "official_sources": {
+      "codec_vocoder": [
+        "model.safetensors.index.json bundled codec prefix",
+        "SGLang audio_codec.py and vocoder_scheduler.py",
+        "vLLM higgs_audio_v3_code2wav.py"
+      ],
+      "output_container": [
+        "Boson create-speech API",
+        "SGLang Higgs cookbook",
+        "vLLM deploy YAML and OpenAI adapter"
+      ]
+    },
+    "no_model_weights_downloaded": true
+  },
+  "codec_vocoder_weight_boundary": {
+    "codec_checkpoint_prefix": "tied.embedding.modality_embeddings.0.model.",
+    "codec_weight_entry_count": 528,
+    "codec_weight_examples": [
+      "tied.embedding.modality_embeddings.0.model.acoustic_decoder.block.0.conv_t1.bias",
+      "tied.embedding.modality_embeddings.0.model.acoustic_decoder.block.0.conv_t1.weight",
+      "tied.embedding.modality_embeddings.0.model.acoustic_decoder.block.0.res_unit1.conv1.bias",
+      "tied.embedding.modality_embeddings.0.model.acoustic_decoder.block.0.res_unit1.conv1.weight",
+      "tied.embedding.modality_embeddings.0.model.acoustic_decoder.block.0.res_unit1.conv2.bias",
+      "tied.embedding.modality_embeddings.0.model.acoustic_decoder.block.0.res_unit1.conv2.weight"
+    ],
+    "total_weight_entry_count": 927,
+    "total_weight_size_bytes": 8489763794,
+    "text_body_prefix": "body.layers.",
+    "text_body_weight_entry_count": 396,
+    "audio_embedding_prefix": "tied.embedding.modality_embeddings.0.embedding",
+    "audio_embedding_weight_entry_count": 1,
+    "separate_tied_head_weight_entry_count": 0,
+    "useful_backend_requires_codec_vocoder": true,
+    "negative_check": "A port without the bundled codec/vocoder tensors is not a useful SpeakSwiftly backend."
+  },
+  "codebook_decode_boundary": {
+    "raw_codes_shape": [
+      3,
+      8
+    ],
+    "delayed_codes_shape": [
+      10,
+      8
+    ],
+    "reversed_codes_shape": [
+      3,
+      8
+    ],
+    "codebook_axis_order": "frame_major_rows_codebook_columns",
+    "boc_id": 1024,
+    "eoc_id": 1025,
+    "filtering_rule": "reverse_delay_pattern_then_remove_boc_eoc_markers_before_codec_decode",
+    "sample_rate_hz": 24000,
+    "sample_rate_source": "official inventory and serving source snippets",
+    "output_sample_count_known": false,
+    "output_dtype_known": false,
+    "output_channel_count_known": false
+  },
+  "output_container_boundary": {
+    "non_streaming_container_known": false,
+    "streaming_container_conflict": "Some docs mention streaming WAV chunks, while current serving docs emphasize raw PCM for streaming.",
+    "streaming_pcm_is_current_serving_signal": true,
+    "requires_future_official_serving_comparison": true
+  },
+  "streaming_chunk_defaults": {
+    "codec_chunk_frames": 25,
+    "codec_left_context_frames": 25,
+    "codec_right_holdback_frames": 4,
+    "initial_codec_chunk_frames": 1
+  },
+  "promotion_gate": {
+    "graph_only_text_to_codebook_is_not_sufficient": true,
+    "runtime_integration_allowed": false,
+    "next_required_evidence": [
+      "official serving comparison for the same prompt fixture",
+      "waveform metadata capture",
+      "decoded sample count capture",
+      "decoded dtype capture",
+      "decoded channel count capture"
+    ]
+  }
+}

--- a/docs/research/speech-pipelines/lanes/higgs-audio-v3/official-pipeline-inventory-2026-06-24.md
+++ b/docs/research/speech-pipelines/lanes/higgs-audio-v3/official-pipeline-inventory-2026-06-24.md
@@ -27,6 +27,11 @@ The first synthetic codebook delay-pattern fixture is
 It was produced by
 [`../../../../../scripts/repo-maintenance/higgs-audio-v3/generate-codebook-delay-fixture.py`](../../../../../scripts/repo-maintenance/higgs-audio-v3/generate-codebook-delay-fixture.py).
 
+The first no-weight codec/vocoder boundary fixture is
+[`codec-vocoder-boundary-fixture-2026-06-28.json`](codec-vocoder-boundary-fixture-2026-06-28.json).
+It was produced by
+[`../../../../../scripts/repo-maintenance/higgs-audio-v3/generate-codec-vocoder-boundary-fixture.py`](../../../../../scripts/repo-maintenance/higgs-audio-v3/generate-codec-vocoder-boundary-fixture.py).
+
 ## Source Inventory
 
 ### Boson And Hugging Face
@@ -232,9 +237,13 @@ Higgs Audio v2-style codec from the v3 checkpoint under
 codebook rows but cannot decode those rows to 24 kHz PCM is not a useful
 SpeakSwiftly backend.
 
-This should become a separate parity fixture before any runtime backend surface:
-raw delayed rows, reversed rows, decoded sample count, sample rate, and output
-container metadata.
+The first no-weight boundary fixture is
+[`codec-vocoder-boundary-fixture-2026-06-28.json`](codec-vocoder-boundary-fixture-2026-06-28.json).
+It captures the bundled codec prefix, weight-entry counts, codebook axis order,
+BOC/EOC filtering rule, 24 kHz sample rate, streaming chunk defaults, and the
+remaining unknown decoded sample count, dtype, channel count, and container
+questions. It still blocks runtime promotion until official serving comparison
+captures waveform metadata.
 
 ### Waveform Post-Processing And Output
 
@@ -265,8 +274,12 @@ settles it.
 4. Compare the fixture against SGLang/vLLM official serving behavior before
    choosing the first Core AI graph boundary.
 5. Extend the no-weight fixture set from prompt IDs into sampler state and
-   codec/vocoder metadata. The first delay-pattern fixture is checked in; the
-   next open item is official serving comparison or codec/vocoder shape capture.
+   codec/vocoder metadata.
+   Done for delay-pattern layout in
+   [`codebook-delay-fixture-2026-06-26.json`](codebook-delay-fixture-2026-06-26.json)
+   and for codec/vocoder boundary metadata in
+   [`codec-vocoder-boundary-fixture-2026-06-28.json`](codec-vocoder-boundary-fixture-2026-06-28.json).
+   The next open item is official serving comparison with waveform metadata.
 
 ## Current Decision
 

--- a/docs/research/speech-pipelines/lanes/higgs-audio-v3/official-pipeline-inventory-2026-06-24.md
+++ b/docs/research/speech-pipelines/lanes/higgs-audio-v3/official-pipeline-inventory-2026-06-24.md
@@ -32,6 +32,11 @@ The first no-weight codec/vocoder boundary fixture is
 It was produced by
 [`../../../../../scripts/repo-maintenance/higgs-audio-v3/generate-codec-vocoder-boundary-fixture.py`](../../../../../scripts/repo-maintenance/higgs-audio-v3/generate-codec-vocoder-boundary-fixture.py).
 
+The first no-weight official-serving comparison fixture is
+[`official-serving-comparison-fixture-2026-06-29.json`](official-serving-comparison-fixture-2026-06-29.json).
+It was produced by
+[`../../../../../scripts/repo-maintenance/higgs-audio-v3/generate-official-serving-comparison-fixture.py`](../../../../../scripts/repo-maintenance/higgs-audio-v3/generate-official-serving-comparison-fixture.py).
+
 ## Source Inventory
 
 ### Boson And Hugging Face
@@ -261,6 +266,13 @@ some model-card wording references streamed base64 WAV chunks. Treat streaming
 container behavior as an explicit parity question instead of assuming one doc
 settles it.
 
+The first no-weight official-serving comparison fixture is
+[`official-serving-comparison-fixture-2026-06-29.json`](official-serving-comparison-fixture-2026-06-29.json).
+It records the current vLLM serving signals for 24 kHz PCM and streaming PCM
+bytes while preserving the unresolved WAV/base64 wording conflict. It does not
+claim decoded sample count, dtype, channel count, or non-streaming container
+behavior because those require an executed official serving request.
+
 ## First Artifacts To Build Next
 
 1. Add a parity fixture plan for one reference-free English prompt. Done in
@@ -279,7 +291,11 @@ settles it.
    [`codebook-delay-fixture-2026-06-26.json`](codebook-delay-fixture-2026-06-26.json)
    and for codec/vocoder boundary metadata in
    [`codec-vocoder-boundary-fixture-2026-06-28.json`](codec-vocoder-boundary-fixture-2026-06-28.json).
-   The next open item is official serving comparison with waveform metadata.
+6. Start the official-serving comparison from archived official source signals.
+   Done in
+   [`official-serving-comparison-fixture-2026-06-29.json`](official-serving-comparison-fixture-2026-06-29.json).
+   The next open item is an executed official serving request with waveform
+   metadata.
 
 ## Current Decision
 

--- a/docs/research/speech-pipelines/lanes/higgs-audio-v3/official-serving-comparison-fixture-2026-06-29.json
+++ b/docs/research/speech-pipelines/lanes/higgs-audio-v3/official-serving-comparison-fixture-2026-06-29.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 1,
+  "created_at_utc": "2026-06-29T00:00:00Z",
+  "mode": "higgs_audio_v3_official_serving_comparison_fixture",
+  "source": {
+    "source_map_path": "docs/research/speech-pipelines/lanes/higgs-audio-v3/official-pipeline-map-2026-06-24.json",
+    "tokenizer_fixture_path": "docs/research/speech-pipelines/lanes/higgs-audio-v3/tokenizer-parity-fixture-2026-06-26.json",
+    "codec_fixture_path": "docs/research/speech-pipelines/lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json",
+    "official_sources": {
+      "waveform_post_processing": [
+        "SGLang vocoder scheduler",
+        "vLLM stage_input_processors/higgs_audio_v3.py",
+        "Boson and SGLang serving docs for PCM/WAV output behavior"
+      ],
+      "output_container": [
+        "Boson create-speech API",
+        "SGLang Higgs cookbook",
+        "vLLM deploy YAML and OpenAI adapter"
+      ]
+    },
+    "no_model_weights_downloaded": true,
+    "no_serving_request_executed": true
+  },
+  "prompt_case": {
+    "name": "plain-english-tts",
+    "kind": "plain_tts",
+    "raw_text": "Welcome to SpeakSwiftly. This is the first official Higgs Audio v3 parity fixture.",
+    "prompt_shape": "<|tts|> <|text|> target text tokens <|audio|>",
+    "prompt_length": 22
+  },
+  "official_serving_signals": [
+    {
+      "source": "vLLM HIGGS_AUDIO_V3_PIPELINE docstring",
+      "signal": "Talker text-to-eight-codebook rows feed Code2Wav codec-to-24-kHz-PCM output.",
+      "captured_from": "official-pipeline-map key lines for vllm_omni/model_executor/pipeline_configs/higgs_audio_v3.py"
+    },
+    {
+      "source": "vLLM Higgs multimodal deploy YAML",
+      "signal": "async_chunk streams PCM bytes back to the client as Stage 1 emits each chunk.",
+      "captured_from": "official-pipeline-map key lines for vllm_omni/deploy/higgs_multimodal_qwen3.yaml"
+    },
+    {
+      "source": "Boson/SGLang current serving docs versus model-card wording",
+      "signal": "Some docs mention streaming WAV chunks, while current serving docs emphasize raw PCM for streaming.",
+      "captured_from": "official-pipeline-map component_map.output_container.known_conflict"
+    }
+  ],
+  "non_streaming_output_contract": {
+    "container_known": false,
+    "container": null,
+    "serving_signal": "not captured by the current no-weight source map",
+    "requires_executed_official_serving_request": true
+  },
+  "streaming_output_contract": {
+    "container_known": true,
+    "container": "raw_pcm_bytes",
+    "container_conflict_preserved": "Some docs mention streaming WAV chunks, while current serving docs emphasize raw PCM for streaming.",
+    "pcm_signal_source": "vLLM deploy YAML",
+    "base64_wav_signal_still_unresolved": true,
+    "requires_executed_official_serving_request": true
+  },
+  "waveform_metadata": {
+    "sample_rate_hz": 24000,
+    "sample_rate_confirmed_by_source_map": true,
+    "decoded_sample_count_known": false,
+    "decoded_dtype_known": false,
+    "decoded_channel_count_known": false,
+    "observed_decoded_sample_count": null,
+    "observed_decoded_dtype": null,
+    "observed_decoded_channel_count": null,
+    "requires_executed_official_serving_request": true
+  },
+  "streaming_chunk_expectations": {
+    "codec_chunk_frames": 25,
+    "codec_left_context_frames": 25,
+    "codec_right_holdback_frames": 4,
+    "initial_codec_chunk_frames": 1,
+    "nominal_seconds_per_codec_chunk": 1.0,
+    "nominal_codec_frame_rate_hz": 25
+  },
+  "promotion_gate": {
+    "runtime_integration_allowed": false,
+    "official_serving_comparison_started": true,
+    "official_serving_request_executed": false,
+    "remaining_blockers": [
+      "execute one official serving request for the plain prompt fixture",
+      "capture non-streaming container behavior",
+      "capture decoded sample count",
+      "capture decoded dtype",
+      "capture decoded channel count",
+      "resolve raw PCM versus WAV/base64 streaming contract with observed output"
+    ],
+    "codec_fixture_runtime_promotion_allowed": false
+  }
+}

--- a/docs/research/speech-pipelines/lanes/higgs-audio-v3/parity-fixture-plan-2026-06-24.md
+++ b/docs/research/speech-pipelines/lanes/higgs-audio-v3/parity-fixture-plan-2026-06-24.md
@@ -121,6 +121,9 @@ captures them for the same prompt fixture.
 
 ### Output Container Expectations
 
+Status: no-weight official-serving comparison started in
+[`official-serving-comparison-fixture-2026-06-29.json`](official-serving-comparison-fixture-2026-06-29.json).
+
 Record output separately for non-streaming and streaming:
 
 - Non-streaming expected container.
@@ -136,6 +139,10 @@ Current source conflict to preserve:
 
 - Boson and SGLang current serving docs emphasize `pcm` for streaming.
 - Some model-card wording describes streamed base64 WAV chunks.
+
+The current comparison fixture records the vLLM deploy YAML raw-PCM streaming
+signal and keeps non-streaming container, decoded sample count, decoded dtype,
+and decoded channel count blocked until an official serving request is executed.
 
 ## Fixture 2: Control Tags
 

--- a/docs/research/speech-pipelines/lanes/higgs-audio-v3/parity-fixture-plan-2026-06-24.md
+++ b/docs/research/speech-pipelines/lanes/higgs-audio-v3/parity-fixture-plan-2026-06-24.md
@@ -96,6 +96,9 @@ the policies into a pretend common default.
 
 ### Codec/Vocoder Expectations
 
+Status: no-weight boundary fixture captured in
+[`codec-vocoder-boundary-fixture-2026-06-28.json`](codec-vocoder-boundary-fixture-2026-06-28.json).
+
 The first codec fixture does not need to include waveform samples yet, but it
 must record the expected boundary:
 
@@ -111,6 +114,10 @@ must record the expected boundary:
 
 The codec/vocoder fixture is mandatory before declaring any graph-only text to
 codebook proof useful for SpeakSwiftly.
+
+The current fixture intentionally records decoded sample count, decoded dtype,
+and decoded channel count as unknown until an official serving comparison
+captures them for the same prompt fixture.
 
 ### Output Container Expectations
 

--- a/scripts/repo-maintenance/higgs-audio-v3/generate-codec-vocoder-boundary-fixture.py
+++ b/scripts/repo-maintenance/higgs-audio-v3/generate-codec-vocoder-boundary-fixture.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Generate Higgs Audio v3 codec/vocoder boundary fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SOURCE_MAP = "docs/research/speech-pipelines/lanes/higgs-audio-v3/official-pipeline-map-2026-06-24.json"
+DEFAULT_DELAY_FIXTURE = "docs/research/speech-pipelines/lanes/higgs-audio-v3/codebook-delay-fixture-2026-06-26.json"
+DEFAULT_OUTPUT = "docs/research/speech-pipelines/lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json"
+
+CODEC_PREFIX = "tied.embedding.modality_embeddings.0.model."
+TEXT_BODY_PREFIX = "body.layers."
+AUDIO_EMBEDDING_PREFIX = "tied.embedding.modality_embeddings.0.embedding"
+TIED_HEAD_PREFIX = "tied.head"
+SAMPLE_RATE_HZ = 24000
+
+
+def current_utc_timestamp() -> str:
+  return (
+    datetime.now(timezone.utc)
+    .replace(microsecond=0)
+    .isoformat()
+    .replace("+00:00", "Z")
+  )
+
+
+def read_json(path: Path) -> dict[str, Any]:
+  with path.open("r", encoding="utf-8") as handle:
+    value = json.load(handle)
+
+  if not isinstance(value, dict):
+    raise RuntimeError(f"{path} must contain a JSON object.")
+  return value
+
+
+def prefix_summary(source_map: dict[str, Any], prefix: str) -> dict[str, Any]:
+  weight_index = source_map.get("hugging_face", {}).get("weight_index", {})
+  prefixes = weight_index.get("prefixes", {})
+  summary = prefixes.get(prefix)
+  if summary is None:
+    return {"count": 0, "examples": []}
+  if not isinstance(summary, dict):
+    raise RuntimeError(f"weight prefix '{prefix}' must contain an object summary.")
+  return summary
+
+
+def require_int(value: Any, description: str) -> int:
+  if not isinstance(value, int):
+    raise RuntimeError(f"{description} must be an integer.")
+  return value
+
+
+def require_list(value: Any, description: str) -> list[Any]:
+  if not isinstance(value, list):
+    raise RuntimeError(f"{description} must be a list.")
+  return value
+
+
+def build_fixture(args: argparse.Namespace) -> dict[str, Any]:
+  source_map = read_json(args.source_map)
+  delay_fixture = read_json(args.codebook_delay_fixture)
+
+  weight_index = source_map.get("hugging_face", {}).get("weight_index", {})
+  codec_summary = prefix_summary(source_map, CODEC_PREFIX)
+  text_body_summary = prefix_summary(source_map, TEXT_BODY_PREFIX)
+  audio_embedding_summary = prefix_summary(source_map, AUDIO_EMBEDDING_PREFIX)
+  tied_head_summary = prefix_summary(source_map, TIED_HEAD_PREFIX)
+  codec_vocoder_map = source_map.get("component_map", {}).get("codec_vocoder", {})
+  output_container_map = source_map.get("component_map", {}).get("output_container", {})
+  constants = delay_fixture.get("constants", {})
+
+  raw_shape = require_list(delay_fixture.get("raw_codes", {}).get("shape"), "raw code shape")
+  delayed_shape = require_list(delay_fixture.get("delayed_codes", {}).get("shape"), "delayed code shape")
+  reversed_shape = require_list(delay_fixture.get("reversed_codes", {}).get("shape"), "reversed code shape")
+
+  return {
+    "schema_version": 1,
+    "created_at_utc": args.created_at_utc or current_utc_timestamp(),
+    "mode": "higgs_audio_v3_codec_vocoder_boundary_fixture",
+    "source": {
+      "source_map_path": str(args.source_map),
+      "codebook_delay_fixture_path": str(args.codebook_delay_fixture),
+      "official_sources": {
+        "codec_vocoder": codec_vocoder_map.get("official_sources", []),
+        "output_container": output_container_map.get("official_sources", []),
+      },
+      "no_model_weights_downloaded": True,
+    },
+    "codec_vocoder_weight_boundary": {
+      "codec_checkpoint_prefix": CODEC_PREFIX,
+      "codec_weight_entry_count": require_int(
+        codec_summary.get("count"),
+        f"weight count for {CODEC_PREFIX}",
+      ),
+      "codec_weight_examples": require_list(
+        codec_summary.get("examples", []),
+        f"weight examples for {CODEC_PREFIX}",
+      ),
+      "total_weight_entry_count": require_int(
+        weight_index.get("weight_entry_count"),
+        "total weight entry count",
+      ),
+      "total_weight_size_bytes": require_int(
+        weight_index.get("metadata", {}).get("total_size"),
+        "total weight size",
+      ),
+      "text_body_prefix": TEXT_BODY_PREFIX,
+      "text_body_weight_entry_count": require_int(
+        text_body_summary.get("count"),
+        f"weight count for {TEXT_BODY_PREFIX}",
+      ),
+      "audio_embedding_prefix": AUDIO_EMBEDDING_PREFIX,
+      "audio_embedding_weight_entry_count": require_int(
+        audio_embedding_summary.get("count"),
+        f"weight count for {AUDIO_EMBEDDING_PREFIX}",
+      ),
+      "separate_tied_head_weight_entry_count": require_int(
+        tied_head_summary.get("count"),
+        f"weight count for {TIED_HEAD_PREFIX}",
+      ),
+      "useful_backend_requires_codec_vocoder": True,
+      "negative_check": codec_vocoder_map.get("highest_risk"),
+    },
+    "codebook_decode_boundary": {
+      "raw_codes_shape": raw_shape,
+      "delayed_codes_shape": delayed_shape,
+      "reversed_codes_shape": reversed_shape,
+      "codebook_axis_order": "frame_major_rows_codebook_columns",
+      "boc_id": require_int(constants.get("boc_id"), "BOC id"),
+      "eoc_id": require_int(constants.get("eoc_id"), "EOC id"),
+      "filtering_rule": "reverse_delay_pattern_then_remove_boc_eoc_markers_before_codec_decode",
+      "sample_rate_hz": SAMPLE_RATE_HZ,
+      "sample_rate_source": "official inventory and serving source snippets",
+      "output_sample_count_known": False,
+      "output_dtype_known": False,
+      "output_channel_count_known": False,
+    },
+    "output_container_boundary": {
+      "non_streaming_container_known": False,
+      "streaming_container_conflict": output_container_map.get("known_conflict"),
+      "streaming_pcm_is_current_serving_signal": True,
+      "requires_future_official_serving_comparison": True,
+    },
+    "streaming_chunk_defaults": {
+      "codec_chunk_frames": 25,
+      "codec_left_context_frames": 25,
+      "codec_right_holdback_frames": 4,
+      "initial_codec_chunk_frames": 1,
+    },
+    "promotion_gate": {
+      "graph_only_text_to_codebook_is_not_sufficient": True,
+      "runtime_integration_allowed": False,
+      "next_required_evidence": [
+        "official serving comparison for the same prompt fixture",
+        "waveform metadata capture",
+        "decoded sample count capture",
+        "decoded dtype capture",
+        "decoded channel count capture",
+      ],
+    },
+  }
+
+
+def parse_args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(
+    description="Generate a no-weight Higgs Audio v3 codec/vocoder boundary fixture."
+  )
+  parser.add_argument("--source-map", type=Path, default=Path(DEFAULT_SOURCE_MAP))
+  parser.add_argument(
+    "--codebook-delay-fixture",
+    type=Path,
+    default=Path(DEFAULT_DELAY_FIXTURE),
+  )
+  parser.add_argument("--created-at-utc", default=None)
+  parser.add_argument("--output", type=Path, default=Path(DEFAULT_OUTPUT))
+  return parser.parse_args()
+
+
+def write_fixture(fixture: dict[str, Any], output: Path | None) -> None:
+  rendered = json.dumps(fixture, indent=2, ensure_ascii=False) + "\n"
+  if output is None:
+    sys.stdout.write(rendered)
+    return
+
+  output.parent.mkdir(parents=True, exist_ok=True)
+  output.write_text(rendered, encoding="utf-8")
+
+
+def main() -> int:
+  args = parse_args()
+  try:
+    write_fixture(build_fixture(args), args.output)
+  except Exception as error:
+    print(f"ERROR: {error}", file=sys.stderr)
+    return 1
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/repo-maintenance/higgs-audio-v3/generate-official-serving-comparison-fixture.py
+++ b/scripts/repo-maintenance/higgs-audio-v3/generate-official-serving-comparison-fixture.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Generate Higgs Audio v3 official-serving comparison fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SOURCE_MAP = "docs/research/speech-pipelines/lanes/higgs-audio-v3/official-pipeline-map-2026-06-24.json"
+DEFAULT_TOKENIZER_FIXTURE = "docs/research/speech-pipelines/lanes/higgs-audio-v3/tokenizer-parity-fixture-2026-06-26.json"
+DEFAULT_CODEC_FIXTURE = "docs/research/speech-pipelines/lanes/higgs-audio-v3/codec-vocoder-boundary-fixture-2026-06-28.json"
+DEFAULT_OUTPUT = "docs/research/speech-pipelines/lanes/higgs-audio-v3/official-serving-comparison-fixture-2026-06-29.json"
+
+
+def current_utc_timestamp() -> str:
+  return (
+    datetime.now(timezone.utc)
+    .replace(microsecond=0)
+    .isoformat()
+    .replace("+00:00", "Z")
+  )
+
+
+def read_json(path: Path) -> dict[str, Any]:
+  with path.open("r", encoding="utf-8") as handle:
+    value = json.load(handle)
+
+  if not isinstance(value, dict):
+    raise RuntimeError(f"{path} must contain a JSON object.")
+  return value
+
+
+def require_int(value: Any, description: str) -> int:
+  if not isinstance(value, int):
+    raise RuntimeError(f"{description} must be an integer.")
+  return value
+
+
+def require_bool(value: Any, description: str) -> bool:
+  if not isinstance(value, bool):
+    raise RuntimeError(f"{description} must be a boolean.")
+  return value
+
+
+def require_list(value: Any, description: str) -> list[Any]:
+  if not isinstance(value, list):
+    raise RuntimeError(f"{description} must be a list.")
+  return value
+
+
+def prompt_case(tokenizer_fixture: dict[str, Any], name: str) -> dict[str, Any]:
+  cases = require_list(tokenizer_fixture.get("cases"), "tokenizer fixture cases")
+  for candidate in cases:
+    if isinstance(candidate, dict) and candidate.get("name") == name:
+      return candidate
+  raise RuntimeError(f"tokenizer fixture does not contain case '{name}'.")
+
+
+def build_fixture(args: argparse.Namespace) -> dict[str, Any]:
+  source_map = read_json(args.source_map)
+  tokenizer_fixture = read_json(args.tokenizer_fixture)
+  codec_fixture = read_json(args.codec_fixture)
+
+  component_map = source_map.get("component_map", {})
+  output_container_map = component_map.get("output_container", {})
+  waveform_map = component_map.get("waveform_post_processing", {})
+  prompt = prompt_case(tokenizer_fixture, args.prompt_case)
+  runtime_constants = tokenizer_fixture.get("official_runtime_constants", {})
+  codec_decode = codec_fixture.get("codebook_decode_boundary", {})
+  streaming_defaults = codec_fixture.get("streaming_chunk_defaults", {})
+
+  sample_rate_hz = require_int(runtime_constants.get("sample_rate_hz"), "sample rate")
+  codec_chunk_frames = require_int(streaming_defaults.get("codec_chunk_frames"), "codec chunk frames")
+
+  return {
+    "schema_version": 1,
+    "created_at_utc": args.created_at_utc or current_utc_timestamp(),
+    "mode": "higgs_audio_v3_official_serving_comparison_fixture",
+    "source": {
+      "source_map_path": str(args.source_map),
+      "tokenizer_fixture_path": str(args.tokenizer_fixture),
+      "codec_fixture_path": str(args.codec_fixture),
+      "official_sources": {
+        "waveform_post_processing": waveform_map.get("official_sources", []),
+        "output_container": output_container_map.get("official_sources", []),
+      },
+      "no_model_weights_downloaded": True,
+      "no_serving_request_executed": True,
+    },
+    "prompt_case": {
+      "name": prompt.get("name"),
+      "kind": prompt.get("kind"),
+      "raw_text": prompt.get("raw_text"),
+      "prompt_shape": prompt.get("prompt_shape"),
+      "prompt_length": require_int(prompt.get("prompt_length"), "prompt length"),
+    },
+    "official_serving_signals": [
+      {
+        "source": "vLLM HIGGS_AUDIO_V3_PIPELINE docstring",
+        "signal": "Talker text-to-eight-codebook rows feed Code2Wav codec-to-24-kHz-PCM output.",
+        "captured_from": "official-pipeline-map key lines for vllm_omni/model_executor/pipeline_configs/higgs_audio_v3.py",
+      },
+      {
+        "source": "vLLM Higgs multimodal deploy YAML",
+        "signal": "async_chunk streams PCM bytes back to the client as Stage 1 emits each chunk.",
+        "captured_from": "official-pipeline-map key lines for vllm_omni/deploy/higgs_multimodal_qwen3.yaml",
+      },
+      {
+        "source": "Boson/SGLang current serving docs versus model-card wording",
+        "signal": output_container_map.get("known_conflict"),
+        "captured_from": "official-pipeline-map component_map.output_container.known_conflict",
+      },
+    ],
+    "non_streaming_output_contract": {
+      "container_known": False,
+      "container": None,
+      "serving_signal": "not captured by the current no-weight source map",
+      "requires_executed_official_serving_request": True,
+    },
+    "streaming_output_contract": {
+      "container_known": True,
+      "container": "raw_pcm_bytes",
+      "container_conflict_preserved": output_container_map.get("known_conflict"),
+      "pcm_signal_source": "vLLM deploy YAML",
+      "base64_wav_signal_still_unresolved": True,
+      "requires_executed_official_serving_request": True,
+    },
+    "waveform_metadata": {
+      "sample_rate_hz": sample_rate_hz,
+      "sample_rate_confirmed_by_source_map": sample_rate_hz == require_int(
+        codec_decode.get("sample_rate_hz"),
+        "codec fixture sample rate",
+      ),
+      "decoded_sample_count_known": False,
+      "decoded_dtype_known": False,
+      "decoded_channel_count_known": False,
+      "observed_decoded_sample_count": None,
+      "observed_decoded_dtype": None,
+      "observed_decoded_channel_count": None,
+      "requires_executed_official_serving_request": True,
+    },
+    "streaming_chunk_expectations": {
+      "codec_chunk_frames": codec_chunk_frames,
+      "codec_left_context_frames": require_int(
+        streaming_defaults.get("codec_left_context_frames"),
+        "codec left context frames",
+      ),
+      "codec_right_holdback_frames": require_int(
+        streaming_defaults.get("codec_right_holdback_frames"),
+        "codec right holdback frames",
+      ),
+      "initial_codec_chunk_frames": require_int(
+        streaming_defaults.get("initial_codec_chunk_frames"),
+        "initial codec chunk frames",
+      ),
+      "nominal_seconds_per_codec_chunk": codec_chunk_frames / 25,
+      "nominal_codec_frame_rate_hz": 25,
+    },
+    "promotion_gate": {
+      "runtime_integration_allowed": False,
+      "official_serving_comparison_started": True,
+      "official_serving_request_executed": False,
+      "remaining_blockers": [
+        "execute one official serving request for the plain prompt fixture",
+        "capture non-streaming container behavior",
+        "capture decoded sample count",
+        "capture decoded dtype",
+        "capture decoded channel count",
+        "resolve raw PCM versus WAV/base64 streaming contract with observed output",
+      ],
+      "codec_fixture_runtime_promotion_allowed": require_bool(
+        codec_fixture.get("promotion_gate", {}).get("runtime_integration_allowed"),
+        "codec fixture runtime promotion flag",
+      ),
+    },
+  }
+
+
+def parse_args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(
+    description="Generate a no-weight Higgs Audio v3 official-serving comparison fixture."
+  )
+  parser.add_argument("--source-map", type=Path, default=Path(DEFAULT_SOURCE_MAP))
+  parser.add_argument(
+    "--tokenizer-fixture",
+    type=Path,
+    default=Path(DEFAULT_TOKENIZER_FIXTURE),
+  )
+  parser.add_argument("--codec-fixture", type=Path, default=Path(DEFAULT_CODEC_FIXTURE))
+  parser.add_argument("--prompt-case", default="plain-english-tts")
+  parser.add_argument("--created-at-utc", default=None)
+  parser.add_argument("--output", type=Path, default=Path(DEFAULT_OUTPUT))
+  return parser.parse_args()
+
+
+def write_fixture(fixture: dict[str, Any], output: Path | None) -> None:
+  rendered = json.dumps(fixture, indent=2, ensure_ascii=False) + "\n"
+  if output is None:
+    sys.stdout.write(rendered)
+    return
+
+  output.parent.mkdir(parents=True, exist_ok=True)
+  output.write_text(rendered, encoding="utf-8")
+
+
+def main() -> int:
+  args = parse_args()
+  try:
+    write_fixture(build_fixture(args), args.output)
+  except Exception as error:
+    print(f"ERROR: {error}", file=sys.stderr)
+    return 1
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())


### PR DESCRIPTION
## Summary

- replay the two unique Higgs Audio v3 fixture commits onto current main
- pin codec-vocoder boundary constants and official serving comparison signals
- preserve the newer normalization, Qwen consistency, and roadmap work already on main

## Verification

- swift test --filter higgs audio v3 passed all 18 matching tests
- no large speech model was loaded